### PR TITLE
discover: Print more information on failure

### DIFF
--- a/src/util/discover.ml
+++ b/src/util/discover.ml
@@ -538,6 +538,18 @@ let () =
              safe_remove (Filename.chop_extension !caml_file ^ ".cmi");
              safe_remove (Filename.chop_extension !caml_file ^ ".cmo"));
 
+  let exit status =
+    if status <> 0 then begin
+      if !debug then printf "
+See %s for more details.
+      " !log_file
+      else printf "
+Run with DEBUG=y for more details.
+      ";
+    end;
+    exit status
+  in
+
   let setup_data = ref [] in
 
   (* Test for pkg-config. *)


### PR DESCRIPTION
Just putting this here in case it's useful. Without peeking into discover.ml I'd have no idea how to get at the logs when configure fails. This tells you to set `DEBUG=1` if the logs are going to be deleted, and once you _have_ done that it'll print the location of the log on failure.