### PR TITLE
Fix issue #136

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -217,15 +217,19 @@ CAMLprim value lwt_test(value Unit)
 "
 
 let netdb_reentrant_code = "
+#define _POSIX_PTHREAD_SEMANTICS
 #include <caml/mlvalues.h>
 #include <netdb.h>
+#include <stddef.h>
 
 CAMLprim value lwt_test(value Unit)
 {
-  getprotobyname_r(0, 0, 0, 0, 0);
-  getprotobynumber_r(0, 0, 0, 0, 0);
-  getservbyname_r(0, 0, 0, 0, 0, 0);
-  getservbyport_r(0, 0, 0, 0, 0, 0);
+  struct hostent *he;
+  struct servent *se;
+  he = gethostbyname_r((const char *)NULL, (struct hostent *)NULL,(char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);
+  he = gethostbyaddr_r((const char *)NULL, (int)0, (int)0,(struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL,(int *)NULL);
+  se = getservbyname_r((const char *)NULL, (const char *)NULL,(struct servent *)NULL, (char *)NULL, (int)0, (struct servent **)NULL);
+  se = getservbyport_r((int)0, (const char *)NULL,(struct servent *)NULL, (char *)NULL, (int)0, (struct servent **)NULL);
   return Val_unit;
 }
 "

--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -1544,53 +1544,90 @@ let gethostname () =
   else
     run_job (gethostname_job ())
 
+external have_reentrant_hostent: unit -> bool = "lwt_have_reentrant_hostent" "noalloc"
+let have_reentrant_hostent = have_reentrant_hostent ()
+let hostent_mutex = Lwt_mutex.create ()
+
 external gethostbyname_job : string -> Unix.host_entry job = "lwt_unix_gethostbyname_job"
 
 let gethostbyname name =
   if Sys.win32 then
     Lwt.return (Unix.gethostbyname name)
-  else
+  else if have_reentrant_hostent then
     run_job (gethostbyname_job name)
+  else
+    Lwt_mutex.with_lock hostent_mutex ( fun () ->
+        run_job (gethostbyname_job name) )
 
 external gethostbyaddr_job : Unix.inet_addr -> Unix.host_entry job = "lwt_unix_gethostbyaddr_job"
 
 let gethostbyaddr addr =
   if Sys.win32 then
     Lwt.return (Unix.gethostbyaddr addr)
-  else
+  else if have_reentrant_hostent then
     run_job (gethostbyaddr_job addr)
+  else
+    Lwt_mutex.with_lock hostent_mutex ( fun () ->
+        run_job (gethostbyaddr_job addr) )
+
+external have_netdb_reentrant : unit -> bool = "lwt_have_netdb_reentrant" "noalloc"
+let have_netdb_reentrant = have_netdb_reentrant ()
+
+let protoent_mutex =
+  if Sys.win32 || have_netdb_reentrant then
+    hostent_mutex
+  else
+    Lwt_mutex.create ()
 
 external getprotobyname_job : string -> Unix.protocol_entry job = "lwt_unix_getprotobyname_job"
 
 let getprotobyname name =
   if Sys.win32 then
     Lwt.return (Unix.getprotobyname name)
-  else
+  else if have_netdb_reentrant then
     run_job (getprotobyname_job name)
+  else
+    Lwt_mutex.with_lock protoent_mutex ( fun () ->
+        run_job (getprotobyname_job name))
 
 external getprotobynumber_job : int -> Unix.protocol_entry job = "lwt_unix_getprotobynumber_job"
 
 let getprotobynumber number =
   if Sys.win32 then
     Lwt.return (Unix.getprotobynumber number)
-  else
+  else if have_netdb_reentrant then
     run_job (getprotobynumber_job number)
+  else
+    Lwt_mutex.with_lock protoent_mutex ( fun () ->
+        run_job (getprotobynumber_job number))
+
+let servent_mutex =
+  if Sys.win32 || have_netdb_reentrant then
+    hostent_mutex
+  else
+    Lwt_mutex.create ()
 
 external getservbyname_job : string -> string -> Unix.service_entry job = "lwt_unix_getservbyname_job"
 
 let getservbyname name x =
   if Sys.win32 then
     Lwt.return (Unix.getservbyname name x)
-  else
+  else if have_netdb_reentrant then
     run_job (getservbyname_job name x)
+  else
+    Lwt_mutex.with_lock protoent_mutex ( fun () ->
+        run_job (getservbyname_job name x) )
 
 external getservbyport_job : int -> string -> Unix.service_entry job = "lwt_unix_getservbyport_job"
 
 let getservbyport port x =
   if Sys.win32 then
     Lwt.return (Unix.getservbyport port x)
-  else
+  else if have_netdb_reentrant then
     run_job (getservbyport_job port x)
+  else
+    Lwt_mutex.with_lock protoent_mutex ( fun () ->
+        run_job (getservbyport_job port x) )
 
 type addr_info =
     Unix.addr_info =

--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -1544,8 +1544,6 @@ let gethostname () =
   else
     run_job (gethostname_job ())
 
-external have_reentrant_hostent: unit -> bool = "lwt_have_reentrant_hostent" "noalloc"
-let have_reentrant_hostent = have_reentrant_hostent ()
 let hostent_mutex = Lwt_mutex.create ()
 
 external gethostbyname_job : string -> Unix.host_entry job = "lwt_unix_gethostbyname_job"
@@ -1553,7 +1551,7 @@ external gethostbyname_job : string -> Unix.host_entry job = "lwt_unix_gethostby
 let gethostbyname name =
   if Sys.win32 then
     Lwt.return (Unix.gethostbyname name)
-  else if have_reentrant_hostent then
+  else if Lwt_config._HAVE_REENTRANT_HOSTENT then
     run_job (gethostbyname_job name)
   else
     Lwt_mutex.with_lock hostent_mutex ( fun () ->
@@ -1564,17 +1562,14 @@ external gethostbyaddr_job : Unix.inet_addr -> Unix.host_entry job = "lwt_unix_g
 let gethostbyaddr addr =
   if Sys.win32 then
     Lwt.return (Unix.gethostbyaddr addr)
-  else if have_reentrant_hostent then
+  else if Lwt_config._HAVE_REENTRANT_HOSTENT then
     run_job (gethostbyaddr_job addr)
   else
     Lwt_mutex.with_lock hostent_mutex ( fun () ->
         run_job (gethostbyaddr_job addr) )
 
-external have_netdb_reentrant : unit -> bool = "lwt_have_netdb_reentrant" "noalloc"
-let have_netdb_reentrant = have_netdb_reentrant ()
-
 let protoent_mutex =
-  if Sys.win32 || have_netdb_reentrant then
+  if Sys.win32 || Lwt_config._HAVE_NETDB_REENTRANT then
     hostent_mutex
   else
     Lwt_mutex.create ()
@@ -1584,7 +1579,7 @@ external getprotobyname_job : string -> Unix.protocol_entry job = "lwt_unix_getp
 let getprotobyname name =
   if Sys.win32 then
     Lwt.return (Unix.getprotobyname name)
-  else if have_netdb_reentrant then
+  else if Lwt_config._HAVE_NETDB_REENTRANT then
     run_job (getprotobyname_job name)
   else
     Lwt_mutex.with_lock protoent_mutex ( fun () ->
@@ -1595,14 +1590,14 @@ external getprotobynumber_job : int -> Unix.protocol_entry job = "lwt_unix_getpr
 let getprotobynumber number =
   if Sys.win32 then
     Lwt.return (Unix.getprotobynumber number)
-  else if have_netdb_reentrant then
+  else if Lwt_config._HAVE_NETDB_REENTRANT then
     run_job (getprotobynumber_job number)
   else
     Lwt_mutex.with_lock protoent_mutex ( fun () ->
         run_job (getprotobynumber_job number))
 
 let servent_mutex =
-  if Sys.win32 || have_netdb_reentrant then
+  if Sys.win32 || Lwt_config._HAVE_NETDB_REENTRANT then
     hostent_mutex
   else
     Lwt_mutex.create ()
@@ -1612,7 +1607,7 @@ external getservbyname_job : string -> string -> Unix.service_entry job = "lwt_u
 let getservbyname name x =
   if Sys.win32 then
     Lwt.return (Unix.getservbyname name x)
-  else if have_netdb_reentrant then
+  else if Lwt_config._HAVE_NETDB_REENTRANT then
     run_job (getservbyname_job name x)
   else
     Lwt_mutex.with_lock protoent_mutex ( fun () ->
@@ -1623,7 +1618,7 @@ external getservbyport_job : int -> string -> Unix.service_entry job = "lwt_unix
 let getservbyport port x =
   if Sys.win32 then
     Lwt.return (Unix.getservbyport port x)
-  else if have_netdb_reentrant then
+  else if Lwt_config._HAVE_NETDB_REENTRANT then
     run_job (getservbyport_job port x)
   else
     Lwt_mutex.with_lock protoent_mutex ( fun () ->

--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -1664,6 +1664,119 @@ LWT_NOT_AVAILABLE1(unix_getgrgid_job)
 
 #endif
 
+/* Helper functions for not re-entrant functions */
+#if !defined(HAS_GETHOSTBYADDR_R) || (HAS_GETHOSTBYADDR_R != 7 && HAS_GETHOSTBYADDR_R != 8)
+#define NON_R_GETHOSTBYADDR 1
+#endif
+
+#if !defined(HAS_GETHOSTBYNAME_R) || (HAS_GETHOSTBYNAME_R != 5 && HAS_GETHOSTBYNAME_R != 6)
+#define NON_R_GETHOSTBYNAME 1
+#endif
+
+CAMLprim value lwt_have_reentrant_hostent(value u)
+{
+  (void)u;
+#if defined(NON_R_GETHOSTBYNAME) || defined(NON_R_GETHOSTBYNAME)
+  return Val_int(0);
+#else
+  return Val_int(1);
+#endif
+}
+
+CAMLprim value lwt_have_netdb_reentrant(value u){
+  (void)u;
+#ifdef HAVE_NETDB_REENTRANT
+  return Val_int(1);
+#else
+  return Val_int(0);
+#endif
+}
+
+#if defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
+static char **
+c_copy_addr_array(char ** src, int addr_len)
+{
+  if ( src == NULL ){
+    return NULL;
+  }
+  char ** p = src;
+  size_t i = 0 ;
+  while ( *p ){
+    i++;
+    p++;
+  }
+  const size_t ar_len = i;
+  p = malloc((ar_len+1) * sizeof(char*));
+  if ( p == NULL ){
+    return NULL;
+  }
+  for ( i = 0 ; i < ar_len ; ++i ){
+    p[i] = malloc(addr_len);
+    if ( p[i] == NULL ){
+      size_t j;
+      for ( j = 0 ; j < i ; j++ ){
+        free(p[j]);
+      }
+      free(p);
+      return NULL;
+    }
+    memcpy(p[i],src[i],addr_len);
+  }
+  p[ar_len] = NULL;
+  return p;
+}
+#endif
+#if !defined(HAVE_NETDB_REENTRANT) || defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
+static char **
+c_copy_string_array(char **src)
+{
+  char ** p = src;
+  size_t i = 0 ;
+  size_t len ;
+  if ( src == NULL ){
+    return NULL;
+  }
+  while ( *p ){
+    i++;
+    p++;
+  }
+  len = i;
+  p = malloc((len+1) * sizeof(char *));
+  if ( p == NULL ){
+    return NULL;
+  }
+  for ( i = 0 ; i < len ; ++i ){
+    p[i] = strdup(src[i]);
+    if ( p[i] == NULL ){
+      size_t j;
+      for ( j = 0 ; j < i ; j++ ){
+        free(p[j]);
+      }
+      free(p);
+      return NULL;
+    }
+  }
+  p[len] = NULL;
+  return p;
+}
+
+static void c_free_string_array(char ** src)
+{
+  if ( src ){
+    char ** p = src;
+    while (*p){
+      free(*p);
+      ++p;
+    }
+    free(src);
+  }
+}
+
+static inline char * s_strdup (const char *s){
+  return (strdup( s == NULL ? "" : s ));
+}
+#endif
+
 /* +-----------------------------------------------------------------+
    | JOB: gethostname                                                |
    +-----------------------------------------------------------------+ */
@@ -1727,7 +1840,9 @@ struct job_gethostbyname {
   struct lwt_unix_job job;
   struct hostent entry;
   struct hostent *ptr;
+#ifndef NON_R_GETHOSTBYNAME
   char buffer[NETDB_BUFFER_SIZE];
+#endif
   char *name;
   char data[];
 };
@@ -1783,6 +1898,63 @@ static value alloc_host_entry(struct hostent *entry)
   return res;
 }
 
+#if defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
+static struct hostent *
+hostent_dup(struct hostent *orig)
+{
+  if ( orig == NULL ){
+    return NULL;
+  }
+  struct hostent *h = malloc(sizeof *h);
+  if ( h == NULL ){
+    return NULL;
+  }
+  h->h_name = s_strdup(orig->h_name);
+  if ( !h->h_name ){
+    goto nomem1;
+  }
+  if ( !orig->h_aliases ){
+    h->h_aliases = NULL;
+  }
+  else {
+    h->h_aliases = c_copy_string_array(orig->h_aliases);
+    if ( !h->h_aliases){
+      goto nomem2;
+    }
+  }
+  if ( !orig->h_addr_list ){
+    h->h_addr_list = NULL;
+  }
+  else {
+    h->h_addr_list = c_copy_addr_array(orig->h_addr_list,orig->h_length);
+    if ( !h->h_addr_list ){
+      goto nomem3;
+    }
+  }
+  h->h_addrtype = orig->h_addrtype;
+  h->h_length = orig->h_length;
+  return h;
+nomem3:
+  c_free_string_array(h->h_aliases);
+nomem2:
+  free(h->h_name);
+nomem1:
+  free(h);
+  return NULL;
+}
+
+static void
+hostent_free(struct hostent *h)
+{
+  if ( h ){
+    c_free_string_array(h->h_addr_list);
+    c_free_string_array(h->h_aliases);
+    free(h->h_name);
+    free(h);
+  }
+}
+#endif
+
 static void worker_gethostbyname(struct job_gethostbyname *job)
 {
 #if HAS_GETHOSTBYNAME_R == 5
@@ -1795,8 +1967,10 @@ static void worker_gethostbyname(struct job_gethostbyname *job)
 #else
   job->ptr = gethostbyname(job->name);
   if (job->ptr) {
-    memcpy((void*)&job->entry, (void*)job->ptr, sizeof(struct hostent));
-    job->ptr = &job->entry;
+    job->ptr= hostent_dup(job->ptr);
+    if ( job->ptr ){
+      job->entry = *job->ptr;
+    }
   }
 #endif
 }
@@ -1808,6 +1982,9 @@ static value result_gethostbyname(struct job_gethostbyname *job)
     caml_raise_not_found();
   } else {
     value entry = alloc_host_entry(&job->entry);
+#ifdef NON_R_GETHOSTBYNAME
+    hostent_free(job->ptr);
+#endif
     lwt_unix_free_job(&job->job);
     return entry;
   }
@@ -1828,7 +2005,9 @@ struct job_gethostbyaddr {
   struct in_addr addr;
   struct hostent entry;
   struct hostent *ptr;
+#ifndef NON_R_GETHOSTBYADDR
   char buffer[NETDB_BUFFER_SIZE];
+#endif
 };
 
 static void worker_gethostbyaddr(struct job_gethostbyaddr *job)
@@ -1843,8 +2022,10 @@ static void worker_gethostbyaddr(struct job_gethostbyaddr *job)
 #else
   job->ptr = gethostbyaddr(&job->addr, 4, AF_INET);
   if (job->ptr) {
-    memcpy((void*)&job->entry, (void*)job->ptr, sizeof(struct hostent));
-    job->ptr = &job->entry;
+    job->ptr = hostent_dup(job->ptr);
+    if ( job->ptr ){
+      job->entry = *job->ptr;
+    }
   }
 #endif
 }
@@ -1856,6 +2037,9 @@ static value result_gethostbyaddr(struct job_gethostbyaddr *job)
     caml_raise_not_found();
   } else {
     value entry = alloc_host_entry(&job->entry);
+#ifdef NON_R_GETHOSTBYADDR
+    hostent_free(job->ptr);
+#endif
     lwt_unix_free_job(&job->job);
     return entry;
   }
@@ -1962,6 +2146,86 @@ static value alloc_servent(struct servent *entry)
 
 #else /* defined(HAVE_NETDB_REENTRANT) */
 
+static struct servent * servent_dup(const struct servent * serv)
+{
+  struct servent * s;
+  if (!serv){
+    return NULL;
+  }
+  s = malloc(sizeof *s);
+  if ( s == NULL ){
+    goto nomem1;
+  }
+  s->s_name = s_strdup(serv->s_name);
+  if ( s->s_name == NULL ){
+    goto nomem2;
+  }
+  s->s_proto = s_strdup(serv->s_proto);
+  if ( s->s_proto == NULL ){
+    goto nomem3;
+  }
+  s->s_aliases = c_copy_string_array(serv->s_aliases);
+  if ( s->s_aliases == NULL && serv->s_aliases != NULL ){
+    goto nomem4;
+  }
+  s->s_port = serv->s_port;
+  return s;
+nomem4:
+  free(s->s_proto);
+nomem3:
+  free(s->s_name);
+nomem2:
+  free(s);
+nomem1:
+  return NULL;
+}
+
+static void servent_free(struct servent * s)
+{
+  if ( ! s ){
+    return;
+  }
+  free(s->s_proto);
+  free(s->s_name);
+  c_free_string_array(s->s_aliases);
+  free(s);
+}
+
+static struct protoent * protoent_dup(const struct protoent * proto)
+{
+  if (!proto){
+    return NULL;
+  }
+  struct protoent * p = malloc(sizeof *p);
+  if ( p == NULL ){
+    return NULL;
+  }
+  p->p_name = s_strdup(proto->p_name);
+  if ( p->p_name == NULL ){
+    goto nomem1;
+  }
+  p->p_aliases = c_copy_string_array( proto->p_aliases );
+  if ( p->p_aliases == NULL && proto->p_aliases != NULL ){
+    goto nomem2;
+  }
+  p->p_proto = proto->p_proto;
+  return p;
+nomem2:
+  free(p->p_name);
+nomem1:
+  free(p);
+  return NULL;
+}
+
+static void protoent_free(struct protoent * p)
+{
+  if ( p ){
+    free(p->p_name);
+    c_free_string_array(p->p_aliases);
+    free(p);
+  }
+}
+
 #define JOB_GET_ENTRY2(INIT, FUNC, TYPE, ARGS_VAL, ARGS_DECL, ARGS_CALL) \
   struct job_##FUNC {                                                   \
     struct lwt_unix_job job;                                            \
@@ -1972,6 +2236,11 @@ static value alloc_servent(struct servent *entry)
   static void worker_##FUNC(struct job_##FUNC *job)                     \
   {                                                                     \
     job->entry = FUNC(ARGS_CALL);                                       \
+    if ( job->entry ){                                                  \
+      job->entry = TYPE ## _dup ( job->entry );                         \
+      if (! job->entry ){                                               \
+      }                                                                 \
+    }                                                                   \
   }                                                                     \
                                                                         \
   static value result_##FUNC(struct job_##FUNC *job)                    \
@@ -1981,6 +2250,7 @@ static value alloc_servent(struct servent *entry)
       caml_raise_not_found();                                           \
     } else {                                                            \
       value res = alloc_##TYPE(job->entry);                             \
+      TYPE ## _free ( job->entry );                                     \
       lwt_unix_free_job(&job->job);                                     \
       return res;                                                       \
     }                                                                   \
@@ -2018,7 +2288,7 @@ JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB_STRING2(job, getservbyname, 0, name, proto),
                char data[],
                ARGS(job->name, job->proto))
 JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB_STRING(job, getservbyport, 0, proto);
-               job->port = Int_val(port),
+               job->port = htons(Int_val(port)),
                getservbyport,
                servent,
                ARGS(value port, value proto),

--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -1665,32 +1665,16 @@ LWT_NOT_AVAILABLE1(unix_getgrgid_job)
 #endif
 
 /* Helper functions for not re-entrant functions */
+
+/* keep test in sync with discover.ml */
 #if !defined(HAS_GETHOSTBYADDR_R) || (HAS_GETHOSTBYADDR_R != 7 && HAS_GETHOSTBYADDR_R != 8)
 #define NON_R_GETHOSTBYADDR 1
 #endif
 
+/* keep test in sync with discover.ml */
 #if !defined(HAS_GETHOSTBYNAME_R) || (HAS_GETHOSTBYNAME_R != 5 && HAS_GETHOSTBYNAME_R != 6)
 #define NON_R_GETHOSTBYNAME 1
 #endif
-
-CAMLprim value lwt_have_reentrant_hostent(value u)
-{
-  (void)u;
-#if defined(NON_R_GETHOSTBYNAME) || defined(NON_R_GETHOSTBYNAME)
-  return Val_int(0);
-#else
-  return Val_int(1);
-#endif
-}
-
-CAMLprim value lwt_have_netdb_reentrant(value u){
-  (void)u;
-#ifdef HAVE_NETDB_REENTRANT
-  return Val_int(1);
-#else
-  return Val_int(0);
-#endif
-}
 
 #if defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
 static char **

--- a/src/unix/lwt_unix_windows.c
+++ b/src/unix/lwt_unix_windows.c
@@ -506,6 +506,16 @@ CAMLprim value lwt_unix_system_job(value cmdline)
   }
 }
 
+CAMLprim value lwt_have_reentrant_hostent(value u)
+{
+  (void) u;
+  return Val_int(0);
+}
+CAMLprim value lwt_have_netdb_reentrant(value u)
+{
+  (void) u;
+  return Val_int(0);
+}
 /* +-----------------------------------------------------------------+
    | Unavailable primitives                                          |
    +-----------------------------------------------------------------+ */

--- a/src/unix/lwt_unix_windows.c
+++ b/src/unix/lwt_unix_windows.c
@@ -506,16 +506,6 @@ CAMLprim value lwt_unix_system_job(value cmdline)
   }
 }
 
-CAMLprim value lwt_have_reentrant_hostent(value u)
-{
-  (void) u;
-  return Val_int(0);
-}
-CAMLprim value lwt_have_netdb_reentrant(value u)
-{
-  (void) u;
-  return Val_int(0);
-}
 /* +-----------------------------------------------------------------+
    | Unavailable primitives                                          |
    +-----------------------------------------------------------------+ */


### PR DESCRIPTION
See discussion at https://github.com/ocsigen/lwt/issues/136

- The test code for netdb_reentrant_code was too weak. E.g. it compiled on netbsd, although 'gethostbyname_r' etc. aren't available in the necessary form (link information is available for backward compatiblity, but the prototype is not defined in any header). I've added more type information and assign the result to a variable, so the compiler will complain.

- non-reentrant functions like gethostbyname are protected by lwt mutexes and the result is copied to the common c heap. The functions are often implemented thread-safe even without the *_r suffix (however, there are currently no #ifdefs for this case). The returned pointer could point to thread local storage.

- htons was missing in getservbyport.