### PR TITLE
Lwt_unix: add support for joining/leaving multicast groups

### DIFF
--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -1507,6 +1507,36 @@ let getsockopt_error ch =
   Unix.getsockopt_error ch.fd
 
 (* +-----------------------------------------------------------------+
+   | Multicast functions                                             |
+   +-----------------------------------------------------------------+ *)
+
+external stub_mcast_set_loop : Unix.file_descr -> bool -> unit = "lwt_unix_mcast_set_loop"
+
+external stub_mcast_set_ttl : Unix.file_descr -> int -> unit = "lwt_unix_mcast_set_ttl"
+
+type mcast_action = Add | Drop
+
+external stub_mcast_modify_membership :
+  Unix.file_descr -> mcast_action -> Unix.inet_addr -> Unix.inet_addr -> unit =
+  "lwt_unix_mcast_modify_membership"
+
+let mcast_set_loop ch flag =
+  check_descriptor ch;
+  stub_mcast_set_loop ch.fd flag
+
+let mcast_set_ttl ch ttl =
+  check_descriptor ch;
+  stub_mcast_set_ttl ch.fd ttl
+
+let mcast_add_membership ch ?(ifname = Unix.inet_addr_any) addr =
+  check_descriptor ch;
+  stub_mcast_modify_membership ch.fd Add ifname addr
+
+let mcast_drop_membership ch ?(ifname = Unix.inet_addr_any) addr =
+  check_descriptor ch;
+  stub_mcast_modify_membership ch.fd Drop ifname addr
+
+(* +-----------------------------------------------------------------+
    | Host and protocol databases                                     |
    +-----------------------------------------------------------------+ *)
 

--- a/src/unix/lwt_unix.mli
+++ b/src/unix/lwt_unix.mli
@@ -844,6 +844,22 @@ val setsockopt_float : file_descr -> socket_float_option -> float -> unit
 val getsockopt_error : file_descr -> Unix.error option
   (** Wrapper for [Unix.getsockopt_error] *)
 
+(** {3 Multicast functions} *)
+
+val mcast_set_loop : file_descr -> bool -> unit
+  (** Whether sent multicast messages are received by the sending host *)
+
+val mcast_set_ttl : file_descr -> int -> unit
+  (** Set TTL/hops value *)
+
+val mcast_add_membership : file_descr -> ?ifname:Unix.inet_addr -> Unix.inet_addr -> unit
+  (** [mcast_add_membership fd ~ifname addr] joins the multicast group [addr]
+      on the network interface [ifname]. *)
+
+val mcast_drop_membership : file_descr -> ?ifname:Unix.inet_addr -> Unix.inet_addr -> unit
+  (** [mcast_drop_membership fd ~ifname addr] leaves the multicast group [addr]
+      on the network interface [ifname]. *)
+
 (** {2 Host and protocol databases} *)
 
 type host_entry =

--- a/tests/unix/main.ml
+++ b/tests/unix/main.ml
@@ -23,4 +23,5 @@
 Test.run "unix" [
   Test_lwt_io.suite;
   Test_lwt_io_non_block.suite;
+  Test_mcast.suite;
 ]

--- a/tests/unix/test_mcast.ml
+++ b/tests/unix/test_mcast.ml
@@ -1,0 +1,76 @@
+(* Lightweight thread library for OCaml
+ * http://www.ocsigen.org/lwt
+ * Module Test_mcast
+ * Copyright (C) 2015 Nicolas Ojeda Bar
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, with linking exceptions;
+ * either version 2.1 of the License, or (at your option) any later
+ * version. See COPYING file for details.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *)
+
+open Lwt.Infix
+open Test
+
+let hello = Bytes.unsafe_of_string "Hello, World!"
+let mcast_addr = "225.0.0.1"
+let mcast_port = 4321
+
+let with_fd f =
+  let fd = Lwt_unix.(socket PF_INET SOCK_DGRAM 0) in
+  Lwt.finalize (fun () -> f fd) (fun () -> Lwt_unix.close fd)
+
+let child join fd =
+  (* Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true; *)
+  Lwt_unix.(bind fd (ADDR_INET (Unix.inet_addr_any, mcast_port)));
+  if join then Lwt_unix.mcast_add_membership fd (Unix.inet_addr_of_string mcast_addr);
+  let buf = Bytes.create 50 in
+  Lwt_unix.read fd buf 0 50 >>= fun n ->
+  (* Printf.printf "\nReceived multicast message %S\n%!" (Bytes.unsafe_to_string (Bytes.sub buf 0 n)); *)
+  if Bytes.sub buf 0 n <> hello then
+    Lwt.fail (Failure "unexpected multicast message")
+  else
+    Lwt.return_unit
+
+let parent set_loop fd =
+  Lwt_unix.mcast_set_loop fd set_loop;
+  let rec loop () =
+    Lwt_unix.(sendto fd hello 0 (Bytes.length hello) []
+                (ADDR_INET (Unix.inet_addr_of_string mcast_addr, mcast_port))) >>= fun _ ->
+    (* Printf.printf "\nSending multicast message %S to %s:%d\n%!" (Bytes.unsafe_to_string hello) *)
+    (*   mcast_addr mcast_port; *)
+    Lwt_unix.sleep 0.2 >>= loop
+  in
+  loop ()
+
+let test_mcast join set_loop =
+  let should_timeout = not join || not set_loop in
+  let t = Lwt_unix.with_timeout 0.5 (fun () -> Lwt.pick [ with_fd (child join); with_fd (parent set_loop) ]) in
+  Lwt.catch (fun () -> t >>= fun x -> Lwt.return (`Ok x)) (fun e -> Lwt.return (`Fail e)) >>= function
+  | `Fail Lwt_unix.Timeout ->
+    Lwt.return should_timeout
+  | `Fail e ->
+    Printf.eprintf "\ntest_mcast: unexpected failure: %S\n%!" (Printexc.to_string e);
+    Lwt.return false
+  | `Ok () ->
+    Lwt.return true
+
+let suite =
+  suite "unix_mcast"
+    [
+      test "mcast-join-loop" (fun () -> test_mcast true true);
+      test "mcast-nojoin-loop" (fun () -> test_mcast false true);
+      test "mcast-join-noloop" (fun () -> test_mcast true false);
+      test "mcast-nojoin-noloop" (fun () -> test_mcast false false);
+    ]


### PR DESCRIPTION
This patch adds bindings to be able to join and leave IPv4 multicast groups.  As far as I know currently the only libraries where this functions are bound are JS `core` and `ocamlnet`.  Both are inconvenient to use with `lwt`.