### PR TITLE
Avoid deadlock when canceling a thread blocked on a mutex

### DIFF
--- a/src/core/lwt_mutex.ml
+++ b/src/core/lwt_mutex.ml
@@ -19,21 +19,13 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- *)
+*)
 
 open Lwt.Infix
 
-type t = { mutable locked : bool; mutable waiters : unit Lwt.u Lwt_sequence.t  }
+type t = { mutable locked : bool; mutable waiters : (unit Lwt.u * bool ref) Lwt_sequence.t  }
 
 let create () = { locked = false; waiters = Lwt_sequence.create () }
-
-let rec lock m =
-  if m.locked then
-    Lwt.add_task_r m.waiters
-  else begin
-    m.locked <- true;
-    Lwt.return_unit
-  end
 
 let unlock m =
   if m.locked then begin
@@ -42,12 +34,35 @@ let unlock m =
     else
       (* We do not use [Lwt.wakeup] here to avoid a stack overflow
          when unlocking a lot of threads. *)
-      Lwt.wakeup_later (Lwt_sequence.take_l m.waiters) ()
+      let wakener, is_locked_by_us = Lwt_sequence.take_l m.waiters in
+      let () = is_locked_by_us := true in
+      Lwt.wakeup_later wakener ()
   end
 
+let rec lock m =
+  if m.locked then
+    let waiter, wakener = Lwt.task () in
+    let is_locked_by_us = ref false in
+    let node = Lwt_sequence.add_r (wakener, is_locked_by_us) m.waiters in
+    let () = Lwt.on_cancel waiter (fun () -> Lwt_sequence.remove node) in
+    Lwt.catch
+      (fun () -> waiter)
+      (fun e ->
+         let () = if !is_locked_by_us then unlock m in
+         Lwt.fail e
+      )
+  else
+    let () = m.locked <- true in
+    Lwt.return ()
+
 let with_lock m f =
-  lock m >>= fun () ->
-  Lwt.finalize f (fun () -> unlock m; Lwt.return_unit)
+  Lwt.finalize
+    (fun () -> Lwt.bind (lock m) (fun () -> f ()))
+    (fun () ->
+       let () = unlock m in
+       Lwt.return_unit
+    )
 
 let is_locked m = m.locked
+
 let is_empty m = Lwt_sequence.is_empty m.waiters


### PR DESCRIPTION
Problem scenario:
- Thread 1 locks mutex
- Thread 2 tries to lock mutex but is blocked and moved to the Lwt_sequence.
- Now, somehow Thread 2 is canceled (and therefor unblocked).
- Thread 1 is unlocked.  The Lwt_sequence still contains the wakener of Thread 2 so the mutex code thinks Thread 2 should get the lock.
- Thread 2 never unlocks the lock since it was canceled and therefor assumes that it does not hold the lock.

To test I:
- ocaml setup.ml -configure --enable-tests
- ocaml setup.ml -build
- ocaml setup.ml -test
