### PR TITLE
Add support for selecting the libev backend (more gently)

### DIFF
--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -431,3 +431,9 @@ let fake_io fd = !current#fake_io fd
 let readable_count () = !current#readable_count
 let writable_count () = !current#writable_count
 let timer_count () = !current#timer_count
+
+module Versioned =
+struct
+  class libev_1 = libev
+  class libev_2 = libev'
+end

--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -146,6 +146,17 @@ struct
   let kqueue = EV_KQUEUE
   let devpoll = EV_DEVPOLL
   let port = EV_PORT
+
+  let name = function
+    | EV_DEFAULT -> "EV_DEFAULT"
+    | EV_SELECT -> "EV_SELECT"
+    | EV_POLL -> "EV_POLL"
+    | EV_EPOLL -> "EV_EPOLL"
+    | EV_KQUEUE -> "EV_KQUEUE"
+    | EV_DEVPOLL -> "EV_DEVPOLL"
+    | EV_PORT -> "EV_PORT"
+
+  let pp fmt t = Format.pp_print_string fmt (name t)
 end
 
 external ev_init : Ev_backend.t -> ev_loop = "lwt_libev_init"

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -128,6 +128,19 @@ end
 (** {2 Predefined engines} *)
 
 type ev_loop
+
+module Ev_backend :
+sig
+  type t
+  val default : t
+  val select : t
+  val poll : t
+  val epoll : t
+  val kqueue : t
+  val devpoll : t
+  val port : t
+end
+
   (** Type of libev loops. *)
 
 (** Engine based on libev. If not compiled with libev support, the

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -156,6 +156,12 @@ class libev : object
   method loop : ev_loop
     (** Returns [loop]. *)
 end
+[@@ocaml.deprecated
+"This class will soon have parameters for selecting a libev backend. This will
+be a breaking change. See
+  https://github.com/ocsigen/lwt/pull/269
+To preserve the current signature, use Lwt_engine.Versioned.libev_1
+To use the replacement immediately, use Lwt_engine.Versioned.libev_2 ()"]
 
 (** Engine based on [Unix.select]. *)
 class select : t
@@ -207,3 +213,21 @@ val set : ?transfer : bool -> ?destroy : bool -> #t -> unit
 
       If [destroy] is [true] (the default) then the current engine is
       destroyed before being replaced. *)
+
+module Versioned :
+sig
+  class libev_1 : object
+    inherit t
+    val loop : ev_loop
+    method loop : ev_loop
+  end
+  [@@ocaml.deprecated
+   "Deprecated in favor of Lwt_engine.Versioned.libev_2. See
+  https://github.com/ocsigen/lwt/pull/269"]
+
+  class libev_2 : ?backend:Ev_backend.t -> unit -> object
+    inherit t
+    val loop : ev_loop
+    method loop : ev_loop
+  end
+end

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -139,6 +139,8 @@ sig
   val kqueue : t
   val devpoll : t
   val port : t
+
+  val pp : Format.formatter -> t -> unit
 end
 
   (** Type of libev loops. *)


### PR DESCRIPTION
This is a version of #269 that warns current users of `Lwt_engine.libev` that the signature will change, as per #293.

- The new version is available as `Lwt_engine.Versioned.libev_2`. It will be released in the next Lwt release, but will replace the current `libev` in a major release.
- The current `libev` has a warning attached to it in the meantime:

  ```
  Warning 3: deprecated: Lwt_engine.libev
  This class will soon have parameters for selecting a libev backend. This will
  be a breaking change. See
    https://github.com/ocsigen/lwt/pull/269
  To preserve the current signature, use Lwt_engine.Versioned.libev_1
  To use the replacement immediately, use Lwt_engine.Versioned.libev_2 ()
  ```

Resolves #269

cc @yallop I modified the first commit slightly:
  - renamed `libev` to `libev'` in the `.ml` file,
  - defined `libev` in terms of that, and
  - undid the change to the signature of `libev`

Hope that is ok.
