### PR TITLE
When using -lpthread, modifying the library search path is harmful

### DIFF
--- a/discover.ml
+++ b/discover.ml
@@ -557,13 +557,7 @@ let () =
   let test_pthread () =
     let opt, lib =
       if !android_target then ([], []) else
-      lib_flags "PTHREAD"
-        (fun () ->
-          match search_header "pthread.h" with
-            | Some (dir_i, dir_l) ->
-                (["-I" ^ dir_i], ["-L" ^ dir_l; "-lpthread"])
-            | None ->
-                ([], ["-lpthread"]))
+      lib_flags "PTHREAD" (fun () -> ([], ["-lpthread"]))
     in
     setup_data := ("pthread_opt", opt) :: ("pthread_lib", lib) :: !setup_data;
     test_code (opt, lib) pthread_code


### PR DESCRIPTION
When using -lpthread, setting the library search path is not required and
results in general dysfunction for later library lookups. For instance, on
OS X, Apple ships a very old version of libffi but most users install a
modern libffi via homebrew. Due to a longstanding OCaml compiler front-end
bug (mantis report forthcoming), the ordering of cmxa and -cclib arguments
is not preserved. This results in the OS-supplied libffi being selected
instead of the homebrew installed libffi despite downstream developers'
best efforts. Either pthread will be in the default library search path
in a system directory with low precedence (e.g. /usr/lib) or the developer
can explicitly control the library search path order downstream to correctly
determine precedence between multiple shared library dependencies. Given
this situation, I believe it is incorrect to ever specify -L flags in cmxa
files. I have not modified the libev dependency lookup but will if desired.

/cc @yallop