### PR TITLE
Remove temp files properly

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -309,7 +309,7 @@ let test_code args stub_code =
   let stub_file, oc = Filename.open_temp_file "lwt_stub" ".c" in
   let cleanup () =
     safe_remove stub_file;
-    safe_remove (Filename.chop_extension (Filename.basename stub_file) ^ !ext_obj)
+    safe_remove (Filename.chop_extension stub_file ^ !ext_obj)
   in
   try
     output_string oc stub_code;


### PR DESCRIPTION
It does not make any sense to call `Filename.basename` at this place and indeed it doesn't work.