### PR TITLE
Check for an fdatasync prototype during configuration.

### DIFF
--- a/utils/discover.ml
+++ b/utils/discover.ml
@@ -200,7 +200,8 @@ let fdatasync_code = "
 
 CAMLprim value lwt_test(value Unit)
 {
-  fdatasync(0);
+  int (*fdatasyncp)(int) = fdatasync;
+  fdatasyncp(0);
   return Val_unit;
 }
 "


### PR DESCRIPTION
Fixes #285.

C compilers will (following K&R/C89) add implicit declarations for calls to unknown functions, but they won't support converting functions to function pointers without a prototype.