### PR TITLE
Lwt_log: get backtrace early to overcome exns in Printexc.to_string.

### DIFF
--- a/src/logger/lwt_log_core.ml
+++ b/src/logger/lwt_log_core.ml
@@ -306,14 +306,12 @@ let log ?exn ?(section=Section.main) ?location ?logger ~level message =
       | None ->
           Lwt.with_value location_key location (fun () -> logger.lg_output section level (split message))
       | Some exn ->
+          let bt = if Printexc.backtrace_status () then Printexc.get_backtrace ()
+                   else "" in
           let message = message ^ ": " ^ Printexc.to_string exn in
           let message =
-            if Printexc.backtrace_status () then
-              match Printexc.get_backtrace () with
-                | "" -> message
-                | backtrace -> message ^ "\nbacktrace:\n" ^ backtrace
-            else
-              message
+            if String.length bt = 0 then message
+            else message ^ "\nbacktrace:\n" ^ bt
           in
           Lwt.with_value location_key location (fun () -> logger.lg_output section level (split message))
   else


### PR DESCRIPTION
If 3rd-party code registers a printer function that raises (and then captures) an exception,
the original backtrace will be overwritten. This happens in particular with `Netexn`.
