### PR TITLE
Replace non-portable (on MacOS X at least) `sed` with a `grep -v`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ default: build
 
 # Setup for the development version
 setup-dev.exe: _oasis setup.ml
-	sed '/^#/D' setup.ml > setup_dev.ml
+	grep -v '^#' setup.ml > setup_dev.ml
 	ocamlfind ocamlopt -o $@ -linkpkg -package ocamlbuild,oasis.dynrun setup_dev.ml || \
 	  ocamlfind ocamlc -o $@ -linkpkg -package ocamlbuild,oasis.dynrun setup_dev.ml || true
 	rm -f setup_dev.*


### PR DESCRIPTION
This fixes `oasis setup` and compiling the development version of Lwt
for me on MacOS X 10.8.
