### PR TITLE
Lwt_daemon: Add force option for when PPID = 1

### DIFF
--- a/src/unix/lwt_daemon.ml
+++ b/src/unix/lwt_daemon.ml
@@ -47,9 +47,9 @@ let redirect_output dev_null fd mode = match mode with
   | `Log logger ->
       redirect fd (Some logger)
 
-let daemonize ?(syslog=true) ?(stdin=`Dev_null) ?(stdout=`Log_default) ?(stderr=`Log_default) ?(directory="/") ?(umask=`Set 0o022) () =
-  if Unix.getppid () = 1 then
-    (* If our parent is [init], then we already are a demon *)
+let daemonize ?(syslog=true) ?(stdin=`Dev_null) ?(stdout=`Log_default) ?(stderr=`Log_default) ?(directory="/") ?(umask=`Set 0o022) ?(force=false) () =
+  if not force && Unix.getppid () = 1 then
+    (* If our parent is [init], then we already are a deamon *)
     ()
   else begin
     Unix.chdir directory;

--- a/src/unix/lwt_daemon.mli
+++ b/src/unix/lwt_daemon.mli
@@ -29,13 +29,15 @@ val daemonize :
   ?stderr : [ `Dev_null | `Close | `Keep | `Log_default | `Log of Lwt_log.logger ] ->
   ?directory : string ->
   ?umask : [ `Keep | `Set of int ] ->
+  ?force : bool ->
   unit -> unit
   (** Put the current running process into daemon mode. I.e. it forks
       and exit the parent, detach it from its controlling terminal,
       and redict standard intputs/outputs..
 
       Notes:
-      - if the process is already a daemon, it does nothing.
+      - if the process is already a daemon (i.e. the parent PID is 1), then
+        function does nothing unless [force] is [true].
       - you must be sure that there is no pending threads when
         calling this function, otherwise they may be canceled.
 


### PR DESCRIPTION
Came across this while porting our daemons to systemd services of `Type=forking`. This is the standard service kind when porting from SysV init scripts.

The problem is that that `systemd` runs as PID 1 and then `fork`s and `exec`s your `ExecStart` directive. 

We can see here that the call to `Lwt_daemon.daemonize` doesn't `fork` as in this dummy example:

```
...
[Service]
Type=forking
PIDFile=/var/run/my-daemon.pid
ExecStart=/usr/sbin/my-daemon --daemon --pidfile /var/run/my-daemon.pid
```

```
Mar  7 14:14:35 localhost systemd[1]: About to execute: /usr/sbin/my-daemon --daemon --pidfile /var/run/my-daemon.pid
Mar  7 14:14:35 localhost systemd[1]: Forked /usr/sbin/my-daemon as 24970
...
Mar  7 14:14:35 localhost systemd[24970]: Executing: /usr/sbin/my-daemon --daemon --pidfile /var/run/my-daemon.pid
Mar  7 14:14:35 localhost my-daemon[24970]: my-daemon: main: Hello start_of_day
Mar  7 14:14:35 localhost my-daemon[24970]: my-daemon: main: Hello after calling daemonize
Mar  7 14:14:35 localhost my-daemon[24970]: my-daemon: main: Sleeping...
...
Mar  7 14:16:05 localhost systemd[1]: my-daemon.service start operation timed out. Terminating.
Mar  7 14:16:05 localhost systemd[1]: my-daemon.service changed start -> final-sigterm
```

Now, unless we wrap the `ExecStart` directive in another wrapper process we can't get our Lwt daemons to start up.

I'm also wondering what the use case is for this condition anyway? Maybe it can just be removed altogether?

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>