### PR TITLE
lwt_unix: sub-second precision for stat results

### DIFF
--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -1070,9 +1070,20 @@ static value copy_stat(int use_64, struct stat *buf)
   CAMLparam0();
   CAMLlocal5(atime, mtime, ctime, offset, v);
 
-  atime = copy_double((double) buf->st_atime);
-  mtime = copy_double((double) buf->st_mtime);
-  ctime = copy_double((double) buf->st_ctime);
+  #if defined _BSD_SOURCE || defined _SVID_SOURCE
+    atime = caml_copy_double((double) buf->st_atime + (buf->st_atim.tv_nsec / 1000000000.0f));
+    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtim.tv_nsec / 1000000000.0f));
+    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctim.tv_nsec / 1000000000.0f));
+  #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimespec.tv_nsec / 1000000000.0f));
+    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimespec.tv_nsec / 1000000000.0f));
+    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimespec.tv_nsec / 1000000000.0f));
+  #else
+    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimensec / 1000000000.0f));
+    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimensec / 1000000000.0f));
+    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimensec / 1000000000.0f));
+  #endif
+
   offset = use_64 ? caml_copy_int64(buf->st_size) : Val_int(buf->st_size);
   v = alloc_small(12, 0);
   Field(v, 0) = Val_int (buf->st_dev);

--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -1070,20 +1070,9 @@ static value copy_stat(int use_64, struct stat *buf)
   CAMLparam0();
   CAMLlocal5(atime, mtime, ctime, offset, v);
 
-  #if defined _BSD_SOURCE || defined _SVID_SOURCE
-    atime = caml_copy_double((double) buf->st_atime + (buf->st_atim.tv_nsec / 1000000000.0f));
-    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtim.tv_nsec / 1000000000.0f));
-    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctim.tv_nsec / 1000000000.0f));
-  #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimespec.tv_nsec / 1000000000.0f));
-    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimespec.tv_nsec / 1000000000.0f));
-    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimespec.tv_nsec / 1000000000.0f));
-  #else
-    atime = caml_copy_double((double) buf->st_atime + (buf->st_atimensec / 1000000000.0f));
-    mtime = caml_copy_double((double) buf->st_mtime + (buf->st_mtimensec / 1000000000.0f));
-    ctime = caml_copy_double((double) buf->st_ctime + (buf->st_ctimensec / 1000000000.0f));
-  #endif
-
+  atime = copy_double((double) buf->st_atime + (NANOSEC(buf, a) / 1000000000.0));
+  mtime = copy_double((double) buf->st_mtime + (NANOSEC(buf, m) / 1000000000.0));
+  ctime = copy_double((double) buf->st_ctime + (NANOSEC(buf, c) / 1000000000.0));
   offset = use_64 ? caml_copy_int64(buf->st_size) : Val_int(buf->st_size);
   v = alloc_small(12, 0);
   Field(v, 0) = Val_int (buf->st_dev);


### PR DESCRIPTION
This patch does make lwt_Unix.stat results unequal to the corresponding Unix.stat results, since Unix.stat still only uses the second-level fields. I'd like to fix that as well, but forking and compiling ocaml itself is harder than lwt.

(there's an open bug if anyone else wants to jump in: http://caml.inria.fr/mantis/view.php?id=6285)

**note**: The code is copied from Jane street core (https://github.com/janestreet/core/blob/master/lib/unix_stubs.c#L426). The code is under the APL, although I don't know if copyright attribution is required, since the code is driven almost entirely by maths and system APIs.