### PR TITLE
Disable the logging syntax extension by default in lwt.ppx.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@
   * Minor fixes + documentation improvements
   * Add support for if%lwt in ppx extension
   * Add Lwt.return_some
+  * Disable log syntax extension by default in ppx.
+    Give [-log] as ppx argument to enable it.
 
 ===== 2.4.8 (2015-03-11) =====
 

--- a/ppx/ppx_lwt.mli
+++ b/ppx/ppx_lwt.mli
@@ -195,7 +195,8 @@
 
    {2 Logging}
 
-   The syntax extension will replace expression of the form:
+   The logging syntax extension is enabled with [-log].
+   It will replace expressions of the form:
 
    {[
      Lwt_log.info_f ~section "x = %d" x
@@ -216,7 +217,5 @@
    will make compilation fail.
 
    - Debug messages are removed if the option [-no-debug] is passed.
-
-   - The log syntax extension can be disabled with the option [-no-log].
 
 *)

--- a/ppx/ppx_lwt_ex.ml
+++ b/ppx/ppx_lwt_ex.ml
@@ -24,7 +24,7 @@ let warn_let_lwt_rec loc attrs =
   attr :: attrs
 
 let debug      = ref true
-let log        = ref true
+let log        = ref false
 let sequence   = ref true
 let strict_seq = ref true
 
@@ -305,6 +305,7 @@ let lwt_mapper args =
   args |> List.iter (fun arg ->
     match arg with
     | "-no-debug" -> debug := false
+    | "-log" -> log := true
     | "-no-log" -> log := false
     | "-no-sequence" -> sequence := false
     | "-no-strict-sequence" -> strict_seq := false


### PR DESCRIPTION
The logging syntax extension was not enabled by default in the camlp4 version and, more importantly, can make compilation fail for partially applied log functions. It should really not be enabled by default, it's just an optimisation.