### PR TITLE
change close semantics for fixed-length sources

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -170,38 +170,6 @@ let enqueue' e last =
 let enqueue e s =
   enqueue' e s.last
 
-let of_list l =
-  let l = ref l in
-  from_direct
-    (fun () ->
-       match !l with
-         | [] -> None
-         | x :: l' -> l := l'; Some x)
-
-let of_array a =
-  let len = Array.length a and i = ref 0 in
-  from_direct
-    (fun () ->
-       if !i = len then
-         None
-       else begin
-         let c = Array.unsafe_get a !i in
-         incr i;
-         Some c
-       end)
-
-let of_string s =
-  let len = String.length s and i = ref 0 in
-  from_direct
-    (fun () ->
-       if !i = len then
-         None
-       else begin
-         let c = String.unsafe_get s !i in
-         incr i;
-         Some c
-       end)
-
 let create_with_reference () =
   (* Create the source for notifications of new elements. *)
   let source, wakener_cell =
@@ -242,6 +210,21 @@ let create_with_reference () =
 let create () =
   let source, push, _ = create_with_reference () in
   (source, push)
+
+let of_iter iter i =
+  let stream, push = create () in
+  iter (fun x -> push (Some x)) i;
+  push None;
+  stream
+
+let of_list l =
+  of_iter List.iter l
+
+let of_array a =
+  of_iter Array.iter a
+
+let of_string s =
+  of_iter String.iter s
 
 (* Add the pending element to the queue and notify the blocked pushed.
 

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -336,6 +336,14 @@ let suite = suite "lwt_stream" [
       let b3 = Lwt_stream.is_closed st in
       Lwt.return (b1 && b2 && b3));
 
+  test "on_termination when closed"
+    (fun () ->
+      let st = Lwt_stream.of_list [] in
+      let b = ref false in
+      let b1 = Lwt_stream.is_closed st in
+      Lwt_stream.on_termination st (fun () -> b := true);
+      Lwt.return (b1 && !b));
+
   test "choose_exhausted"
     (fun () ->
       Lwt_stream.(to_list (choose [of_list []])) >|= fun _ -> true);

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -294,61 +294,47 @@ let suite = suite "lwt_stream" [
 
   test "is_closed"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
-      let b1 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.peek st);
-      let b2 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b4 = Lwt_stream.is_closed st in
-      Lwt.return (b1 && b2 && b3 && b4));
+      let b1 = Lwt_stream.(is_closed (of_list [])) in
+      let b2 = Lwt_stream.(is_closed (of_list [1;2;3])) in
+      let b3 = Lwt_stream.(is_closed (of_array [||])) in
+      let b4 = Lwt_stream.(is_closed (of_array [|1;2;3;|])) in
+      let b5 = Lwt_stream.(is_closed (of_string "")) in
+      let b6 = Lwt_stream.(is_closed (of_string "123")) in
+      let b7 = Lwt_stream.(is_closed (from_direct (fun () -> Some 1))) in
+      let b8 = Lwt_stream.(is_closed (from_direct (fun () -> None))) in
+      return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8));
 
   test "closed"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
+      let st = Lwt_stream.from_direct (
+        let value = ref (Some 1) in
+        fun () -> let r = !value in value := None; r)
+      in
       let b = ref false in
-      let is_closed_in_notification = ref false in
-      Lwt.async (fun () ->
-        Lwt_stream.closed st >|= fun () ->
-        b := true;
-        is_closed_in_notification := Lwt_stream.is_closed st);
+      Lwt.async (fun () -> Lwt_stream.closed st >|= fun () -> b := true);
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
-      let b2 = !b = false in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = !b = true in
-      Lwt.return (b1 && b2 && b3 && !is_closed_in_notification));
+      let b2 = !b = true in
+      let b3 = Lwt_stream.is_closed st in
+      return (b1 && b2 && b3));
 
   test "on_termination"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
+      let st = Lwt_stream.from_direct (
+        let value = ref (Some 1) in
+        fun () -> let r = !value in value := None; r)
+      in
       let b = ref false in
       Lwt_stream.on_termination st (fun () -> b := true);
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
-      let b2 = !b = false in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = !b = true in
+      let b2 = !b = true in
+      let b3 = Lwt_stream.is_closed st in
       Lwt.return (b1 && b2 && b3));
-
-  test "on_termination when closed"
-    (fun () ->
-      let st = Lwt_stream.of_list [] in
-      let b = ref false in
-      let b1 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      let b2 = Lwt_stream.is_closed st in
-      Lwt_stream.on_termination st (fun () -> b := true);
-      Lwt.return (b1 && b2 && !b));
 
   test "choose_exhausted"
     (fun () ->

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -311,14 +311,14 @@ let suite = suite "lwt_stream" [
         fun () -> let r = !value in value := None; r)
       in
       let b = ref false in
-      Lwt.async (fun () -> Lwt_stream.closed st >|= fun () -> b := true);
+      Lwt.async (fun () ->
+        Lwt_stream.closed st >|= fun () -> b := Lwt_stream.is_closed st);
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
       let b2 = !b = true in
-      let b3 = Lwt_stream.is_closed st in
-      return (b1 && b2 && b3));
+      return (b1 && b2));
 
   test "on_termination"
     (fun () ->


### PR DESCRIPTION
This pull request includes a change to the close semantics of fixed-length sources that was previously included in #223, but requires further discussion. An extensive discussion in IRC took place between myself and @aantron, which can be found [here](http://irclog.whitequark.org/ocaml/2016-05-04#16365196;).

In summary, changing `of_list` and `of_array` to be closed by default is likely an acceptable choice, but the library should accommodate similar functionality for other sort of structures. Right now, this could be accomplished with a function of the following form:

```ocaml
let init (k:('a -> unit) -> unit) : 'a Lwt_stream.t =
  let stream, push = Lwt_stream.create () in
  k (fun x -> push (Some x));
  k None;
  stream
```

However, that may not be at all obvious to users.

The motivation for this change is to allow libraries that consume a user-constructed stream to be able to determine the blocking behavior of a stream and use appropriate serialization strategies. As of now, there is no way in general to determine whether a stream will block in order to generate its elements, or if all its elements have been generated and can be read immediately. In the case of `of_list` and `of_array`, this is information is known when the constructors are called, but is then discarded. This pull request would not discard that information.

Depends on #223.