### PR TITLE
[fix] ev_timer_init last arg is the repeat delay, not a boolean flag

### DIFF
--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -195,7 +195,7 @@ CAMLprim value lwt_libev_timer_init(value loop, value delay, value repeat, value
   /* Create and initialise the watcher */
   struct ev_timer* watcher = lwt_unix_new(struct ev_timer);
   if (Bool_val(repeat))
-    ev_timer_init(watcher, handle_timer, Double_val(delay), Bool_val(delay));
+    ev_timer_init(watcher, handle_timer, Double_val(delay), Double_val(delay));
   else
     ev_timer_init(watcher, handle_timer, Double_val(delay), 0.0);
 


### PR DESCRIPTION
It seems that there is a little typo in the way timer is initialized (see http://doc.dvgu.ru/devel/ev.html; tested on MacOS)
