### PR TITLE
Lwt_stream: bounded_push#close needs to wake reader

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -326,6 +326,14 @@ class ['a] bounded_push_impl (info : 'a push_bounded) wakener_cell last hooks = 
         info.pushb_pending <- None;
         Lwt.wakeup_later_exn info.pushb_push_wakener Closed
       end;
+      (* Send a signal if at least one thread is waiting for a new
+         element. *)
+      if info.pushb_waiting then begin
+        info.pushb_waiting <- false;
+        let old_wakener = !wakener_cell in
+        (* Signal that a new value has been received. *)
+        Lwt.wakeup_later old_wakener ()
+      end;
       List.iter (fun f -> f ()) !hooks
     end
 

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -109,6 +109,19 @@ let suite = suite "lwt_stream" [
        let acc = acc && state (Lwt_stream.to_list stream) = Return [3; 4; 7] in
        return acc);
 
+  test "create_bounded close"
+    (fun () ->
+       let stream, push = Lwt_stream.create_bounded 1 in
+       let acc = true in
+       let acc = acc && state (push#push 1) = Return () in
+       let iter_delayed = Lwt_stream.to_list stream in
+       Lwt_unix.yield () >>= fun () ->
+       push#close;
+       Lwt_unix.yield () >>= fun () ->
+       let acc = acc && state iter_delayed = Return [1] in
+       return acc
+    );
+
   test "get_while"
     (fun () ->
        let stream = Lwt_stream.of_list [1; 2; 3; 4; 5] in


### PR DESCRIPTION
If at the time the `bounded_push#close` method is called the stream is empty then any attempt to process the entire stream will never finish (`Lwt_stream.iter`, `Lwt_stream.map`, etc.).
Calling the `close` method should wake any waiting threads.

See this test, it prints just `test`, but never prints `stream done`.
```ocaml
open Lwt;;

let () =
  Lwt_main.run (
    let stream, push = Lwt_stream.create_bounded 4 in
    Lwt.async( fun () ->
        Lwt_stream.iter (fun s -> print_endline s) stream >>= fun () ->
        print_endline "stream done";
        flush stdout;
        return ()
      );
    push#push "test1" >>= fun () ->
    push#close;
    Lwt_unix.sleep 2. >>= fun () ->
    return ()
  )
```

After the patch it prints:
```
test1
stream done
```

The patch also includes a testcase 'create_bounded close' that fails without the patch to `lwt_stream.ml` and passes otherwise.