### PR TITLE
Make Lwt compatible with CPS.

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -765,6 +765,22 @@ let on_any t f g =
     | Repr _ ->
         assert false
 
+let on_any_unsafe t f g =
+  match (repr t).state with
+    | Return v ->
+        f v
+    | Fail exn ->
+        g exn
+    | Sleep sleeper ->
+        let data = !current_data in
+        add_immutable_waiter sleeper
+          (function
+             | Return v -> current_data := data; f v
+             | Fail exn -> current_data := data; g exn
+             | _ -> assert false)
+    | Repr _ ->
+        assert false
+
 let try_bind x f g =
   let t = repr (try x () with exn -> fail exn) in
   match t.state with

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -439,6 +439,14 @@ val on_any : 'a t -> ('a -> unit) -> (exn -> unit) -> unit
       or [g] raises an exception it is given to
       {!async_exception_hook}. *)
 
+val on_any_unsafe : 'a t -> ('a -> unit) -> (exn -> unit) -> unit
+  (** [on_any_unsafe t f g] is the same as [on_any t f g], except that
+      the calls to [f] and [g] are tail calls.
+
+      As a consequence, [on_any_unsafe] does not attempt to catch
+      exceptions raised by [f] and [g], and therefore does not call
+      {!async_exception_hook}. *)
+
 (** Infix operators. You should open only this module. *)
 module Infix : sig
 


### PR DESCRIPTION
Adds a version of `on_any` that performs tail calls on `f` and `g`. The following test program:

``` ocaml
let repeat : int -> (unit -> unit) -> unit = fun limit k ->
  let rec loop n =
    if n >= limit then k ()
    else Lwt.on_any Lwt.return_unit (fun () -> loop (n + 1)) ignore
  in
  loop 0

let () = repeat 100000 ignore
```

Fails with a stack overflow, when compiled and run as:

```
ocamlfind opt -linkpkg -package lwt test.ml && ulimit -s 128 && ./a.out
```

This is because `Lwt.on_any` wraps the calls to `f` and `g` in exception handlers, resulting in a growing stack. Replacing `Lwt.on_any` with `Lwt.on_any_unsafe` fixes the problem.

I am working with CPS code, and this helps to interface it to Lwt. I think this can also be accomplished by exposing a function in Lwt that can tail-call a function on the completion of any given thread. I could then use that function together with a reference to get the same result. I think the solution in the current diff is more sensible, however.
