### PR TITLE
OCaml 4.01.0dev has a Unix.O_CLOEXEC flag, so add this to Lwt_unix too.

### DIFF
--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -596,6 +596,9 @@ type open_flag =
 #if ocaml_version >= (3, 13)
   | O_SHARE_DELETE
 #endif
+#if ocaml_version >= (4, 01)
+  | O_CLOEXEC
+#endif
 
 #if windows
 

--- a/src/unix/lwt_unix.mli
+++ b/src/unix/lwt_unix.mli
@@ -315,6 +315,9 @@ type open_flag =
 #if ocaml_version >= (3, 13)
   | O_SHARE_DELETE
 #endif
+#if ocaml_version >= (4, 01)
+  | O_CLOEXEC
+#endif
 
 val openfile : string -> open_flag list -> file_perm -> file_descr Lwt.t
   (** Wrapper for [Unix.openfile]. *)


### PR DESCRIPTION
This was added quite recently in ocaml/ocaml@2207c45056e69d1ea5 and the build is broken on 4.01 without it.
