### PR TITLE
Rename Lwt_stream.on_termin{ate -> ation}

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -153,8 +153,10 @@ let from_direct f =
     hooks = ref [];
   }
 
-let on_terminate s f =
+let on_termination s f =
   s.hooks := f :: !(s.hooks)
+
+let on_terminate = on_termination
 
 let of_list l =
   let l = ref l in

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -224,10 +224,13 @@ val get_available_up_to : int -> 'a t -> 'a list
 val is_empty : 'a t -> bool Lwt.t
   (** [is_empty st] returns wether the given stream is empty *)
 
-val on_terminate : 'a t -> (unit -> unit) -> unit
-  (** [on_terminate st f] executes [f] when the end of the stream [st]
+val on_termination : 'a t -> (unit -> unit) -> unit
+  (** [on_termination st f] executes [f] when the end of the stream [st]
       is reached. Note that the stream may still contains elements if
       {!peek} or similar was used. *)
+
+val on_terminate : 'a t -> (unit -> unit) -> unit
+  (* Deprecated, use [on_termination] *)
 
 (** {2 Stream transversal} *)
 

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -279,11 +279,11 @@ let suite = suite "lwt_stream" [
        Lwt_stream.to_list (Lwt_stream.map_exn stream) >>= fun l' ->
        return (l = l'));
 
-  test "on_terminate"
+  test "on_termination"
     (fun () ->
       let st = Lwt_stream.of_list [1; 2] in
       let b = ref false in
-      Lwt_stream.on_terminate st (fun () -> b := true);
+      Lwt_stream.on_termination st (fun () -> b := true);
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);


### PR DESCRIPTION
This is done to be consistent with Lwt.on_termination.
Lwt_stream.on_termination is retained but is now deprecated.

Not sure if this change is desired but I'd prefer if Lwt stuck to 1 naming
convention.