### PR TITLE
Pre-built binaries and caching to speed up Cygwin AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,6 @@ install:
 
 build_script:
   - '%CYGSH% "cd /cygdrive/c/projects/lwt ; utils/appveyor-%SYSTEM%-build.sh"'
+
+cache:
+  - '..\opam-cache-%COMPILER%.tar -> opam, appveyor.yml, utils\appveyor*.sh'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,13 @@ environment:
     CYGWIN: C:\Cygwin
     CYGSH: C:\Cygwin\bin\bash -lc
   matrix:
-    - COMPILER: 4.01.0
-      SYSTEM: cygwin
-
-    - COMPILER: 4.02.3
-      SYSTEM: cygwin
+    - {SYSTEM: cygwin, COMPILER: 4.01}
+    - {SYSTEM: cygwin, COMPILER: 4.02}
 
 install:
+  - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/ocaml/$env:COMPILER/install.ps1") | PowerShell -Command -'
+  - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/camlp4/$env:COMPILER/install.ps1") | PowerShell -Command -'
+  - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/opam/1.2/install.ps1") | PowerShell -Command -'
   - utils\appveyor-%SYSTEM%-install.bat
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/ocaml/$env:COMPILER/install.ps1") | PowerShell -Command -'
   - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/camlp4/$env:COMPILER/install.ps1") | PowerShell -Command -'
   - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/x86/opam/1.2/install.ps1") | PowerShell -Command -'
-  - utils\appveyor-%SYSTEM%-install.bat
+  - '%CYGSH% "cd /cygdrive/c/projects/lwt ; utils/appveyor-%SYSTEM%-install.sh"'
 
 build_script:
-  - utils\appveyor-%SYSTEM%-build.bat
+  - '%CYGSH% "cd /cygdrive/c/projects/lwt ; utils/appveyor-%SYSTEM%-build.sh"'

--- a/utils/appveyor-cygwin-build.bat
+++ b/utils/appveyor-cygwin-build.bat
@@ -1,2 +1,0 @@
-%CYGSH% "ocamlc -version"
-%CYGSH% "cd /cygdrive/c/projects/lwt && opam pin add -yn . && opam install -ytb lwt"

--- a/utils/appveyor-cygwin-build.sh
+++ b/utils/appveyor-cygwin-build.sh
@@ -1,0 +1,7 @@
+set -e
+set -x
+
+ocamlc -version
+
+opam pin add -y --no-action .
+opam install -y --build-test --keep-build-dir lwt

--- a/utils/appveyor-cygwin-build.sh
+++ b/utils/appveyor-cygwin-build.sh
@@ -1,7 +1,4 @@
 set -e
 set -x
 
-ocamlc -version
-
-opam pin add -y --no-action .
 opam install -y --build-test --keep-build-dir lwt

--- a/utils/appveyor-cygwin-install.bat
+++ b/utils/appveyor-cygwin-install.bat
@@ -1,11 +1,8 @@
-%CYGWIN%\setup-x86.exe -q -P ocaml,ocaml-camlp4,ocaml-compiler-libs,libncurses-devel,unzip,libmpfr-devel,patch,flexdll
 set PATH=%PATH%;%CYGWIN%\bin
-cd ..
-wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-full-1.2.2.tar.gz
-tar xvf opam-full-1.2.2.tar.gz
-%CYGSH% "cd /cygdrive/c/projects/opam-full-1.2.2 && env DJDIR=workaround ./configure && make lib-ext && make && make install"
+
 %CYGSH% "opam init -ya"
-%CYGSH% "opam switch %COMPILER%"
+
+cd ..
 git clone https://github.com/ocaml/oasis.git
 cd oasis
 git checkout 0.4.6

--- a/utils/appveyor-cygwin-install.sh
+++ b/utils/appveyor-cygwin-install.sh
@@ -1,6 +1,7 @@
-set PATH=%PATH%;%CYGWIN%\bin
+set -e
+set -x
 
-%CYGSH% "opam init -ya"
+opam init -y --auto-setup
 
 cd ..
 git clone https://github.com/ocaml/oasis.git
@@ -8,5 +9,5 @@ cd oasis
 git checkout 0.4.6
 wget -O - https://github.com/Chris00/oasis/commit/4316cf28797ab0686196e0d90651ebf0cdfb6319.patch | git am
 wget -O - https://github.com/pwbs/oasis/commit/00640c1ef3ea4a3790699c0e35a15cad70a7a4b4.patch | git am
-%CYGSH% "opam pin add -yn oasis /cygdrive/c/projects/oasis"
+opam pin add -y --no-action oasis .
 cd ../lwt

--- a/utils/appveyor-cygwin-install.sh
+++ b/utils/appveyor-cygwin-install.sh
@@ -1,13 +1,36 @@
 set -e
 set -x
 
-opam init -y --auto-setup
+ocamlc -version
 
-cd ..
-git clone https://github.com/ocaml/oasis.git
-cd oasis
-git checkout 0.4.6
-wget -O - https://github.com/Chris00/oasis/commit/4316cf28797ab0686196e0d90651ebf0cdfb6319.patch | git am
-wget -O - https://github.com/pwbs/oasis/commit/00640c1ef3ea4a3790699c0e35a15cad70a7a4b4.patch | git am
-opam pin add -y --no-action oasis .
-cd ../lwt
+DIRECTORY=$(pwd)
+
+# AppVeyor does not cache empty subdirectories of .opam, such as $SWITCH/build.
+# To get around that, create a tar archive of .opam.
+CACHE=$DIRECTORY/../opam-cache-$COMPILER.tar
+
+if [ ! -f $CACHE ]
+then
+    opam init -y --auto-setup
+    eval `opam config env`
+
+    git config --global user.name "AppVeyor"
+    git config --global user.email "appveyor@none.org"
+    cd ..
+    git clone https://github.com/ocaml/oasis.git
+    cd oasis
+    git checkout 0.4.6
+    wget -O - https://github.com/Chris00/oasis/commit/4316cf28797ab0686196e0d90651ebf0cdfb6319.patch | git am
+    wget -O - https://github.com/pwbs/oasis/commit/00640c1ef3ea4a3790699c0e35a15cad70a7a4b4.patch | git am
+    opam pin add -y --no-action oasis .
+    cd $DIRECTORY
+
+    opam pin add -y --no-action .
+    opam install -y --deps-only lwt
+    opam install -y ounit
+
+    ( cd ~ ; tar cf $CACHE .opam )
+else
+    ( cd ~ ; tar xf $CACHE )
+    eval `opam config env`
+fi

--- a/utils/travis.sh
+++ b/utils/travis.sh
@@ -96,13 +96,14 @@ then
     opam install -y conf-libev
 fi
 
-opam install -y camlp4 react ssl lablgtk
 
 
-
-# Install Lwt and run the tests.
+# Pin Lwt, install its optional dependencies, then install Lwt and run the
+# tests.
 opam pin add -y --no-action .
-opam install -y --build-test lwt
+opam install -y `opam list --short --depopts --required-by lwt | grep -v '^conf-'`
+opam install -y ounit
+opam install -y --build-test --keep-build-dir lwt
 
 
 


### PR DESCRIPTION
Builds are now about 5x faster, and take about 6 minutes to complete.

The workers now download binary packages of OPAM and OCaml. Then, the `~/.opam` directory is restored from an AppVeyor cache. It contains the already-built dependencies of Lwt.

- Previously, builds took about [30 minutes](https://ci.appveyor.com/project/aantron/lwt/build/38).
- Using only the binaries, when the cache is invalid, builds now take about [13 minutes](https://ci.appveyor.com/project/aantron/lwt/build/72).
- When the cache is valid, builds take about [6 minutes](https://ci.appveyor.com/project/aantron/lwt/build/73). These builds spend about 50% of their time doing work directly related to Lwt.

There was also the option of downloading only an OPAM binary, then building OCaml switches, and caching those with the rest of `~/.opam`. I decided against it for multiple reasons, the biggest of which is that a build with an invalid cache would take considerably longer than 13 minutes. This would be a pain if iterating on files that invalidate the cache (e.g. `opam` and `appveyor.yml`) – especially since, as I understand it, the cache is per-project, so invalidation occurs even across branches and PRs.

Related #249.