### PR TITLE
3.0.0: the breaking changes (OCaml APIs)

### DIFF
--- a/doc/examples/unix/relay.ml
+++ b/doc/examples/unix/relay.ml
@@ -125,7 +125,7 @@ let%lwt () =
     (* Initialize the listening address. *)
     let sock = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
     Lwt_unix.setsockopt sock Unix.SO_REUSEADDR true;
-    let%lwt () = Lwt_unix.Versioned.bind_2 sock src_addr in
+    let%lwt () = Lwt_unix.bind sock src_addr in
     Lwt_unix.listen sock 1024;
 
     ignore (Lwt_log.notice "waiting for connection");

--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -175,7 +175,7 @@ external ev_io_stop : ev_loop -> ev_io -> unit = "lwt_libev_io_stop"
 external ev_timer_init : ev_loop -> float -> bool -> (unit -> unit) -> ev_timer = "lwt_libev_timer_init"
 external ev_timer_stop : ev_loop -> ev_timer -> unit  = "lwt_libev_timer_stop"
 
-class libev' ?(backend=Ev_backend.default) () = object
+class libev ?(backend=Ev_backend.default) () = object
   inherit abstract
 
   val loop = ev_init backend
@@ -203,7 +203,7 @@ class libev' ?(backend=Ev_backend.default) () = object
     lazy(ev_timer_stop loop ev)
 end
 
-class libev = libev' ()
+class libev_deprecated = libev ()
 
 (* +-----------------------------------------------------------------+
    | Select/poll based engines                                       |
@@ -418,7 +418,7 @@ end
 
 let current =
   if Lwt_config._HAVE_LIBEV && Lwt_config.libev_default then
-    ref (new libev :> t)
+    ref (new libev () :> t)
   else
     ref (new select :> t)
 
@@ -441,6 +441,6 @@ let timer_count () = !current#timer_count
 
 module Versioned =
 struct
-  class libev_1 = libev
-  class libev_2 = libev'
+  class libev_1 = libev_deprecated
+  class libev_2 = libev
 end

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -147,7 +147,7 @@ end
 
 (** Engine based on libev. If not compiled with libev support, the
     creation of the class will raise {!Lwt_sys.Not_available}. *)
-class libev : object
+class libev : ?backend:Ev_backend.t -> unit -> object
   inherit t
 
   val loop : ev_loop
@@ -156,13 +156,6 @@ class libev : object
   method loop : ev_loop
     (** Returns [loop]. *)
 end
-[@@ocaml.deprecated
-" This class will soon have parameters for selecting a libev backend. This will
- be a breaking change in Lwt 3.0.0. See
-   https://github.com/ocsigen/lwt/pull/269
- To preserve the current signature, use Lwt_engine.Versioned.libev_1
- To use the replacement immediately, use Lwt_engine.Versioned.libev_2 ()
- Both alternatives require Lwt >= 2.7.0."]
 
 (** Engine based on [Unix.select]. *)
 class select : t
@@ -223,15 +216,23 @@ sig
     method loop : ev_loop
   end
   [@@ocaml.deprecated
-   "Deprecated in favor of Lwt_engine.Versioned.libev_2. See
+" Deprecated in favor of Lwt_engine.libev. See
   https://github.com/ocsigen/lwt/pull/269"]
-  (** @deprecated In favor of {!libev_2}.
+  (** Old version of {!Lwt_engine.libev}. The current {!Lwt_engine.libev} allows
+      selecting the libev back end.
+
+      @deprecated Use {!Lwt_engine.libev}.
       @since 2.7.0 *)
 
-  (** @since 2.7.0 *)
   class libev_2 : ?backend:Ev_backend.t -> unit -> object
     inherit t
     val loop : ev_loop
     method loop : ev_loop
   end
+  [@@ocaml.deprecated
+" In Lwt >= 3.0.0, this is an alias for Lwt_engine.libev."]
+  (** Since Lwt 3.0.0, this is just an alias for {!Lwt_engine.libev}.
+
+      @deprecated Use {!Lwt_engine.libev}.
+      @since 2.7.0 *)
 end

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1465,14 +1465,17 @@ let establish_server_base
 
   server, started
 
-let establish_server ?fd ?buffer_size ?backlog sockaddr f =
+(* Old, deprecated version of [establish_server]. This function has to persist
+   for a while, in some form, until it is no longer exposed as
+   [Lwt_io.Versioned.establish_server_1]. *)
+let establish_server_deprecated ?fd ?buffer_size ?backlog sockaddr f =
   let blocking_bind fd addr =
     Lwt.return (Lwt_unix.Versioned.bind_1 fd addr) [@ocaml.warning "-3"]
   in
   establish_server_base blocking_bind ?fd ?buffer_size ?backlog sockaddr f
   |> fst
 
-let establish_server_safe
+let establish_server
     ?fd ?buffer_size ?backlog ?(no_close = false) sockaddr f =
   let best_effort_close channel =
     (* First, check whether the channel is closed. f may have already tried to
@@ -1556,8 +1559,8 @@ let default_buffer_size _ = !default_buffer_size
 
 module Versioned =
 struct
-  let establish_server_1 = establish_server
-  let establish_server_2 = establish_server_safe
+  let establish_server_1 = establish_server_deprecated
+  let establish_server_2 = establish_server
 
   let shutdown_server_1 = shutdown_server
   let shutdown_server_2 = shutdown_server_2

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1511,8 +1511,8 @@ let establish_server_safe
 
   let server, started =
     establish_server_base
-      Lwt_unix.Versioned.bind_2
-      ?fd ?buffer_size ?backlog sockaddr handler in
+      Lwt_unix.bind ?fd ?buffer_size ?backlog sockaddr handler
+  in
   started >>= fun () ->
   Lwt.return server
 

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1415,9 +1415,10 @@ type server = {
   shutdown : unit Lwt.t Lazy.t;
 }
 
-let shutdown_server_2 server = Lazy.force server.shutdown
+let shutdown_server server = Lazy.force server.shutdown
 
-let shutdown_server server = Lwt.async (fun () -> shutdown_server_2 server)
+let shutdown_server_deprecated server =
+  Lwt.async (fun () -> shutdown_server server)
 
 let establish_server_base
     bind ?fd ?(buffer_size = !default_buffer_size) ?(backlog=5) sockaddr f =
@@ -1562,6 +1563,6 @@ struct
   let establish_server_1 = establish_server_deprecated
   let establish_server_2 = establish_server
 
-  let shutdown_server_1 = shutdown_server
-  let shutdown_server_2 = shutdown_server_2
+  let shutdown_server_1 = shutdown_server_deprecated
+  let shutdown_server_2 = shutdown_server
 end

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -446,21 +446,13 @@ val establish_server :
 
     @since 3.0.0 *)
 
-val shutdown_server : server -> unit
-[@@ocaml.deprecated
-" This function will soon evaluate to a promise that resolves when the close
- system call completes. This will be a breaking change in Lwt 3.0.0. See
-   https://github.com/ocsigen/lwt/issues/259
- To keep the current signature, use Lwt_io.Versioned.shutdown_server_1
- To use the new version immediately, use Lwt_io.Versioned.shutdown_server_2
- Both alternatives require Lwt >= 2.7.0."]
-  (** Closes the given server's listening socket. This function does not wait
-      for the [close] operation to actually complete. It does not affect the
-      sockets of connections that have already been accepted, i.e. passed to [f]
-      by [establish_server].
+val shutdown_server : server -> unit Lwt.t
+(** Closes the given server's listening socket. The returned promise resolves
+    when the [close(2)] system call completes. This function does not affect the
+    sockets of connections that have already been accepted, i.e. passed to [f]
+    by {!establish_server}.
 
-      @deprecated Will be replaced by {!Versioned.shutdown_server_2}, which
-        evaluates to a thread that waits for [close] to complete. *)
+    @since 3.0.0 *)
 
 val lines_of_file : file_name -> string Lwt_stream.t
   (** [lines_of_file name] returns a stream of all lines of the file
@@ -610,20 +602,20 @@ sig
 
   val shutdown_server_1 : server -> unit
     [@@ocaml.deprecated
-" Deprecated in favor of Lwt_io.Versioned.shutdown_server_2. See
+" Deprecated in favor of Lwt_io.shutdown_server. See
    https://github.com/ocsigen/lwt/issues/259"]
-  (** Alias for the current {!Lwt_io.shutdown_server}.
+  (** Old version of {!Lwt_io.shutdown_server}. The current
+      {!Lwt_io.shutdown_server} returns a promise, which resolves when the
+      server's listening socket is closed.
 
-      @deprecated Use {!shutdown_server_2}.
+      @deprecated Use {!Lwt_io.shutdown_server}.
       @since 2.7.0 *)
 
   val shutdown_server_2 : server -> unit Lwt.t
-  (** Closes the given server's listening socket. The thread returned by this
-      function waits for the underlying [close] system call to complete.
+    [@@ocaml.deprecated
+" In Lwt >= 3.0.0, this is an alias for Lwt_io.shutdown_server."]
+  (** Since Lwt 3.0.0, this is just an alias for {!Lwt_io.shutdown_server}.
 
-      This function does not affect sockets of connections that have already
-      been accepted by the server, i.e. those passed by [establish_server] to
-      its callback [f].
-
+      @deprecated Use {!Lwt_io.shutdown_server}.
       @since 2.7.0 *)
 end

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1606,14 +1606,10 @@ let connect ch addr =
               raise Retry
     end
 
-let bind ch addr =
-  check_descriptor ch;
-  Unix.bind ch.fd addr
-
 external bind_job : Unix.file_descr -> Unix.sockaddr -> unit job =
   "lwt_unix_bind_job"
 
-let bind' fd addr =
+let bind fd addr =
   check_descriptor fd;
   match Sys.win32, addr with
   | true, _ | false, Unix.ADDR_INET _ -> Lwt.return (Unix.bind fd.fd addr)
@@ -2371,6 +2367,9 @@ let () =
 
 module Versioned =
 struct
-  let bind_1 = bind
-  let bind_2 = bind'
+  let bind_1 ch addr =
+    check_descriptor ch;
+    Unix.bind ch.fd addr
+
+  let bind_2 = bind
 end

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -888,24 +888,13 @@ val socket : socket_domain -> socket_type -> int -> file_descr
 val socketpair : socket_domain -> socket_type -> int -> file_descr * file_descr
   (** Wrapper for [Unix.socketpair] *)
 
-val bind : file_descr -> sockaddr -> unit
-  [@@ocaml.deprecated
-" This function will soon evaluate to a promise (-> unit Lwt.t), because the
- bind system call can block for Unix domain sockets. See
-   https://github.com/ocsigen/lwt/issues/230
- This will be a breaking change in Lwt 3.0.0.
- If you don't use Unix domain sockets and use Lwt_unix.bind ... ; rather than
- let () = Lwt_unix.bind ... in, you can ignore this warning.
- To retain the current signature, use Lwt_unix.Versioned.bind_1
- To use the new non-blocking version immediately, use Lwt_unix.Versioned.bind_2
- Both alternatives require Lwt >= 2.7.0."]
+val bind : file_descr -> sockaddr -> unit Lwt.t
 (** Binds an address to the given socket. This is the cooperative analog of
     {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#VALbind}
     [Unix.bind]}. See also
     {{:http://man7.org/linux/man-pages/man3/bind.3p.html} [bind(3p)]}.
 
-    @deprecated Will be replaced by {!Versioned.bind_2}, whose result type is
-      [unit Lwt.t] instead of [unit]. *)
+    @since 3.0.0 *)
 
 val listen : file_descr -> int -> unit
   (** Wrapper for [Unix.listen] *)
@@ -1432,17 +1421,21 @@ module Versioned :
 sig
   val bind_1 : file_descr -> sockaddr -> unit
     [@@ocaml.deprecated
-" Deprecated in favor of Lwt_unix.Versioned.bind_2. See
+" Deprecated in favor of Lwt_unix.bind. See
    https://github.com/ocsigen/lwt/issues/230"]
-  (** Alias for the current {!Lwt_unix.bind}.
+  (** Old version of {!Lwt_unix.bind}. The current {!Lwt_unix.bind} evaluates to
+      a promise, because the internal [bind(2)] system call can block if the
+      given socket is a Unix domain socket.
 
-      @deprecated Use {!bind_2}.
+      @deprecated Use {!Lwt_unix.bind}.
       @since 2.7.0 *)
 
   val bind_2 : file_descr -> sockaddr -> unit Lwt.t
-  (** Like {!Lwt_unix.bind}, but evaluates to an Lwt thread, in order to avoid
-      blocking the process in case the given socket is a Unix domain socket.
+    [@@ocaml.deprecated
+" In Lwt >= 3.0.0, this is an alias for Lwt_unix.bind."]
+  (** Since Lwt 3.0.0, this is just an alias for {!Lwt_unix.bind}.
 
+      @deprecated Use {!Lwt_unix.bind}.
       @since 2.7.0 *)
 end
 

--- a/tests/unix/test_lwt_io.ml
+++ b/tests/unix/test_lwt_io.ml
@@ -58,7 +58,7 @@ struct
     in
 
     client_finished >>= fun () ->
-    Lwt_io.Versioned.shutdown_server_2 server
+    Lwt_io.shutdown_server server
 
   (* Dirty hack for forcing [Lwt_io.close] to fail, to test response to [close]
      exceptions. Impolitely closes the [n]th last file descriptor allocated by
@@ -183,7 +183,7 @@ let suite = suite "lwt_io" [
 
       Lwt_io.with_connection local (fun _ -> Lwt.return_unit) >>= fun () ->
       Lwt.wakeup client_finished ();
-      Lwt_io.Versioned.shutdown_server_2 server >>= fun () ->
+      Lwt_io.shutdown_server server >>= fun () ->
       handler);
 
   (* Counterpart to establish_server: shutdown test. Confirms that shutdown is
@@ -207,7 +207,7 @@ let suite = suite "lwt_io" [
 
       >>= fun result ->
 
-      Lwt_io.Versioned.shutdown_server_2 server >|= fun () ->
+      Lwt_io.shutdown_server server >|= fun () ->
       result);
 
   test "establish_server: implicit close"
@@ -376,7 +376,7 @@ let suite = suite "lwt_io" [
         Lwt.return_unit)
 
       >>= fun () ->
-      Lwt_io.Versioned.shutdown_server_2 server >>= fun () ->
+      Lwt_io.shutdown_server server >>= fun () ->
       is_closed_in !in_channel' >>= fun in_closed ->
       is_closed_out !out_channel' >|= fun out_closed ->
       in_closed && out_closed);
@@ -414,6 +414,6 @@ let suite = suite "lwt_io" [
 
       >>= fun () ->
       Lwt.wakeup resume_server ();
-      Lwt_io.Versioned.shutdown_server_2 server >|= fun () ->
+      Lwt_io.shutdown_server server >|= fun () ->
       !exceptions_observed = 2);
 ]

--- a/tests/unix/test_lwt_unix.cppo.ml
+++ b/tests/unix/test_lwt_unix.cppo.ml
@@ -589,7 +589,7 @@ let bind_tests = [
 
       Lwt.finalize
         (fun () ->
-          Lwt_unix.Versioned.bind_2 socket bind_tests_address >>= fun () ->
+          Lwt_unix.bind socket bind_tests_address >>= fun () ->
           Lwt.return (Unix.getsockname (Lwt_unix.unix_file_descr socket)))
         (fun () ->
           Lwt_unix.close socket)
@@ -610,7 +610,7 @@ let bind_tests = [
           let address = Unix.(ADDR_UNIX path) in
           Lwt.catch
             (fun () ->
-              Lwt_unix.Versioned.bind_2 socket address >>= fun () ->
+              Lwt_unix.bind socket address >>= fun () ->
               Lwt.return_true)
             (function
               | Unix.Unix_error (Unix.EADDRINUSE, "bind", _) -> Lwt.return_false
@@ -655,7 +655,7 @@ let bind_tests = [
       Lwt_unix.close socket >>= fun () ->
       Lwt.catch
         (fun () ->
-          Lwt_unix.Versioned.bind_2 socket bind_tests_address >>= fun () ->
+          Lwt_unix.bind socket bind_tests_address >>= fun () ->
           Lwt.return_false)
         (function
           | Unix.Unix_error (Unix.EBADF, _, _) -> Lwt.return_true
@@ -669,7 +669,7 @@ let bind_tests = [
         (fun () ->
           Lwt.catch
             (fun () ->
-              Lwt_unix.Versioned.bind_2 socket bind_tests_address >>= fun () ->
+              Lwt_unix.bind socket bind_tests_address >>= fun () ->
               Lwt.return_false)
             (function
               | Exit -> Lwt.return_true

--- a/tests/unix/test_mcast.ml
+++ b/tests/unix/test_mcast.ml
@@ -57,7 +57,7 @@ let test_mcast name join set_loop =
     let t () =
       Lwt.catch
         (fun () ->
-           Lwt_unix.(Versioned.bind_2
+           Lwt_unix.(bind
              fd1 (ADDR_INET (Unix.inet_addr_any, mcast_port))) >>= fun () ->
            let t1 = child join fd1 in
            let t2 = parent set_loop fd2 in


### PR DESCRIPTION
This PR would commit the breaking changes listed in #308, excluding the one about factoring out packages (the last one). I will make a separate PR for that, as it's a pretty different type of change.

The commits mostly consist of renaming values and editing deprecation messages.