### PR TITLE
Add is_closed and closed operations to Lwt_stream

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -170,9 +170,27 @@ let enqueue' e last =
 let enqueue e s =
   enqueue' e s.last
 
+let feed_direct f last close  =
+  let x = f () in
+  (* Push the element to the end of the queue. *)
+  enqueue' x last;
+  if x = None then Lwt.wakeup close ();
+;;
+
+(* Create a stream from a fixed-length direct source, e.g., lists, arrays, and
+   strings. This constructor will call the genterator function until
+   termination, producing a closed stream with all the elements it will provide
+   in the internal queue. *)
+let from_fixed f =
+  let s = from_direct f in
+  while not (is_closed s) do
+    feed_direct f s.last s.close
+  done;
+  s
+
 let of_list l =
   let l = ref l in
-  from_direct
+  from_fixed
     (fun () ->
        match !l with
          | [] -> None
@@ -180,7 +198,7 @@ let of_list l =
 
 let of_array a =
   let len = Array.length a and i = ref 0 in
-  from_direct
+  from_fixed
     (fun () ->
        if !i = len then
          None
@@ -192,7 +210,7 @@ let of_array a =
 
 let of_string s =
   let len = String.length s and i = ref 0 in
-  from_direct
+  from_fixed
     (fun () ->
        if !i = len then
          None
@@ -389,10 +407,7 @@ let feed s =
           Lwt.protected thread
         end
     | From_direct f ->
-        let x = f () in
-        (* Push the element to the end of the queue. *)
-        enqueue x s;
-        if x = None then Lwt.wakeup s.close ();
+        feed_direct f s.last s.close;
         Lwt.return_unit
     | Push push ->
         push.push_waiting <- true;

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -101,6 +101,8 @@ type 'a source =
 type 'a t = {
   source : 'a source;
   (* The source of the stream. *)
+  closed : bool ref;
+  (* Whether the source of the stream has been closed. *)
   mutable node : 'a node;
   (* Pointer to first pending element, or to [last] if there is no
      pending element. *)
@@ -130,28 +132,30 @@ let clone s =
      | _ -> ());
   {
     source = s.source;
+    closed = s.closed;
     node = s.node;
     last = s.last;
     hooks = s.hooks;
   }
 
-let from f =
+let from_source source =
   let last = new_node () in
-  {
-    source = From { from_create = f; from_thread = Lwt.return_unit };
-    node = last;
-    last = ref last;
-    hooks = ref [];
+  let closed = ref false in
+  let mark_closed () = closed := true in
+  { source = source
+  ; closed = closed
+  ; node = last
+  ; last = ref last
+  ; hooks = ref [mark_closed]
   }
 
+let from f =
+  from_source (From { from_create = f; from_thread = Lwt.return_unit })
+
 let from_direct f =
-  let last = new_node () in
-  {
-    source = From_direct f;
-    node = last;
-    last = ref last;
-    hooks = ref [];
-  }
+  let t = from_source (From_direct f) in
+  List.iter (fun f -> f ()) !(t.hooks);
+  t
 
 let on_termination s f =
   s.hooks := f :: !(s.hooks)
@@ -191,8 +195,6 @@ let of_string s =
        end)
 
 let create_with_reference () =
-  (* Create the cell pointing to the end of the queue. *)
-  let last = ref (new_node ()) in
   (* Create the source for notifications of new elements. *)
   let source, wakener_cell =
     let waiter, wakener = Lwt.wait () in
@@ -201,13 +203,14 @@ let create_with_reference () =
        push_external = Obj.repr () },
      ref wakener)
   in
-  (* Set to [true] when the end-of-stream is sent. *)
-  let closed = ref false in
-  let hooks = ref [] in
+  let t = from_source (Push source) in
+  (* [push] should not close over [t] so that it can be garbage collected even
+   * there are still references to [push]. Unpack all the components of [t]
+   * that [push] needs and reference those identifiers instead. *)
+  let closed = t.closed and last = t.last and hooks = t.hooks in
   (* The push function. It does not keep a reference to the stream. *)
   let push x =
     if !closed then raise Closed;
-    if x = None then closed := true;
     (* Push the element at the end of the queue. *)
     let node = !last and new_last = new_node () in
     node.data <- x;
@@ -229,12 +232,7 @@ let create_with_reference () =
        exception. *)
     if x = None then List.iter (fun f -> f ()) !hooks
   in
-  ({ source = Push source;
-     node = !last;
-     last = last;
-     hooks = hooks },
-   push,
-   fun x -> source.push_external <- Obj.repr x)
+  (t, push, fun x -> source.push_external <- Obj.repr x)
 
 let create () =
   let source, push, _ = create_with_reference () in
@@ -352,9 +350,6 @@ end
 
 let create_bounded size =
   if size < 0 then invalid_arg "Lwt_stream.create_bounded";
-  (* Create the cell pointing to the end of the queue. *)
-  let last = ref (new_node ()) in
-  let hooks = ref [] in
   (* Create the source for notifications of new elements. *)
   let info, wakener_cell =
     let waiter, wakener = Lwt.wait () in
@@ -369,11 +364,8 @@ let create_bounded size =
        pushb_external = Obj.repr () },
      ref wakener)
   in
-  ({ source = Push_bounded info;
-     node = !last;
-     last = last;
-     hooks = hooks },
-   new bounded_push_impl info wakener_cell last hooks)
+  let t = from_source (Push_bounded info) in
+  (t, new bounded_push_impl info wakener_cell t.last t.hooks)
 
 (* Wait for a new element to be added to the queue of pending element
    of the stream. *)
@@ -735,6 +727,9 @@ let rec is_empty s =
     feed s >>= fun () -> is_empty s
   else
     Lwt.return (s.node.data = None)
+
+let is_closed s =
+  !(s.closed)
 
 let map f s =
   from (fun () -> get s >|= function

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -154,9 +154,7 @@ let from f =
   from_source (From { from_create = f; from_thread = Lwt.return_unit })
 
 let from_direct f =
-  let t = from_source (From_direct f) in
-  List.iter (fun f -> f ()) !(t.hooks);
-  t
+  from_source (From_direct f)
 
 let on_termination s f =
   s.hooks := f :: !(s.hooks)

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -224,6 +224,10 @@ val get_available_up_to : int -> 'a t -> 'a list
 val is_empty : 'a t -> bool Lwt.t
   (** [is_empty st] returns wether the given stream is empty *)
 
+val is_closed : 'a t -> bool
+  (** [is_closed st] returns whether the given stream has been closed. Even if
+      the stream is closed, it still may contain elements waiting to be read. *)
+
 val on_termination : 'a t -> (unit -> unit) -> unit
   (** [on_termination st f] executes [f] when the end of the stream [st]
       is reached. Note that the stream may still contains elements if

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -225,8 +225,10 @@ val is_empty : 'a t -> bool Lwt.t
   (** [is_empty st] returns whether the given stream is empty. *)
 
 val is_closed : 'a t -> bool
-  (** [is_closed st] returns whether the given stream has been closed. Even if
-      the stream is closed, it still may contain elements waiting to be read. *)
+  (** [is_closed st] returns whether the given stream has been closed. A closed
+      stream is not necessarily empty. It may still contain unread elements. If
+      [is_closed s = true], then all subsequent reads until eof are guaranteed
+      not to block. *)
 
 val closed : 'a t -> unit Lwt.t
   (** [closed st] returns a thread that will sleep until the stream has been

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -215,14 +215,14 @@ val junk_old : 'a t -> unit Lwt.t
 
 val get_available : 'a t -> 'a list
   (** [get_available st] returns all available elements of [l] without
-      blocking *)
+      blocking. *)
 
 val get_available_up_to : int -> 'a t -> 'a list
   (** [get_available_up_to n st] returns up to [n] elements of [l]
-      without blocking *)
+      without blocking. *)
 
 val is_empty : 'a t -> bool Lwt.t
-  (** [is_empty st] returns wether the given stream is empty *)
+  (** [is_empty st] returns whether the given stream is empty. *)
 
 val is_closed : 'a t -> bool
   (** [is_closed st] returns whether the given stream has been closed. Even if
@@ -238,7 +238,7 @@ val on_termination : 'a t -> (unit -> unit) -> unit
       {!peek} or similar was used. *)
 
 val on_terminate : 'a t -> (unit -> unit) -> unit
-  (* Deprecated, use [on_termination] *)
+  (* Deprecated, use [on_termination]. *)
 
 (** {2 Stream transversal} *)
 

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -228,6 +228,10 @@ val is_closed : 'a t -> bool
   (** [is_closed st] returns whether the given stream has been closed. Even if
       the stream is closed, it still may contain elements waiting to be read. *)
 
+val closed : 'a t -> unit Lwt.t
+  (** [closed st] returns a thread that will sleep until the stream has been
+      closed. *)
+
 val on_termination : 'a t -> (unit -> unit) -> unit
   (** [on_termination st f] executes [f] when the end of the stream [st]
       is reached. Note that the stream may still contains elements if

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -227,8 +227,9 @@ val is_empty : 'a t -> bool Lwt.t
 val is_closed : 'a t -> bool
   (** [is_closed st] returns whether the given stream has been closed. A closed
       stream is not necessarily empty. It may still contain unread elements. If
-      [is_closed s = true], then all subsequent reads until eof are guaranteed
-      not to block. *)
+      [is_closed s = true], then the stream is guaranteed to contain a finite
+      number of elements, and all subsequent reads of those elements are
+      guaranteed not to block. *)
 
 val closed : 'a t -> unit Lwt.t
   (** [closed st] returns a thread that will sleep until the stream has been

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -292,30 +292,20 @@ let suite = suite "lwt_stream" [
        Lwt_stream.to_list (Lwt_stream.map_exn stream) >>= fun l' ->
        return (l = l'));
 
-
-  test "closed"
+  test "on_termination"
     (fun () ->
-      let b1 = Lwt_stream.(is_closed (of_list [])) in
-      let b2 = Lwt_stream.(is_closed (of_list [1;2;3])) in
-      let b3 = Lwt_stream.(is_closed (of_array [||])) in
-      let b4 = Lwt_stream.(is_closed (of_array [|1;2;3;|])) in
-      let b5 = Lwt_stream.(is_closed (of_string "")) in
-      let b6 = Lwt_stream.(is_closed (of_string "123")) in
-      let b7 = Lwt_stream.(is_closed (from_direct (fun () -> Some 1))) in
-      let b8 = Lwt_stream.(is_closed (from_direct (fun () -> None))) in
-      let st = Lwt_stream.from_direct (
-        let value = ref (Some 1) in
-        fun () -> let r = !value in value := None; r)
-      in
+      let st = Lwt_stream.of_list [1; 2] in
       let b = ref false in
-      Lwt.async (fun () -> Lwt_stream.closed st >|= fun () -> b := true);
+      Lwt_stream.on_termination st (fun () -> b := true);
       ignore (Lwt_stream.peek st);
-      let b9 = !b = false in
+      let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
-      let b10 = !b = true in
-      let b11 = Lwt_stream.is_closed st in
-      return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8 && b9 && b10 && b11));
+      let b2 = !b = false in
+      ignore (Lwt_stream.junk st);
+      ignore (Lwt_stream.peek st);
+      let b3 = !b = true in
+      Lwt.return (b1 && b2 && b3));
 
   test "choose_exhausted"
     (fun () ->


### PR DESCRIPTION
Previously, the `Lwt_stream` API provided no reliable way to detect if a stream had been closed. While on_termination notifies the user if the stream is closed in the future, it does not tell the user if the stream was closed in the past.
    
Introducing the `is_closed` function addresses this problem, allowing the user to detect if a stream has been closed at any point in time using code like the following:

```ocaml
if Lwt_stream.is_closed stream then
  rest_of_code ()
else
  Lwt_stream.on_termination rest_of_code
```
Alternative to this pattern, one could use the `Lwt_stream.close` operation to get a thread that will sleep until the stream is closed:

```ocaml
Lwt_stream.closed stream >|= rest_of_code
```
  