### PR TITLE
Lwt_unix: lwt_unix_mcast_* not available on Windows

### DIFF
--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -474,6 +474,10 @@ LWT_NOT_AVAILABLE1(unix_get_credentials)
 
 #endif
 
+/* +-----------------------------------------------------------------+
+   | Multicast functions                                             |
+   +-----------------------------------------------------------------+ */
+
 static int socket_domain (int fd)
 {
     /* Return the socket domain, PF_INET or PF_INET6. Fails for non-IP

--- a/src/unix/lwt_unix_windows.c
+++ b/src/unix/lwt_unix_windows.c
@@ -510,6 +510,9 @@ CAMLprim value lwt_unix_system_job(value cmdline)
    | Unavailable primitives                                          |
    +-----------------------------------------------------------------+ */
 
+LWT_NOT_AVAILABLE2(unix_mcast_set_loop)
+LWT_NOT_AVAILABLE2(unix_mcast_set_ttl)
+LWT_NOT_AVAILABLE4(unix_mcast_modify_membership)
 LWT_NOT_AVAILABLE1(unix_get_credentials)
 LWT_NOT_AVAILABLE1(unix_get_cpu)
 LWT_NOT_AVAILABLE1(unix_get_affinity)


### PR DESCRIPTION
This is a follow-up to #143, marking the `lwt_unix_mcast_*` primitives as not available on Windows.