### PR TITLE
Add builds on Cygwin in AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: "{build}"
+
+shallow_clone: true
+
+environment:
+  global:
+    CYGWIN: C:\Cygwin
+    CYGSH: C:\Cygwin\bin\bash -lc
+  matrix:
+    - COMPILER: 4.01.0
+      SYSTEM: cygwin
+
+    - COMPILER: 4.02.3
+      SYSTEM: cygwin
+
+install:
+  - utils\appveyor-%SYSTEM%-install.bat
+
+build_script:
+  - utils\appveyor-%SYSTEM%-build.bat

--- a/utils/appveyor-cygwin-build.bat
+++ b/utils/appveyor-cygwin-build.bat
@@ -1,0 +1,2 @@
+%CYGSH% "ocamlc -version"
+%CYGSH% "cd /cygdrive/c/projects/lwt && opam pin add -yn . && opam install -ytb lwt"

--- a/utils/appveyor-cygwin-install.bat
+++ b/utils/appveyor-cygwin-install.bat
@@ -1,0 +1,15 @@
+%CYGWIN%\setup-x86.exe -q -P ocaml,ocaml-camlp4,ocaml-compiler-libs,libncurses-devel,unzip,libmpfr-devel,patch,flexdll
+set PATH=%PATH%;%CYGWIN%\bin
+cd ..
+wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-full-1.2.2.tar.gz
+tar xvf opam-full-1.2.2.tar.gz
+%CYGSH% "cd /cygdrive/c/projects/opam-full-1.2.2 && env DJDIR=workaround ./configure && make lib-ext && make && make install"
+%CYGSH% "opam init -ya"
+%CYGSH% "opam switch %COMPILER%"
+git clone https://github.com/ocaml/oasis.git
+cd oasis
+git checkout 0.4.6
+wget -O - https://github.com/Chris00/oasis/commit/4316cf28797ab0686196e0d90651ebf0cdfb6319.patch | git am
+wget -O - https://github.com/pwbs/oasis/commit/00640c1ef3ea4a3790699c0e35a15cad70a7a4b4.patch | git am
+%CYGSH% "opam pin add -yn oasis /cygdrive/c/projects/oasis"
+cd ../lwt


### PR DESCRIPTION
cc @samoht

I don't believe `ocaml-ci-scripts` supports builds in Cygwin (i.e. on a compiler compiled to use Cygwin, e.g. a Cygwin package). Please let me know if anything looks wrong. This can also be contributed to `ocaml-ci-scripts`, with suitable adaptations.