### PR TITLE
Don't throw an exception in the notification handler if we're shutting down

### DIFF
--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -665,7 +665,7 @@ static SOCKET socket_r, socket_w;
 
 static int windows_notification_send()
 {
-  char buf;
+  char buf = '!';
   return send(socket_w, &buf, 1, 0);
 }
 


### PR DESCRIPTION
OCaml calls WSACleanup in an at_exit handler. If we try to send a notification after that we get an error and throw an exception in the signal handler. This causes a segfault.

Fixes #59.
