### PR TITLE
Safer alternative to Lwt_io.establish_server

### DIFF
--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -437,13 +437,27 @@ val establish_server :
   ?buffer_size : int ->
   ?backlog : int ->
   Unix.sockaddr -> (input_channel * output_channel -> unit) -> server
-  (** [establish_server ?fd ?buffer_size ?backlog sockaddr f] creates
-      a server which will listen for incoming connections. New
-      connections are passed to [f]. Note that [f] must not raise any
-      exception. If [fd] is not specified, a fresh file descriptor will
-      be created.
+  (** [establish_server ?fd ?buffer_size ?backlog sockaddr f] creates a server
+      which listens for incoming connections. New connections are passed to [f].
 
-      [backlog] is the argument passed to [Lwt_unix.listen] *)
+      [establish_server] does not start separate threads for running [f], nor
+      close the connections passed to [f]. Thus, the skeleton of a practical
+      server based on [establish_server] might look like this:
+
+      {[
+        Lwt_io.establish_server address (fun (ic, oc) ->
+          Lwt.async (fun () ->
+
+            (* ... *)
+
+            Lwt.catch (fun () -> Lwt_io.close oc) (fun _ -> Lwt.return_unit) >>=
+            Lwt.catch (fun () -> Lwt_io.close ic) (fun _ -> Lwt.return_unit)))
+      ]}
+
+      If [fd] is not specified, a fresh file descriptor will be created for
+      listening.
+
+      [backlog] is the argument passed to [Lwt_unix.listen]. *)
 
 val shutdown_server : server -> unit
   (** Shutdown the given server *)

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -413,6 +413,25 @@ val with_connection :
 type server
   (** Type of a server *)
 
+val establish_server_safe :
+  ?fd : Lwt_unix.file_descr ->
+  ?buffer_size : int ->
+  ?backlog : int ->
+  Unix.sockaddr -> (input_channel * output_channel -> unit Lwt.t) -> server
+  (** [establish_server_safe ?fd ?buffer_size ?backlog sockaddr f] creates a
+      server which listens for incoming connections. New connections are passed
+      to [f]. When threads returned by [f] complete, the connections are closed
+      automatically.
+
+      The server does not wait for each thread. It begins accepting new
+      connections immediately.
+
+      If a thread raises an exception, it is passed to
+      [!Lwt.async_exception_hook]. Likewise, if the automatic [close] of a
+      connection raises an exception, it is passed to
+      [!Lwt.async_exception_hook]. To handle exceptions raised by [close], call
+      it manually inside [f]. *)
+
 val establish_server :
   ?fd : Lwt_unix.file_descr ->
   ?buffer_size : int ->


### PR DESCRIPTION
[`Lwt_io.establish_server`][establish_server] is [designed][intent] to be analogous to [`Lwt_io.open_connection`][open_connection]: it hands you channels, but doesn't try to close them. You have to close them yourself.

People have expressed ([1][issue-208], [2][issue-225]) a desire for a version of `establish_server` that is more like [`Lwt_io.with_connection`][with_connection]: it runs your callback `f` to spawn handler threads, and automatically schedules closing the associated channels once each thread completes. This PR adds such a function:

```ocaml
val establish_server_async :
  ?fd : Lwt_unix.file_descr ->
  ?buffer_size : int ->
  ?backlog : int ->                                     (* !!!!! *)
  Unix.sockaddr -> (input_channel * output_channel -> unit Lwt.t) -> server
```

I'm calling it `establish_server_async` as [suggested][name-suggestion] by @c-cube for now, but other suggestions are welcome.

This seems like a difficult problem at first, since if the implicit `close` calls raise exceptions, the user code has no opportunity to catch them and do logging, etc – among other potential challenges. However, if the user needs control over that, it can explicitly close the channels in `f`, and surround that with whatever handling code it wants. The additional implicit `close`s will then have no effect.

So, this should give a safer API for simple usage, that nonetheless remains usable in more complex scenarios.

In fact, I've thought about this at length, and I can find only one reason, besides API breakage, not to replace `establish_server`: one may want to disable implicit channel closing, because the channels are, for example, being stored by `f` in some data structure. However, we could control that with an optional argument.

Other things to consider:

- graceful shutdown,
- concurrent connection limiting,
- aforementioned exception handling,

I don't think `establish_server_async` has any impact on these, relative to `establish_server`, but...

- there are probably other things I didn't think of.

I will probably rewrite the documentation after getting a fresh look at it in some days.

cc @c-cube @fxfactorial @artemkin

Resolves #208.
Resolves #225.

[establish_server]: http://ocsigen.org/lwt/2.5.1/api/Lwt_io#VALestablish_server
[intent]: https://github.com/ocsigen/lwt/issues/196#issuecomment-161936473
[open_connection]: http://ocsigen.org/lwt/2.5.1/api/Lwt_io#VALopen_connection
[with_connection]: http://ocsigen.org/lwt/2.5.1/api/Lwt_io#VALwith_connection
[issue-208]: https://github.com/ocsigen/lwt/issues/208
[issue-225]: https://github.com/ocsigen/lwt/issues/225
[name-suggestion]: https://github.com/ocsigen/lwt/issues/225#issuecomment-202036456
