### PR TITLE
Paused threads that are cancelled can cause busy waiting

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1189,7 +1189,9 @@ let pause () =
   waiter
 
 let wakeup_paused () =
-  if not (Lwt_sequence.is_empty paused) then begin
+  if Lwt_sequence.is_empty paused then
+    paused_count := 0
+  else begin
     let tmp = Lwt_sequence.create () in
     Lwt_sequence.transfer_r paused tmp;
     paused_count := 0;


### PR DESCRIPTION
paused_count doesn't really count the paused threads, because it is not decreased, if a paused thread is cancelled.
Therefore, the Lwt_main.run can cause high cpu usage, eg:
```ocaml
let () =
  let t1 =
    let t = Lwt.pause () in
    Lwt.cancel t;
    Lwt.return_unit
  in
  let t2 =
    Lwt_unix.sleep 60.
  in
  let w = Lwt.join [t1 ; t2] in
  Lwt_main.run w
```
https://github.com/ocsigen/lwt/blob/master/src/unix/lwt_main.ml#L41

A cleaner solution would be to change the interface, e.g. just expose if there are paused threads at all to `register_pause_notifier` and `Lwt_main.run`, not the number of the paused threads.