### PR TITLE
Add support for selecting the libev backend

### DIFF
--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -128,7 +128,27 @@ type ev_loop
 type ev_io
 type ev_timer
 
-external ev_init : unit -> ev_loop = "lwt_libev_init"
+module Ev_backend =
+struct
+  type t =
+    | EV_DEFAULT
+    | EV_SELECT
+    | EV_POLL
+    | EV_EPOLL
+    | EV_KQUEUE
+    | EV_DEVPOLL
+    | EV_PORT
+
+  let default = EV_DEFAULT
+  let select = EV_SELECT
+  let poll = EV_POLL
+  let epoll = EV_EPOLL
+  let kqueue = EV_KQUEUE
+  let devpoll = EV_DEVPOLL
+  let port = EV_PORT
+end
+
+external ev_init : Ev_backend.t -> ev_loop = "lwt_libev_init"
 external ev_stop : ev_loop -> unit = "lwt_libev_stop"
 external ev_loop : ev_loop -> bool -> unit = "lwt_libev_loop"
 external ev_unloop : ev_loop -> unit = "lwt_libev_unloop"
@@ -138,10 +158,10 @@ external ev_io_stop : ev_loop -> ev_io -> unit = "lwt_libev_io_stop"
 external ev_timer_init : ev_loop -> float -> bool -> (unit -> unit) -> ev_timer = "lwt_libev_timer_init"
 external ev_timer_stop : ev_loop -> ev_timer -> unit  = "lwt_libev_timer_stop"
 
-class libev = object
+class libev ?(backend=Ev_backend.default) () = object
   inherit abstract
 
-  val loop = ev_init ()
+  val loop = ev_init backend
   method loop = loop
 
   method private cleanup = ev_stop loop
@@ -378,7 +398,7 @@ end
 
 let current =
   if Lwt_config._HAVE_LIBEV && Lwt_config.libev_default then
-    ref (new libev :> t)
+    ref (new libev () :> t)
   else
     ref (new select :> t)
 

--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -146,6 +146,17 @@ struct
   let kqueue = EV_KQUEUE
   let devpoll = EV_DEVPOLL
   let port = EV_PORT
+
+  let name = function
+    | EV_DEFAULT -> "EV_DEFAULT"
+    | EV_SELECT -> "EV_SELECT"
+    | EV_POLL -> "EV_POLL"
+    | EV_EPOLL -> "EV_EPOLL"
+    | EV_KQUEUE -> "EV_KQUEUE"
+    | EV_DEVPOLL -> "EV_DEVPOLL"
+    | EV_PORT -> "EV_PORT"
+
+  let pp fmt t = Format.pp_print_string fmt (name t)
 end
 
 external ev_init : Ev_backend.t -> ev_loop = "lwt_libev_init"

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -128,11 +128,24 @@ end
 (** {2 Predefined engines} *)
 
 type ev_loop
+
+module Ev_backend :
+sig
+  type t
+  val default : t
+  val select : t
+  val poll : t
+  val epoll : t
+  val kqueue : t
+  val devpoll : t
+  val port : t
+end
+
   (** Type of libev loops. *)
 
 (** Engine based on libev. If not compiled with libev support, the
     creation of the class will raise {!Lwt_sys.Not_available}. *)
-class libev : object
+class libev : ?backend:Ev_backend.t -> unit -> object
   inherit t
 
   val loop : ev_loop

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -139,6 +139,8 @@ sig
   val kqueue : t
   val devpoll : t
   val port : t
+
+  val pp : Format.formatter -> t -> unit
 end
 
   (** Type of libev loops. *)


### PR DESCRIPTION
This pull request adds support for selecting the backend (`poll`, `select`, `kqueue`, etc.) used by the libev engine.  (The [libev man page](http://linux.die.net/man/3/ev) has some fairly forthright notes about the tradeoffs between the various backends.)

The backends are exposed as members of an abstract type, `Ev_backend.t` in the Lwt engine module:

``` ocaml
module Ev_backend :
sig
  type t
  val default : t
  val select : t
  val poll : t
  val epoll : t
  val kqueue : t
  val devpoll : t
  val port : t
end
```

Keeping the type abstract leaves open the possibility to extend the interface in a backwards-compatible way in the future.  For example, it is sometimes useful to pass multiple backend flags, leaving libev to select the best backend from those available; this could be supported in Lwt by the addition of a function of type `Ev_backend.t -> Ev_backend.t -> Ev_backend.t`.  For the moment there is only support for passing a single backend.  

The backend is passed as an argument to the `libev` class:

``` ocaml
class libev : ?backend:Ev_backend.t -> unit -> object
```

The addition of arguments to `libev` is a backwards incompatible change, and client code must be changed to add a unit argument:

``` ocaml
new libev
```

``` ocaml
new libev ()
```

However, this is a one-time cost: if the `libev` interface is extended with additional optional flags in the future, no further changes to client code will be needed.
