### PR TITLE
Fixes discover.ml to support platforms that use PKGSRC

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -42,6 +42,7 @@ let default_search_paths =
   List.map (fun dir -> (dir // "include", dir // "lib")) [
     "/usr";
     "/usr/local";
+    "/usr/pkg";
     "/opt";
     "/opt/local";
     "/sw";


### PR DESCRIPTION
This patch tries to add support for **PKGSRC** in `discover.ml`'s search path algorithm. **PKGSRC** installs `libev` files in `/usr/pkg/include/ev` and `/usr/pkg/lib/ev`. The version of `discover.ml` prior to this would compute the library path to be `/usr/pkg/include/ev/../lib`, which is wrong.
