### PR TITLE
use Bytes.of_string in tests

### DIFF
--- a/tests/unix/test_lwt_io.ml
+++ b/tests/unix/test_lwt_io.ml
@@ -39,7 +39,7 @@ let suite = suite "lwt_io" [
          return false
        else
          Lwt_unix.yield () >>= fun () ->
-         return (!sent = ["foobar"]));
+         return (!sent = [Bytes.of_string "foobar"]));
 
   test "auto-flush in atomic"
     (fun () ->
@@ -57,6 +57,6 @@ let suite = suite "lwt_io" [
               return false
             else
               Lwt_unix.yield () >>= fun () ->
-              return (!sent = ["foobar"]))
+              return (!sent = [Bytes.of_string "foobar"]))
          oc);
 ]


### PR DESCRIPTION
the test cases don't compile out of the box without this,...