### PR TITLE
tests: add reproducer for pull request 202: mutex deadlock on cancel

### DIFF
--- a/tests/core/test_lwt_mutex.ml
+++ b/tests/core/test_lwt_mutex.ml
@@ -115,4 +115,32 @@ let suite = suite "lwt_mutex" [
       (* Run thread 3. *)
       Lwt.wakeup wake_top_level_waiter ();
       while_waking);
+
+  (* See https://github.com/ocsigen/lwt/pull/202 - This is an actual reproducer on 2.3.2 *)
+  test "mutex issue"
+    (fun () ->
+       (* Create and lock the mutex *)
+       let mtx = Lwt_mutex.create () in
+       let _prelock = Lwt_mutex.lock mtx in
+
+       (* create a task (lock-try-noop-finally-unlock) pending on the lock *)
+       let t = Lwt_mutex.with_lock mtx (fun () -> Lwt.return ()) in
+
+       (* create a task to unlock and immediately cancel t *)
+       let waiter, wakener = Lwt.task () in
+       let _ = Lwt.bind waiter (fun () ->
+           let () = Lwt_mutex.unlock mtx in
+           let () = Lwt.cancel t in
+           Lwt.return ())
+       in
+       (* run this unlock task with wakeup_later, such that
+          Lwt.wakeuping (2.3.2) or Lwt.wakening is set.
+          This pushes the unlocked task onto the Lwt.to_wakeup queue.
+          The cancel will then change the state of the task
+          while it's sitting on the queue, making the ultimate
+          ignore_wakeup (2.3.2) a noop.
+          This causes the unlock in with_lock to be lost.
+       *)
+       let () = Lwt.wakeup_later wakener () in
+       Lwt.return (not (Lwt_mutex.is_locked mtx)));
 ]

--- a/tests/core/test_lwt_mutex.ml
+++ b/tests/core/test_lwt_mutex.ml
@@ -142,5 +142,7 @@ let suite = suite "lwt_mutex" [
           This causes the unlock in with_lock to be lost.
        *)
        let () = Lwt.wakeup_later wakener () in
-       Lwt.return (not (Lwt_mutex.is_locked mtx)));
+       let r = Lwt.catch (fun () -> t) (fun _ -> Lwt.return ()) in
+       Lwt.bind r (fun () ->
+         Lwt.return (not (Lwt_mutex.is_locked mtx))));
 ]


### PR DESCRIPTION
This test can reproduce the issue on 2.3.2, while the fix provided in the
pull request below fixes the issue.
However, due to changes in the lwt core, this issue is no longer
reproducible on 2.5.0.

By inspection, it looks like this issue was introduced by
d6e3bd423e95695e144509e3cb97439b792cb556
and fixed by
caf3ed199306391e20e93c859666066bfeb433de

This commit immediately sets the state of the task in wakeup_later, making
the subsequent cancel a noop.

See also:
https://github.com/ocsigen/lwt/pull/202