### PR TITLE
Minor formatting tweak; Fixes to build on alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ They might also be available through your distribution.
  * run `ocaml setup.ml -install` as root to install compiled libraries
  * run `ocaml setup.ml -uninstall` as root to uninstall them
 
-HTML documentation is generated in _build/lwt.docdir/, but is not
+HTML documentation is generated in `_build/lwt.docdir/`, but is not
 installed by default.
 
 If you get the development version you need to obtain OASIS

--- a/discover.ml
+++ b/discover.ml
@@ -744,4 +744,3 @@ Lwt can use pthread or the win32 API.
   (* Generate stubs. *)
   print_endline "Generating C stubs...";
   exit (Sys.command "ocaml src/unix/gen_stubs.ml")
-

--- a/discover.ml
+++ b/discover.ml
@@ -230,6 +230,10 @@ CAMLprim value lwt_test(value Unit)
   he = gethostbyaddr_r((const char *)NULL, (int)0, (int)0,(struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL,(int *)NULL);
   se = getservbyname_r((const char *)NULL, (const char *)NULL,(struct servent *)NULL, (char *)NULL, (int)0, (struct servent **)NULL);
   se = getservbyport_r((int)0, (const char *)NULL,(struct servent *)NULL, (char *)NULL, (int)0, (struct servent **)NULL);
+  pr = getprotoent_r((struct protoent *)NULL, (char *)NULL, (int)0, (struct protoent **)NULL);
+  pr = getprotobyname_r((const char *)NULL, (struct protoent *)NULL, (char *)NULL, (int)0, (struct protoent **)NULL);
+  pr = getprotobynumber_r((int)0, (struct protoent *)NULL, (char *)NULL, (int)0, (struct protoent **)NULL);
+
   return Val_unit;
 }
 "


### PR DESCRIPTION
Hi; I haven't been able to test this on other platforms, but with the patch to `discover.ml` this now builds on Alpine Linux (ie., against musl-libc). Without this, the Lwt build process thinks that it has reentrant netdb functions, while it actually has only a handful and not all of them -- specifically the ones that are added to the test here :)