### PR TITLE
«pick» is closer to «choice» than «join»

### DIFF
--- a/manual/manual.wiki
+++ b/manual/manual.wiki
@@ -302,7 +302,7 @@ val t : '_a Lwt.t = <abstr>
 - : int Lwt.state = Lwt.Return 42
 >>
 
-  The last one, {{{pick}}}, is the same as {{{join}}} except that it cancels
+  The last one, {{{pick}}}, is the same as {{{choice}}} except that it cancels
   all other threads when one terminates.
 
 ==== Threads local storage ====


### PR DESCRIPTION
It was written: 
«The last one, {{{pick}}}, is the same as {{{join}}} except that it cancels all other threads when one terminates.»
While not strictly wrong, it makes more sense to write:
«The last one, {{{pick}}}, is the same as {{{choice}}} except that it cancels all other threads when one terminates.»
