### PR TITLE
discover: Sanity check compilation before checking for missing dependencies

### DIFF
--- a/src/util/discover.ml
+++ b/src/util/discover.ml
@@ -94,6 +94,15 @@ external test : unit -> unit = \"lwt_test\"
 let () = test ()
 "
 
+let trivial_code = "
+#include <caml/mlvalues.h>
+
+CAMLprim value lwt_test(value Unit)
+{
+  return Val_unit;
+}
+"
+
 let pthread_code = "
 #include <caml/mlvalues.h>
 #include <pthread.h>
@@ -549,6 +558,10 @@ let () =
   let have_pkg_config = !not_available = [] in
   not_available := [];
 
+  let test_basic_compilation () =
+    test_code ([], []) trivial_code
+  in
+
   let test_libev () =
     let opt, lib =
       lib_flags "LIBEV"
@@ -611,6 +624,14 @@ let () =
     end in
     fprintf config "#define NANOSEC%s\n" conversion
   in
+
+  if not (test_basic_compilation ()) then begin
+    printf "
+Error: failed to compile a trivial ocaml toplevel.
+You may be missing core components (compiler, ncurses, etc)
+";
+    exit 1
+  end;
 
   test_feature ~do_check:!use_libev "libev" "HAVE_LIBEV" test_libev;
   test_feature ~do_check:!use_pthread "pthread" "HAVE_PTHREAD" test_pthread;


### PR DESCRIPTION
I have a bit of a novel environment in [opam2nix][] where only the (transitive) dependencies are made available to each package while building. Because of this, `lwt` does not have `ncurses` available unless it depends transitively on on an `ncurses` depext (or `conf-ncurses`). There's been a lot of back and forth on where the dependency on `ncurses` belongs, but it hopefully won't be contentious to fail earlier if a basic toplevel can't be compiled.

This PR gives a better error message - currently `lwt` tells me that "pthread" isn't available, because that's just the first thing it attempts to compile. This is misleading, since it would tell me everything is unavailable except for the real problem (in my case, ncurses).

[opam2nix]: https://github.com/timbertson/opam2nix-packages