### PR TITLE
Lwt_queue, for blocking message passing

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -117,7 +117,8 @@ Library "lwt"
     Lwt_stream,
     Lwt_switch,
     Lwt_util,
-    Lwt_pqueue
+    Lwt_pqueue,
+    Lwt_queue
   XMETADescription: Lightweight thread library for OCaml (core library)
 
 Library "lwt-log"

--- a/src/core/lwt_queue.ml
+++ b/src/core/lwt_queue.ml
@@ -1,0 +1,73 @@
+(* Lightweight thread library for OCaml
+ * http://www.ocsigen.org/lwt
+ * Module Lwt_stream
+ * Copyright (C) 2014 Simon Cruanes
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, with linking exceptions;
+ * either version 2.1 of the License, or (at your option) any later
+ * version. See COPYING file for details.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *)
+
+(** {1 Bocking queue} *)
+
+let (>>=) = Lwt.(>>=)
+
+type 'a t = {
+  queue : 'a Queue.t;
+  max : int option;
+  cond_push : unit Lwt_condition.t;  (* on push *)
+  cond_pop : unit Lwt_condition.t; (* on pop *)
+}
+
+let create () =
+  { queue = Queue.create ();
+    max = None;
+    cond_push = Lwt_condition.create ();
+    cond_pop = Lwt_condition.create ();
+  }
+
+let create_bounded max =
+  if max <= 0 then invalid_arg "Lwt_queue.create_bounded";
+  { queue = Queue.create ();
+    max = Some max;
+    cond_push = Lwt_condition.create ();
+    cond_pop = Lwt_condition.create ();
+  }
+
+let is_empty q =
+  Queue.is_empty q.queue
+
+let rec push q x =
+  match q.max with
+  | Some m when Queue.length q.queue >= m ->
+      (* wait and retry *)
+      Lwt_condition.wait q.cond_pop >>= fun () ->
+      push q x
+  | _ ->
+    Queue.push x q.queue;
+    Lwt_condition.signal q.cond_push ();
+    Lwt.return_unit
+
+let rec pop q =
+  if Queue.is_empty q.queue
+    then
+      (* wait and retry *)
+      Lwt_condition.wait q.cond_push >>= fun () ->
+      pop q
+    else (
+      let x = Queue.pop q.queue in
+      Lwt_condition.signal q.cond_pop ();
+      Lwt.return x
+    )

--- a/src/core/lwt_queue.mli
+++ b/src/core/lwt_queue.mli
@@ -1,0 +1,42 @@
+(* Lightweight thread library for OCaml
+ * http://www.ocsigen.org/lwt
+ * Module Lwt_stream
+ * Copyright (C) 2014 Simon Cruanes
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, with linking exceptions;
+ * either version 2.1 of the License, or (at your option) any later
+ * version. See COPYING file for details.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *)
+
+(** {1 Blocking queue}
+This queue can be used for message passing between threads *)
+
+type 'a t
+(** Queue containing elements of type 'a *)
+
+val create : unit -> 'a t
+(** New queue with unbounded capacity *)
+
+val create_bounded : int -> 'a t
+(** New queue with bounded capacity (must be a strictly positive int) *)
+
+val is_empty : 'a t -> bool
+(** Is the queue currently empty? *)
+
+val push : 'a t -> 'a -> unit Lwt.t
+(** Potentially blocking push (in case the queue is full). *)
+
+val pop : 'a t -> 'a Lwt.t
+(** Extract the first value of the queue. Blocks if the queue is empty *)


### PR DESCRIPTION
I had this piece of code in one of my repositories, and today I heard someone else complain that there lacks some way of communicating between long-running `Lwt` threads (unless I missed something). In case it might be useful, here is a very simple blocking queue (for mailboxes, message passing between threads...).

The semantics of `push` is that it might block if the queue has a limited capacity and is full.