### PR TITLE
test_lwt_mutex: cover PR202 as requested in PR261

### DIFF
--- a/tests/core/test_lwt_mutex.ml
+++ b/tests/core/test_lwt_mutex.ml
@@ -112,7 +112,12 @@ let suite = suite "lwt_mutex" [
           not (Lwt_mutex.is_locked mutex)
       in
 
-      (* Run thread 3. *)
-      Lwt.wakeup wake_top_level_waiter ();
+      (* Run thread 3.
+       * Keep this as wakeup_later to test the issue on 2.3.2 reported in
+       * https://github.com/ocsigen/lwt/pull/202
+       * See also:
+       * https://github.com/ocsigen/lwt/pull/261
+       *)
+      Lwt.wakeup_later wake_top_level_waiter ();
       while_waking);
 ]


### PR DESCRIPTION
The original issue was present in 2.3 series of lwt, where
canceling a thread immediately after it unlocking a mutex
could thwart the unlock, resulting in a forever-locked mutex.
See https://github.com/ocsigen/lwt/pull/202 for a fix on 2.3.2.

Subsequent changes in lwt core fixed this issue. A reproducing
test was submitted at https://github.com/ocsigen/lwt/pull/261, but
as reported there the test changed in this patch is a superset
under the condition that 'wakeup' was changed in 'wakeup_later'.