### PR TITLE
Link to Concurrent Programming with Lwt (rwo-lwt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ opam install lwt
 
 ## Documentation
 
-The manual can be found [here][manual]. There are also some examples available
-in [`doc/examples`][examples].
+The manual can be found [here][manual].
+
+[Concurrent Programming with Lwt][rwo-lwt] is a great source of Lwt examples.
+They are translations of code from the excellent Real World OCaml, but they are
+just as useful if you are not reading the book.
+
+Some examples are also available in Lwt's [`doc/examples`][examples].
 
 *Note: much of the manual still refers to `'a Lwt.t` as "lightweight threads" or
 just "threads." This will be fixed in the new manual. `'a Lwt.t` is a promise,
@@ -77,6 +82,7 @@ and has nothing to do with system or preemptive threads.*
 
 [manual]:   http://ocsigen.org/lwt/manual/
 [examples]: https://github.com/ocsigen/lwt/tree/master/doc/examples
+[rwo-lwt]:  https://github.com/dkim/rwo-lwt#readme
 
 <br/>
 


### PR DESCRIPTION
[Concurrent Programming with Lwt](https://github.com/dkim/rwo-lwt) ("rwo-lwt") is a translation of the Async examples in RWO to Lwt by @dkim (thanks!). It's also just a nice set of Lwt examples, even for someone not reading RWO.

This PR links to rwo-lwt from the Lwt `README`, because people are basically always asking for Lwt examples, and rwo-lwt is nice. We should probably also link to it from the mythical future manual.

By the way, if anyone knows of other example collections or tutorials for Lwt that may be out there, please tell us.