### PR TITLE
argument ~perm of Lwt_log.file was unused

### DIFF
--- a/src/unix/lwt_log.ml
+++ b/src/unix/lwt_log.ml
@@ -110,7 +110,7 @@ let file ?(template="$(date): $(section): $(message)") ?(mode=`Append) ?(perm=0o
         [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND; Unix.O_NONBLOCK]
     | `Truncate ->
         [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC; Unix.O_NONBLOCK] in
-  lwt fd = Lwt_unix.openfile file_name flags 0o666 in
+  lwt fd = Lwt_unix.openfile file_name flags perm in
   Lwt_unix.set_close_on_exec fd;
   let oc = Lwt_io.of_fd ~mode:Lwt_io.output fd in
   return (channel ~template ~close_mode:`Close ~channel:oc ())


### PR DESCRIPTION
The `~perm` argument is unused. Also, it's weird that the hard-coded value is different from the default value...
