### PR TITLE
Use ppx to rewrite `Lwt.return foo` to an allocation-less form.

### DIFF
--- a/ppx/ppx_lwt.mli
+++ b/ppx/ppx_lwt.mli
@@ -204,4 +204,10 @@
 
    - The log syntax extension can be disabled with the option [-no-log].
 
+   {2 [Lwt.return] rewriting}
+
+   If you pass the option [-rewrite-return], [Lwt.return ()] (resp. [None], [[]], [true] and [false]) will be rewritten [Lwt.return_unit] (resp. [none], [nil], [true] and [false]).
+
+   Note: The pattern recognition is purely syntactic. [Lwt.return @@ ()] will not be rewritten.
+
 *)


### PR DESCRIPTION
It started of as a joke, but @whitequark told me it was a good idea.

I blame @avsm for giving me the idea. :p

It's disabled by default, because I personally think this is not a good idea.
