### PR TITLE
Add _opam in gitignore for OPAM 2.0 local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ manual/manual-wiki.tex
 manual/.latex_of_wiki_offsets
 setup.exe
 setup-dev.exe
+_opam


### PR DESCRIPTION
OPAM 2.0 allows to have a local configuration and compiler (see https://opam.ocaml.org/blog/opam-2-0-preview/). This configuration is put in `_opam` directory.
Useful for people who wants to contribute to `lwt` without having to install all dependencies in another switch.