### PR TITLE
Fix getaddrinfo

### DIFF
--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -2070,7 +2070,8 @@ static value result_getaddrinfo(struct job_getaddrinfo *job)
       vres = v;
     }
   }
-  freeaddrinfo(job->info);
+  if (job->info != NULL)
+    freeaddrinfo(job->info);
   lwt_unix_free_job(&job->job);
   CAMLreturn(vres);
 }


### PR DESCRIPTION
backtrace from a failing application at https://gist.github.com/hannesm/1045c4aa2d76df6314e1

problem was that my computer (FreeBSD-CURRENT) had no network connection, thus getaddrinfo wasn't able to resolve
