### PR TITLE
Add Lwt_unix.file_exists and Large_file version

### DIFF
--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -757,6 +757,15 @@ let fstat ch =
   else
     run_job (fstat_job ch.fd)
 
+let file_exists name =
+  Lwt.try_bind
+    (fun () -> stat name)
+    (fun _ -> Lwt.return_true)
+    (fun e ->
+       match e with
+       | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return_false
+       | _ -> Lwt.fail e)
+
 external isatty_job : Unix.file_descr -> bool job = "lwt_unix_isatty_job"
 
 let isatty ch =
@@ -834,6 +843,15 @@ struct
       Lwt.return (Unix.LargeFile.fstat ch.fd)
     else
       run_job (fstat_job ch.fd)
+
+  let file_exists name =
+    Lwt.try_bind
+      (fun () -> stat name)
+      (fun _ -> Lwt.return_true)
+      (fun e ->
+         match e with
+         | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return_false
+         | _ -> Lwt.fail e)
 
 end
 

--- a/src/unix/lwt_unix.mli
+++ b/src/unix/lwt_unix.mli
@@ -416,6 +416,9 @@ val lstat : string -> stats Lwt.t
 val fstat : file_descr -> stats Lwt.t
   (** Wrapper for [Unix.fstat] *)
 
+val file_exists : string -> bool Lwt.t
+  (** [file_exists name] tests if a file named [name] exists. *)
+
 val isatty : file_descr -> bool Lwt.t
   (** Wrapper for [Unix.isatty] *)
 
@@ -456,6 +459,9 @@ module LargeFile : sig
 
   val fstat : file_descr -> stats Lwt.t
     (** Wrapper for [Unix.LargeFile.fstat] *)
+
+  val file_exists : string -> bool Lwt.t
+    (** [file_exists name] tests if a file named [name] exists. *)
 end
 
 (** {2 Operations on file names} *)

--- a/tests/unix/test_lwt_io_non_block.ml
+++ b/tests/unix/test_lwt_io_non_block.ml
@@ -35,12 +35,18 @@ let open_and_read_filename () =
   return ()
 
 let suite = suite "lwt_io non blocking io" [
+  test "file does not exist"
+    (fun () -> Lwt_unix.file_exists test_file >|= fun r -> not r);
+
   test "create file"
     (fun () ->
       open_file ~mode:output test_file >>= fun out_chan ->
       write out_chan file_contents >>= fun () ->
       close out_chan >>= fun () ->
       return true);
+
+  test "file exists"
+    (fun () -> Lwt_unix.file_exists test_file);
 
   test "read file"
     (fun () ->


### PR DESCRIPTION
I'm not sure if two versions are actually required but it seems like a safer approach since `stat` comes in two forms.