### PR TITLE
don't include windows header that are later included by unixsupport.h

### DIFF
--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -24,8 +24,6 @@
 
 #if defined(LWT_ON_WINDOWS)
 
-#include <windows.h>
-
 #include <lwt_unix.h>
 
 #include <caml/memory.h>

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -22,11 +22,6 @@
 
 #include "lwt_config.h"
 
-#if defined(LWT_ON_WINDOWS)
-#  include <winsock2.h>
-#  include <windows.h>
-#endif
-
 #define _GNU_SOURCE
 #define _POSIX_PTHREAD_SEMANTICS
 


### PR DESCRIPTION
Updated version of: https://github.com/ocsigen/lwt/pull/125

4.01 (minimum version for lwt) already includes winsock2.h:
https://github.com/ocaml/ocaml/blob/4.01/otherlibs/win32unix/unixsupport.h

and winsock2.h will include windows.h
ftp://ftp.microsoft.com/bussys/winsock/winsock2/winsock2.h
http://sourceforge.net/p/mingw/mingw-org-wsl/ci/4.0.0/tree/include/winsock2.h

It compiles without the warnings reported by @modlfo.