### PR TITLE
trying to fix #195 by making `Lwt_io.common#close` idempotent

### DIFF
--- a/tests/unix/main.ml
+++ b/tests/unix/main.ml
@@ -23,5 +23,6 @@
 Test.run "unix" [
   Test_lwt_io.suite;
   Test_lwt_io_non_block.suite;
+  Test_lwt_process.suite;
   Test_mcast.suite;
 ]

--- a/tests/unix/test_lwt_process.ml
+++ b/tests/unix/test_lwt_process.ml
@@ -1,0 +1,16 @@
+
+open Lwt
+open Lwt_io
+open Test
+
+let suite = suite "lwt_process" [
+  test "lazy_undefined"
+    (fun () ->
+      Lwt_process.with_process_in
+        ~timeout:1. ("sleep", [| "sleep"; "2" |]) 
+          (fun p ->
+            Lwt.catch
+              (fun () -> Lwt_io.read p#stdout)
+              (fun _ -> Lwt.return ""))
+        >>= fun _ -> Lwt.return_true)
+]


### PR DESCRIPTION
Test case

```ocaml
(*

  ocamlopt -I _build/src/core -I _build/src/unix -g -inline 0 bigarray.cmxa unix.cmxa lwt.cmxa lwt-unix.cmxa truc.ml -o truc ; ./truc

  *)

open Lwt;;

Lwt_process.with_process_in
  ~timeout:1. ("sleep", [| "sleep"; "2" |]) 
    (fun p ->
      Lwt.catch
        (fun () -> Lwt_io.read p#stdout)
        (fun _ -> Lwt.return ""))
  >>= Lwt_io.printlf "read %s"
  |> Lwt_main.run;;
```
seems to work, now (that is, the callback tries to read `p#stdout` and gets an exception about a closed channel; not the unexpected `Lazy.Undefined`).