### PR TITLE
Lwt_unix: do not truncate notification ids in C

### DIFF
--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -81,7 +81,7 @@ void lwt_unix_not_available(char const *feature) Noreturn;
    +-----------------------------------------------------------------+ */
 
 /* Sends a notification for the given id. */
-void lwt_unix_send_notification(int id);
+void lwt_unix_send_notification(intnat id);
 
 /* +-----------------------------------------------------------------+
    | Threading                                                       |
@@ -178,7 +178,7 @@ struct lwt_unix_job {
 
   /* Id used to notify the main thread in case the job do not
      terminate immediately. */
-  int notification_id;
+  intnat notification_id;
 
   /* The function to call to do the work.
 

--- a/src/unix/lwt_unix.ml
+++ b/src/unix/lwt_unix.ml
@@ -92,7 +92,9 @@ module Notifiers = Hashtbl.Make(struct
 
 let notifiers = Notifiers.create 1024
 
-let current_notification_id = ref 0
+(* See https://github.com/ocsigen/lwt/issues/277 and
+   https://github.com/ocsigen/lwt/pull/278. *)
+let current_notification_id = ref (0x7FFFFFFF - 1000)
 
 let rec find_free_id id =
   if Notifiers.mem notifiers id then


### PR DESCRIPTION
This patch types all C notification id fields, arguments, and variables at type `intnat`, which is exposed by `caml/mlvalues.h`, and ultimately comes from `caml/config.h`. `intnat` is the C data type used by the OCaml runtime for storing OCaml `int`s. Its definition is selected according to the machine word size and the C compiler detected during configuration of OCaml.

The corresponding conversion macros between `intnat` and `value` are `Long_val` and `Val_long`.

Fixes #277.

cc @stijn-devriendt

I was able to reproduce the problem as described in the issue. This patch eliminates it.

Hope I got everything. I did not test the signal code; I mostly proceeded by static analysis.