### PR TITLE
Lwt_stream: change close semantics for fixed-length sources

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -170,38 +170,6 @@ let enqueue' e last =
 let enqueue e s =
   enqueue' e s.last
 
-let of_list l =
-  let l = ref l in
-  from_direct
-    (fun () ->
-       match !l with
-         | [] -> None
-         | x :: l' -> l := l'; Some x)
-
-let of_array a =
-  let len = Array.length a and i = ref 0 in
-  from_direct
-    (fun () ->
-       if !i = len then
-         None
-       else begin
-         let c = Array.unsafe_get a !i in
-         incr i;
-         Some c
-       end)
-
-let of_string s =
-  let len = String.length s and i = ref 0 in
-  from_direct
-    (fun () ->
-       if !i = len then
-         None
-       else begin
-         let c = String.unsafe_get s !i in
-         incr i;
-         Some c
-       end)
-
 let create_with_reference () =
   (* Create the source for notifications of new elements. *)
   let source, wakener_cell =
@@ -242,6 +210,21 @@ let create_with_reference () =
 let create () =
   let source, push, _ = create_with_reference () in
   (source, push)
+
+let of_iter iter i =
+  let stream, push = create () in
+  iter (fun x -> push (Some x)) i;
+  push None;
+  stream
+
+let of_list l =
+  of_iter List.iter l
+
+let of_array a =
+  of_iter Array.iter a
+
+let of_string s =
+  of_iter String.iter s
 
 (* Add the pending element to the queue and notify the blocked pushed.
 

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -137,14 +137,19 @@ val create_bounded : int -> 'a t * 'a bounded_push
       It raises [Invalid_argument] if [size < 0]. *)
 
 val of_list : 'a list -> 'a t
-  (** [of_list l] creates a stream returning all elements of [l] *)
+(** [of_list l] creates a stream returning all elements of [l]. The elements are
+    pushed into the stream immediately, resulting in a closed stream (in the
+    sense of {!is_closed}). *)
 
 val of_array : 'a array -> 'a t
-  (** [of_array a] creates a stream returning all elements of [a] *)
+(** [of_array a] creates a stream returning all elements of [a]. The elements
+    are pushed into the stream immediately, resulting in a closed stream (in the
+    sense of {!is_closed}). *)
 
 val of_string : string -> char t
-  (** [of_string str] creates a stream returning all characters of
-      [str] *)
+(** [of_string str] creates a stream returning all characters of [str]. The
+    characters are pushed into the stream immediately, resulting in a closed
+    stream (in the sense of {!is_closed}). *)
 
 val clone : 'a t -> 'a t
   (** [clone st] clone the given stream. Operations on each stream

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -308,40 +308,38 @@ let suite = suite "lwt_stream" [
 
   test "is_closed"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
-      let b1 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.peek st);
-      let b2 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b4 = Lwt_stream.is_closed st in
-      Lwt.return (b1 && b2 && b3 && b4));
+      let b1 = Lwt_stream.(is_closed (of_list [])) in
+      let b2 = Lwt_stream.(is_closed (of_list [1;2;3])) in
+      let b3 = Lwt_stream.(is_closed (of_array [||])) in
+      let b4 = Lwt_stream.(is_closed (of_array [|1;2;3;|])) in
+      let b5 = Lwt_stream.(is_closed (of_string "")) in
+      let b6 = Lwt_stream.(is_closed (of_string "123")) in
+      let b7 = Lwt_stream.(is_closed (from_direct (fun () -> Some 1))) in
+      let b8 = Lwt_stream.(is_closed (from_direct (fun () -> None))) in
+      return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8));
 
   test "closed"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
+      let st = Lwt_stream.from_direct (
+        let value = ref (Some 1) in
+        fun () -> let r = !value in value := None; r)
+      in
       let b = ref false in
-      let is_closed_in_notification = ref false in
       Lwt.async (fun () ->
-        Lwt_stream.closed st >|= fun () ->
-        b := true;
-        is_closed_in_notification := Lwt_stream.is_closed st);
+        Lwt_stream.closed st >|= fun () -> b := Lwt_stream.is_closed st);
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
-      let b2 = !b = false in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = !b = true in
-      Lwt.return (b1 && b2 && b3 && !is_closed_in_notification));
+      let b2 = !b = true in
+      return (b1 && b2));
 
   test "on_termination"
     (fun () ->
-      let st = Lwt_stream.of_list [1; 2] in
+      let st = Lwt_stream.from_direct (
+        let value = ref (Some 1) in
+        fun () -> let r = !value in value := None; r)
+      in
       let b = ref false in
       (Lwt_stream.on_termination [@ocaml.warning "-3"])
         st (fun () -> b := true);
@@ -349,22 +347,18 @@ let suite = suite "lwt_stream" [
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
       ignore (Lwt_stream.peek st);
-      let b2 = !b = false in
-      ignore (Lwt_stream.junk st);
-      ignore (Lwt_stream.peek st);
-      let b3 = !b = true in
+      let b2 = !b = true in
+      let b3 = Lwt_stream.is_closed st in
       Lwt.return (b1 && b2 && b3));
 
   test "on_termination when closed"
     (fun () ->
       let st = Lwt_stream.of_list [] in
       let b = ref false in
-      let b1 = not (Lwt_stream.is_closed st) in
-      ignore (Lwt_stream.junk st);
-      let b2 = Lwt_stream.is_closed st in
+      let b1 = Lwt_stream.is_closed st in
       (Lwt_stream.on_termination [@ocaml.warning "-3"])
         st (fun () -> b := true);
-      Lwt.return (b1 && b2 && !b));
+      Lwt.return (b1 && !b));
 
   test "choose_exhausted"
     (fun () ->

--- a/tests/core/test_lwt_stream.ml
+++ b/tests/core/test_lwt_stream.ml
@@ -315,8 +315,11 @@ let suite = suite "lwt_stream" [
       let b5 = Lwt_stream.(is_closed (of_string "")) in
       let b6 = Lwt_stream.(is_closed (of_string "123")) in
       let b7 = Lwt_stream.(is_closed (from_direct (fun () -> Some 1))) in
-      let b8 = Lwt_stream.(is_closed (from_direct (fun () -> None))) in
-      return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8));
+      let st = Lwt_stream.from_direct (fun () -> None) in
+      let b8 = Lwt_stream.is_closed st in
+      ignore (Lwt_stream.junk st);
+      let b9 = Lwt_stream.is_closed st in
+      return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8 && b9));
 
   test "closed"
     (fun () ->


### PR DESCRIPTION
This is a [fixed-up](https://github.com/ocsigen/lwt/pull/239#issuecomment-228638576) version of #239. The first commit is a squash of that entire PR, the main purpose of which is to leave unchanged attribution and blame on lines with no net change during the PR.

Diffs for easy comparison:
- [whole PR #239](https://github.com/ocsigen/lwt/pull/239/files)
- [as a squashed commit](https://github.com/ocsigen/lwt/commit/2614e5e6994bed5db42cf9820a0bb99457220b9c).


attn @seliopou
