### PR TITLE
Tests: add coverage analysis for OCaml code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@ setup.exe
 setup-dev.exe
 _opam
 
+# Coverage analysis.
+bisect*.out
+_coverage/
+
 # For local work, tests, etc.
 scratch/

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ doc: $(SETUP) setup.data build
 doc-api: $(SETUP) setup.data build
 	./$(SETUP) -build lwt-api.docdir/index.html
 
-test: $(SETUP) setup.data build
+test: $(SETUP) setup.data build clean-coverage
 	./$(SETUP) -test $(TESTFLAGS)
 
 all: $(SETUP)
@@ -53,12 +53,16 @@ uninstall: $(SETUP) setup.data
 reinstall: $(SETUP) setup.data
 	./$(SETUP) -reinstall $(REINSTALLFLAGS)
 
-clean: $(SETUP)
+clean: $(SETUP) clean-coverage
 	./$(SETUP) -clean $(CLEANFLAGS)
 
 distclean: $(SETUP)
 	./$(SETUP) -distclean $(DISTCLEANFLAGS)
 	rm -rf setup*.exe
+
+clean-coverage:
+	rm -rf bisect*.out
+	rm -rf _coverage/
 
 configure: $(SETUP)
 	./$(SETUP) -configure $(CONFIGUREFLAGS)
@@ -66,4 +70,9 @@ configure: $(SETUP)
 setup.data: $(SETUP)
 	./$(SETUP) -configure $(CONFIGUREFLAGS)
 
-.PHONY: default setup build doc test all install uninstall reinstall clean distclean configure
+coverage: test
+	bisect-ppx-report -I _build/ -html _coverage/ bisect*.out
+	bisect-ppx-report -text - -summary-only bisect*.out
+	@echo See _coverage/index.html
+
+.PHONY: default setup build doc test all install uninstall reinstall clean distclean configure coverage

--- a/_oasis
+++ b/_oasis
@@ -95,6 +95,10 @@ Flag pthread
   Description: Use pthread
   Default$: !os_type(Win32)
 
+Flag coverage
+  Description: Instrument for coverage analysis
+  Default: false
+
 # +-------------------------------------------------------------------+
 # | Libraries                                                         |
 # +-------------------------------------------------------------------+


### PR DESCRIPTION
From the commit message:

<br/>

Install Bisect_ppx:

    opam install bisect_ppx

Enable with:

    ocaml setup.ml -configure --enable-tests --enable-coverage --disable-camlp4

Then run

    make coverage

This will build and run the tests, and generate a coverage report in the
`_coverage/` subdirectory (`view _coverage/index.html`).

<br/>

Related #249.

cc @mfp