### PR TITLE
Add Lwt_switch.with_switch

### DIFF
--- a/src/core/lwt_switch.ml
+++ b/src/core/lwt_switch.ml
@@ -69,3 +69,9 @@ let turn_off switch =
         Lwt_list.iter_p (fun hook -> Lwt.apply hook ()) hooks
     | St_off ->
         Lwt.return_unit
+
+let with_switch fn =
+  let switch = create () in
+  Lwt.finalize
+    (fun () -> fn switch)
+    (fun () -> turn_off switch)

--- a/src/core/lwt_switch.mli
+++ b/src/core/lwt_switch.mli
@@ -64,15 +64,12 @@
     the code becomes:
 
     {[
-      let switch = Lwt_switch.create () in
-      try_lwt
+      Lwt_switch.with_switch (fun switch ->
         lwt idf = f ~switch ()
         and idg = g ~switch ()
         and idh = h ~switch () in
         ...
-      with exn ->
-        lwt () = Lwt_switch.turn_off switch in
-        raise_lwt exn
+      )
     ]}
 *)
 
@@ -81,6 +78,11 @@ type t
 
 val create : unit -> t
   (** [create ()] creates a new switch. *)
+
+val with_switch : (t -> 'a Lwt.t) -> 'a Lwt.t
+  (** [with_switch fn] is [fn switch], where [switch] is a fresh switch
+      that is turned off when the callback thread finishes (whether it
+      succeeds or fails). *)
 
 val is_on : t -> bool
   (** [is_on switch] returns [true] if the switch is currently on, and


### PR DESCRIPTION
I find myself writing this helper every time I use Lwt. Seems like it should be in the library.

I also updated the example to use it. Technically, it's not quite the same since the example now turns off the switch on success too, but that seems like a reasonable thing to do anyway.