### PR TITLE
Lwt_mvar.t's writers, readers need not be mutable

### DIFF
--- a/src/core/lwt_mvar.ml
+++ b/src/core/lwt_mvar.ml
@@ -33,10 +33,10 @@ type 'a t = {
   mutable contents : 'a option;
   (* Current contents *)
 
-  mutable writers : ('a * unit Lwt.u) Lwt_sequence.t;
+  writers : ('a * unit Lwt.u) Lwt_sequence.t;
   (* Threads waiting to put a value *)
 
-  mutable readers : 'a Lwt.u Lwt_sequence.t;
+  readers : 'a Lwt.u Lwt_sequence.t;
   (* Threads waiting for a value *)
 }
 


### PR DESCRIPTION
`writers`, `readers` fields are never assigned so they don't need to be mutable.