### PR TITLE
Add Lwt_sequence.find_node_* functions

### DIFF
--- a/src/core/lwt_sequence.ml
+++ b/src/core/lwt_sequence.ml
@@ -207,3 +207,41 @@ let fold_r f seq acc =
         loop node.node_next acc
   in
   loop seq.prev acc
+
+let find_node_l f seq =
+  let rec loop curr =
+    if curr != seq then
+      let node = node_of_seq curr in
+      if node.node_active then
+        if f node.node_data then
+          node
+        else
+          loop node.node_next
+      else
+        loop node.node_next
+    else
+      raise Not_found
+  in
+  loop seq.next
+
+let find_node_r f seq =
+  let rec loop curr =
+    if curr != seq then
+      let node = node_of_seq curr in
+      if node.node_active then
+        if f node.node_data then
+          node
+        else
+          loop node.node_prev
+      else
+        loop node.node_prev
+    else
+      raise Not_found
+  in
+  loop seq.prev
+
+let find_node_opt_l f seq =
+  try Some (find_node_l f seq) with Not_found -> None
+
+let find_node_opt_r f seq =
+  try Some (find_node_r f seq) with Not_found -> None

--- a/src/core/lwt_sequence.mli
+++ b/src/core/lwt_sequence.mli
@@ -135,3 +135,21 @@ val fold_r : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
       ]}
       where [e1], [e2], ..., [en] are the elements of [s]
   *)
+
+val find_node_opt_l : ('a -> bool) -> 'a t -> 'a node option
+  (** [find_node_opt_l f s] returns [Some x], where [x] is the first node of
+      [s] starting from the left that satisfies [f] or [None] if none
+      exists. *)
+
+val find_node_opt_r : ('a -> bool) -> 'a t -> 'a node option
+  (** [find_node_opt_r f s] returns [Some x], where [x] is the first node of
+      [s] starting from the right that satisfies [f] or [None] if none
+      exists. *)
+
+val find_node_l : ('a -> bool) -> 'a t -> 'a node
+  (** [find_node_l f s] returns the first node of [s] starting from the left
+      that satisfies [f] or raises [Not_found] if none exists. *)
+
+val find_node_r : ('a -> bool) -> 'a t -> 'a node
+  (** [find_node_r f s] returns the first node of [s] starting from the right
+      that satisfies [f] or raises [Not_found] if none exists. *)


### PR DESCRIPTION
This pull request only contains the functions that return nodes.  For completeness, maybe the functions `find_l`, `find_r`, `find_opt_l`, `find_opt_r` (which return the contents of the node) should be added.  Let me know if you would like me to add them to this pull request.

Thanks!
