### PR TITLE
lwt.ml: human-friendly edition – major refactoring and commenting of the Lwt core

### DIFF
--- a/_tags
+++ b/_tags
@@ -9,6 +9,8 @@ not <src/ssl/*>: safe_string
 # to depend on how Ocamlbuild internally handles lists of warn() tags.
 <src/camlp4/*.ml> or <src/ppx/*.ml>: warn(-4)
 <src/camlp4/*.ml>: warn(-3)
+# Warning 4 is disabled due to https://caml.inria.fr/mantis/view.php?id=7451.
+<src/core/lwt.ml>: warn(-4)
 <**/*>: warn(+A-29-58)
 
 # Syntax extension

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -54,9 +54,11 @@ struct
     mutable cleanups_deferred : int;
   }
 
-  and 'a regular_callback = in_completion_loop -> ('a, underlying, completed) state -> unit
+  and 'a regular_callback = in_completion_loop -> 'a completed_state -> unit
 
   and cancel_callback = in_completion_loop -> unit
+
+  and 'a completed_state = ('a, underlying, completed) state
 
   and in_completion_loop   (* = unit. *)
 
@@ -435,7 +437,7 @@ struct
   let currently_in_completion_loop = ref false
 
   type queued_callbacks =
-    Queued : ('a callbacks * ('a, underlying, completed) state) -> queued_callbacks
+    Queued : ('a callbacks * 'a completed_state) -> queued_callbacks
     [@@ocaml.unboxed]
 
   let queued_callbacks : queued_callbacks Queue.t = Queue.create ()

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -209,6 +209,17 @@ let add_regular_callback_list_node sleeper waiter =
 let add_implicitly_removed_callback sleeper waiter =
   add_regular_callback_list_node sleeper (Regular_callback_list_implicitly_removed_callback waiter)
 
+let add_explicitly_removable_callback_to_each_of threads waiter =
+  let node = Regular_callback_list_explicitly_removable_callback waiter in
+  List.iter
+    (fun t ->
+       match (repr t).state with
+         | Pending sleeper ->
+             add_regular_callback_list_node sleeper node
+         | Resolved _ | Failed _ | Unified_with _ ->
+             assert false)
+    threads
+
 
 
 let async_exception_hook =
@@ -802,17 +813,6 @@ let count_completed_promises_in l =
     match (repr x).state with
     | Pending _ -> acc
     | Resolved _ | Failed _ | Unified_with _ -> acc + 1) 0 l
-
-let add_explicitly_removable_callback_to_each_of threads waiter =
-  let node = Regular_callback_list_explicitly_removable_callback waiter in
-  List.iter
-    (fun t ->
-       match (repr t).state with
-         | Pending sleeper ->
-             add_regular_callback_list_node sleeper node
-         | Resolved _ | Failed _ | Unified_with _ ->
-             assert false)
-    threads
 
 (* The PRNG state is initialized with a constant to make non-IO-based
    programs deterministic. *)

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -68,8 +68,8 @@
    * Please edit the code and the docs!
 
    This code is meant to be readable, and to be edited. If you are reading
-   something, and think there is a much better way to express it, please go
-   ahead and open a pull request to the Lwt repository at
+   something, and think there is a better way to express it, please go ahead and
+   open a pull request to the Lwt repository at
 
      https://github.com/ocsigen/lwt
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -212,7 +212,7 @@
 
    5. Cancelation
 
-   As described above, ordinary promise completion procedes from an initial
+   As described above, ordinary promise completion proceeds from an initial
    promise, forward along callbacks through the dependency graph. Since it
    starts from an initial promise, it can only be triggered using a resolver.
 
@@ -742,7 +742,7 @@ struct
      All that matters is that the top-most sequencing operation (in this case,
      map) is executed by that argument.
 
-     This is implemented using a single global heterogenous key-value map.
+     This is implemented using a single global heterogeneous key-value map.
      Sequential composition functions snapshot this map when they are called,
      and restore the snapshot right before calling the user's callback. The same
      happens for cancel triggers added by [on_cancel].
@@ -860,9 +860,9 @@ struct
 
      Cleanup is throttled by maintaining a counter, [cleanups_deferred], on each
      pending promise. The counter is incremented each time this function wants
-     to clean the callback list (right after after clearing a cell). When the
-     counter reaches [cleanup_throttle], the callback list is actually scanned
-     and cleared callback cells are removed. *)
+     to clean the callback list (right after clearing a cell). When the counter
+     reaches [cleanup_throttle], the callback list is actually scanned and
+     cleared callback cells are removed. *)
   let clear_explicitly_removable_callback_cell cell ~originally_added_to:ps =
     cell := None;
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -96,8 +96,6 @@ external to_public_promise : 'a promise -> 'a t = "%identity"
 external to_public_resolver : 'a promise -> 'a u = "%identity"
 external to_internal_resolver : 'a u -> 'a promise = "%identity"
 
-let cleanup_throttle = 42
-
 
 
 let rec underlying t =
@@ -176,6 +174,8 @@ let rec clean_up_callback_cells = function
   | Regular_callback_list_explicitly_removable_callback _
   | Regular_callback_list_implicitly_removed_callback _ as ws ->
       ws
+
+let cleanup_throttle = 42
 
 let remove_waiters l =
   List.iter

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -96,7 +96,7 @@ external to_public_promise : 'a promise -> 'a t = "%identity"
 external to_public_resolver : 'a promise -> 'a u = "%identity"
 external to_internal_resolver : 'a u -> 'a promise = "%identity"
 
-let max_removed = 42
+let cleanup_throttle = 42
 
 
 type 'a key = {
@@ -376,7 +376,7 @@ let unify t1 t2 =
                   concat_regular_callbacks sleeper1.regular_callbacks sleeper2.regular_callbacks
                 and removed =
                   sleeper1.cleanups_deferred + sleeper2.cleanups_deferred in
-                if removed > max_removed then begin
+                if removed > cleanup_throttle then begin
                   sleeper1.cleanups_deferred <- 0;
                   sleeper1.regular_callbacks <- clean_up_callback_cells waiters
                 end else begin
@@ -771,7 +771,7 @@ let remove_waiters l =
                | Regular_callback_list_implicitly_removed_callback _
                | Regular_callback_list_concat _; _} as sleeper) ->
              let removed = sleeper.cleanups_deferred + 1 in
-             if removed > max_removed then begin
+             if removed > cleanup_throttle then begin
                sleeper.cleanups_deferred <- 0;
                sleeper.regular_callbacks <- clean_up_callback_cells sleeper.regular_callbacks
              end else

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -290,6 +290,15 @@ let run_callbacks sleeper state =
          ());
   run_waiters_rec state sleeper.regular_callbacks []
 
+let complete t state =
+  let t = repr t in
+  match t.state with
+    | Pending sleeper ->
+        t.state <- state;
+        run_callbacks sleeper state
+    | Resolved _ | Failed _ | Unified_with _ ->
+        assert false
+
 let currently_in_completion_loop = ref false
 
 module type A_queued_callbacks = sig
@@ -457,15 +466,6 @@ let unify t1 t2 =
         end
     | Resolved _ | Failed _ | Unified_with _ ->
          assert false
-
-let complete t state =
-  let t = repr t in
-  match t.state with
-    | Pending sleeper ->
-        t.state <- state;
-        run_callbacks sleeper state
-    | Resolved _ | Failed _ | Unified_with _ ->
-        assert false
 
 let fast_connect_if t state =
   let t = repr t in

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -389,11 +389,11 @@ struct
 
   [@@@ocaml.warning "-37"]
 
-  type underlying = Underlying_and_this_constructor_is_not_used
-  type proxy = Proxy_and_this_constructor_is_not_used
+  type underlying = private Underlying_and_this_constructor_is_not_used
+  type proxy = private Proxy_and_this_constructor_is_not_used
 
-  type completed = Completed_and_this_constructor_is_not_used
-  type pending = Pending_and_this_constructor_is_not_used
+  type completed = private Completed_and_this_constructor_is_not_used
+  type pending = private Pending_and_this_constructor_is_not_used
 
   [@@@ocaml.warning "+37"]
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -681,6 +681,11 @@ let try_bind x f g =
     | Unified_with _ ->
         assert false
 
+let finalize f g =
+  try_bind f
+    (fun x -> g () >>= fun () -> return x)
+    (fun e -> g () >>= fun () -> fail e)
+
 let on_success t f =
   match (repr t).state with
     | Resolved v ->
@@ -1051,11 +1056,6 @@ let join l =
 
 let ( <?> ) t1 t2 = choose [t1; t2]
 let ( <&> ) t1 t2 = join [t1; t2]
-
-let finalize f g =
-  try_bind f
-    (fun x -> g () >>= fun () -> return x)
-    (fun e -> g () >>= fun () -> fail e)
 
 
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1125,33 +1125,6 @@ let ( <&> ) t1 t2 = join [t1; t2]
 
 
 
-let pause_hook = ref ignore
-
-let paused = Lwt_sequence.create ()
-let paused_count = ref 0
-
-let pause () =
-  let waiter = add_task_r paused in
-  incr paused_count;
-  !pause_hook !paused_count;
-  waiter
-
-let wakeup_paused () =
-  if Lwt_sequence.is_empty paused then
-    paused_count := 0
-  else begin
-    let tmp = Lwt_sequence.create () in
-    Lwt_sequence.transfer_r paused tmp;
-    paused_count := 0;
-    Lwt_sequence.iter_l (fun wakener -> wakeup wakener ()) tmp
-  end
-
-let register_pause_notifier f = pause_hook := f
-
-let paused_count () = !paused_count
-
-
-
 let rec is_sleeping_rec t =
   match t.state with
     | Resolved _ | Failed _ ->
@@ -1196,6 +1169,34 @@ let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
 let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
 let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
 let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
+
+
+
+let pause_hook = ref ignore
+
+let paused = Lwt_sequence.create ()
+let paused_count = ref 0
+
+let pause () =
+  let waiter = add_task_r paused in
+  incr paused_count;
+  !pause_hook !paused_count;
+  waiter
+
+let wakeup_paused () =
+  if Lwt_sequence.is_empty paused then
+    paused_count := 0
+  else begin
+    let tmp = Lwt_sequence.create () in
+    Lwt_sequence.transfer_r paused tmp;
+    paused_count := 0;
+    Lwt_sequence.iter_l (fun wakener -> wakeup wakener ()) tmp
+  end
+
+let register_pause_notifier f = pause_hook := f
+
+let paused_count () = !paused_count
+
 
 
 module Infix = struct

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -29,11 +29,6 @@ type storage = (unit -> unit) Storage_map.t
 
 
 
-type +'a t
-type -'a u
-
-
-
 type underlying
 type proxy
 
@@ -99,6 +94,9 @@ open Main_internal_types
 
 module Public_types =
 struct
+  type +'a t
+  type -'a u
+
   let to_public_promise : ('a, _, _) promise -> 'a t = Obj.magic
   let to_public_resolver : ('a, _, _) promise -> 'a u = Obj.magic
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -356,16 +356,25 @@ type storage = (unit -> unit) Storage_map.t
 
 
 
-(* Phantom types for use with [promise]/[state]. These must be declared outside
-   module [Main_internal_types]. This is explained inside. *)
-type underlying
-type proxy
-
-type completed
-type pending
-
 module Main_internal_types =
 struct
+  (* Phantom types for use with types [promise] and [state]. These are never
+     constructed; the purpose of the constructors is to prove to the type
+     checker that these types are distinct from each other. Warning 37, "unused
+     constructor," therefore has to be temporarily suppressed. *)
+
+  [@@@ocaml.warning "-37"]
+
+  type underlying = Underlying_and_this_constructor_is_not_used
+  type proxy = Proxy_and_this_constructor_is_not_used
+
+  type completed = Completed_and_this_constructor_is_not_used
+  type pending = Pending_and_this_constructor_is_not_used
+
+  [@@@ocaml.warning "+37"]
+
+
+
   (* Promises proper. *)
 
   type ('a, 'u, 'c) promise = {
@@ -404,15 +413,6 @@ struct
      callbacks have comments explaining what the valid invariants are at that
      point, and/or casts to (1) get the correct typing and (2) document the
      potential state change for readers of the code. *)
-
-  (* Note:
-
-     The phantom types used in the GADT are declared as abstract types. They
-     must be declared outside the module, for OCaml's type system to know that
-     they are definitely distinct types. If they are declared inside this
-     module, OCaml sees them through an inferred signature in the rest of
-     [lwt.ml]. That signature does not guarantee that they are distinct, which
-     defeats the purpose of the GADT in pattern matching. *)
 
 
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -884,6 +884,12 @@ let join l =
   in
   init l
 
+let count_completed_promises_in l =
+  List.fold_left (fun acc x ->
+    match (repr x).state with
+    | Pending _ -> acc
+    | Resolved _ | Failed _ | Unified_with _ -> acc + 1) 0 l
+
 let rec nth_completed l n =
   match l with
     | [] ->
@@ -897,12 +903,6 @@ let rec nth_completed l n =
                 nth_completed l (n - 1)
               else
                 t
-
-let count_completed_promises_in l =
-  List.fold_left (fun acc x ->
-    match (repr x).state with
-    | Pending _ -> acc
-    | Resolved _ | Failed _ | Unified_with _ -> acc + 1) 0 l
 
 (* The PRNG state is initialized with a constant to make non-IO-based
    programs deterministic. *)

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -65,10 +65,10 @@ and 'a promise = {
 }
 
 and 'a callbacks = {
-  mutable how_to_cancel : how_to_cancel;
   mutable regular_callbacks : 'a regular_callback_list;
-  mutable cleanups_deferred : int;
   mutable cancel_callbacks : 'a cancel_callback_list;
+  mutable how_to_cancel : how_to_cancel;
+  mutable cleanups_deferred : int;
 }
 
 and how_to_cancel =
@@ -79,19 +79,19 @@ and how_to_cancel =
 
 and 'a regular_callback_list =
   | Regular_callback_list_empty
+  | Regular_callback_list_concat of
+    'a regular_callback_list * 'a regular_callback_list
   | Regular_callback_list_explicitly_removable_callback of
     ('a promise_state -> unit) option ref
   | Regular_callback_list_implicitly_removed_callback of
     ('a promise_state -> unit)
-  | Regular_callback_list_concat of
-    'a regular_callback_list * 'a regular_callback_list
 
 and 'a cancel_callback_list =
   | Cancel_callback_list_empty
-  | Cancel_callback_list_callback of storage * (unit -> unit)
-  | Cancel_callback_list_remove_sequence_node of 'a u Lwt_sequence.node
   | Cancel_callback_list_concat of
     'a cancel_callback_list * 'a cancel_callback_list
+  | Cancel_callback_list_callback of storage * (unit -> unit)
+  | Cancel_callback_list_remove_sequence_node of 'a u Lwt_sequence.node
 
 external thread_repr : 'a t -> 'a promise = "%identity"
 external thread : 'a promise -> 'a t = "%identity"

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -198,6 +198,17 @@ let remove_waiters l =
              ())
     l
 
+let add_regular_callback_list_node sleeper waiter =
+  sleeper.regular_callbacks <- (match sleeper.regular_callbacks with
+                        | Regular_callback_list_empty -> waiter
+                        | Regular_callback_list_implicitly_removed_callback _
+                        | Regular_callback_list_explicitly_removable_callback _
+                        | Regular_callback_list_concat _ as ws ->
+                          Regular_callback_list_concat (waiter, ws))
+
+let add_implicitly_removed_callback sleeper waiter =
+  add_regular_callback_list_node sleeper (Regular_callback_list_implicitly_removed_callback waiter)
+
 
 
 let async_exception_hook =
@@ -556,17 +567,6 @@ let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
 let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
 let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
 let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
-
-let add_regular_callback_list_node sleeper waiter =
-  sleeper.regular_callbacks <- (match sleeper.regular_callbacks with
-                        | Regular_callback_list_empty -> waiter
-                        | Regular_callback_list_implicitly_removed_callback _
-                        | Regular_callback_list_explicitly_removable_callback _
-                        | Regular_callback_list_concat _ as ws ->
-                          Regular_callback_list_concat (waiter, ws))
-
-let add_implicitly_removed_callback sleeper waiter =
-  add_regular_callback_list_node sleeper (Regular_callback_list_implicitly_removed_callback waiter)
 
 let on_cancel t f =
   match (repr t).state with

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -744,13 +744,6 @@ let try_bind x f g =
     | Unified_with _ ->
         assert false
 
-let poll t =
-  match (repr t).state with
-    | Failed e -> raise e
-    | Resolved v -> Some v
-    | Pending _ -> None
-    | Unified_with _ -> assert false
-
 let async f =
   let t = repr (try f () with exn -> fail exn) in
   match t.state with
@@ -1186,6 +1179,13 @@ let state t = match (repr t).state with
   | Unified_with _ -> assert false
 
 include State
+
+let poll t =
+  match (repr t).state with
+    | Failed e -> raise e
+    | Resolved v -> Some v
+    | Pending _ -> None
+    | Unified_with _ -> assert false
 
 let apply f x = try f x with e -> fail e
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1125,17 +1125,6 @@ let ( <&> ) t1 t2 = join [t1; t2]
 
 
 
-let rec is_sleeping_rec t =
-  match t.state with
-    | Resolved _ | Failed _ ->
-        false
-    | Pending _ ->
-        true
-    | Unified_with t ->
-        is_sleeping_rec t
-
-let is_sleeping t = is_sleeping_rec (to_internal_promise t)
-
 module State = struct
   type 'a state =
     | Return of 'a
@@ -1150,6 +1139,17 @@ let state t = match (repr t).state with
   | Unified_with _ -> assert false
 
 include State
+
+let rec is_sleeping_rec t =
+  match t.state with
+    | Resolved _ | Failed _ ->
+        false
+    | Pending _ ->
+        true
+    | Unified_with t ->
+        is_sleeping_rec t
+
+let is_sleeping t = is_sleeping_rec (to_internal_promise t)
 
 let poll t =
   match (repr t).state with

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -41,7 +41,11 @@
    easily. You can then expand modules as needed, depending on what part of the
    implementation you are interested in. Without code folding, you face an
    intimidating wall of code :( You can still visually parse the file, however,
-   because there are plenty of blank lines to help section things off.
+   because there are plenty of blank lines to help section things off. You can
+   also view this file folded online:
+
+     https://gist.github.com/aantron/9fab0bdead98a60fccf06e0189186863
+     https://gist.github.com/aantron/97b58520d5bb4858ccac6f54700a24d7
 
    The signatures are unusual: big comments are absent. They are moved into the
    modules, so that they are hidden by code folding when you (the reader!) are
@@ -63,6 +67,17 @@
 
    The sections (modules) of the code correspond closely to sections of the
    overview.
+
+
+   * Whitespace
+
+   The total line count of this file may seem frightening, but one third of it
+   is whitespace and comments, both there to help you read the remaining two
+   thirds!
+
+   Also, within those two thirds, there are large groups of functions that are
+   repetitive and formulaic, so there is much less conceptually-unique code in
+   Lwt than you might think at first.
 
 
    * Please edit the code and the docs!

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -96,6 +96,17 @@ external to_public_promise : 'a promise -> 'a t = "%identity"
 external to_public_resolver : 'a promise -> 'a u = "%identity"
 external to_internal_resolver : 'a u -> 'a promise = "%identity"
 
+type +'a result = ('a, exn) Result.result
+
+let state_of_result
+  : 'a result -> 'a promise_state
+  = function
+  | Result.Ok x -> Resolved x
+  | Result.Error e -> Failed e
+
+let make_value v = Result.Ok v
+let make_error e = Result.Error e
+
 
 
 let rec underlying t =
@@ -341,17 +352,6 @@ let run_in_completion_loop sleeper state =
   let ctx = enter_completion_loop () in
   run_callbacks sleeper state;
   leave_completion_loop ctx
-
-type +'a result = ('a, exn) Result.result
-
-let state_of_result
-  : 'a result -> 'a promise_state
-  = function
-  | Result.Ok x -> Resolved x
-  | Result.Error e -> Failed e
-
-let make_value v = Result.Ok v
-let make_error e = Result.Error e
 
 let wakeup_result t result =
   let t = underlying (to_internal_resolver t) in

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -133,6 +133,24 @@ let get key =
   with Not_found ->
     None
 
+let with_value key value f =
+  let save = !current_storage in
+  let data =
+    match value with
+      | Some _ ->
+          Storage_map.add key.id (fun () -> key.store <- value) save
+      | None ->
+          Storage_map.remove key.id save
+  in
+  current_storage := data;
+  try
+    let result = f () in
+    current_storage := save;
+    result
+  with exn ->
+    current_storage := save;
+    raise exn
+
 
 
 let async_exception_hook =
@@ -1055,24 +1073,6 @@ let finalize f g =
   try_bind f
     (fun x -> g () >>= fun () -> return x)
     (fun e -> g () >>= fun () -> fail e)
-
-let with_value key value f =
-  let save = !current_storage in
-  let data =
-    match value with
-      | Some _ ->
-          Storage_map.add key.id (fun () -> key.store <- value) save
-      | None ->
-          Storage_map.remove key.id save
-  in
-  current_storage := data;
-  try
-    let result = f () in
-    current_storage := save;
-    result
-  with exn ->
-    current_storage := save;
-    raise exn
 
 
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -545,18 +545,6 @@ let no_cancel t =
     | Unified_with _ ->
         assert false
 
-let apply f x = try f x with e -> fail e
-
-let wrap f = try return (f ()) with exn -> fail exn
-
-let wrap1 f x1 = try return (f x1) with exn -> fail exn
-let wrap2 f x1 x2 = try return (f x1 x2) with exn -> fail exn
-let wrap3 f x1 x2 x3 = try return (f x1 x2 x3) with exn -> fail exn
-let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
-let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
-let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
-let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
-
 let on_cancel t f =
   match (repr t).state with
     | Pending sleeper ->
@@ -1198,6 +1186,18 @@ let state t = match (repr t).state with
   | Unified_with _ -> assert false
 
 include State
+
+let apply f x = try f x with e -> fail e
+
+let wrap f = try return (f ()) with exn -> fail exn
+
+let wrap1 f x1 = try return (f x1) with exn -> fail exn
+let wrap2 f x1 x2 = try return (f x1 x2) with exn -> fail exn
+let wrap3 f x1 x2 x3 = try return (f x1 x2 x3) with exn -> fail exn
+let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
+let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
+let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
+let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
 
 
 module Infix = struct

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -566,28 +566,20 @@ struct
     Obj.magic node
 
   let add_task_r sequence =
-    let callbacks = {
-      how_to_cancel = Cancel_this_promise;
-      regular_callbacks = Regular_callback_list_empty;
-      cleanups_deferred = 0;
-      cancel_callbacks = Cancel_callback_list_empty
-    } in
-    let p = { state = Pending callbacks } in
+    let p = new_pending ~how_to_cancel:Cancel_this_promise in
     let node = Lwt_sequence.add_r (to_public_resolver p) sequence in
     let node = cast_sequence_node node p in
+
+    let Pending callbacks = p.state in
     callbacks.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
     to_public_promise p
 
   let add_task_l sequence =
-    let callbacks = {
-      how_to_cancel = Cancel_this_promise;
-      regular_callbacks = Regular_callback_list_empty;
-      cleanups_deferred = 0;
-      cancel_callbacks = Cancel_callback_list_empty
-    }in
-    let p = { state = Pending callbacks } in
+    let p = new_pending ~how_to_cancel:Cancel_this_promise in
     let node = Lwt_sequence.add_l (to_public_resolver p) sequence in
     let node = cast_sequence_node node p in
+
+    let Pending callbacks = p.state in
     callbacks.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
     to_public_promise p
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -54,7 +54,7 @@
 
    * Documentation
 
-   The documentation begins with an Overview of major concepts and components.
+   The documentation begins with an overview of major concepts and components.
    This overview puts everything into context. You don't have to read the whole
    thing. The overview begins with basic concepts, moves on to advanced ones,
    and then gets into the truly esoteric. You can read about each concept on an

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -23,8 +23,6 @@
 
 
 
-exception Canceled
-
 module Storage_map = Map.Make(struct type t = int let compare = compare end)
 
 type storage = (unit -> unit) Storage_map.t
@@ -148,6 +146,8 @@ let handle_with_async_exception_hook f x =
     f x
   with exn ->
     !async_exception_hook exn
+
+exception Canceled
 
 let rec run_waiters_rec state ws rem =
   match ws with

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -58,15 +58,15 @@ let pack_promise_list (type x) l =
 
 module Main_internal_types =
 struct
-  type 'a promise_state =
+  type 'a promise = {
+    mutable state : 'a state;
+  }
+
+  and 'a state =
     | Resolved of 'a
     | Failed of exn
     | Pending of 'a callbacks
     | Unified_with of 'a promise
-
-  and 'a promise = {
-    mutable state : 'a promise_state;
-  }
 
   and 'a callbacks = {
     mutable regular_callbacks : 'a regular_callback_list;
@@ -85,10 +85,10 @@ struct
     | Regular_callback_list_empty
     | Regular_callback_list_concat of
       'a regular_callback_list * 'a regular_callback_list
-    | Regular_callback_list_explicitly_removable_callback of
-      ('a promise_state -> unit) option ref
     | Regular_callback_list_implicitly_removed_callback of
-      ('a promise_state -> unit)
+      ('a state -> unit)
+    | Regular_callback_list_explicitly_removable_callback of
+      ('a state -> unit) option ref
 
   and 'a cancel_callback_list =
     | Cancel_callback_list_empty
@@ -345,7 +345,7 @@ and run_cancel_handlers_rec_next rem =
 module type A_queued_callbacks = sig
   type a
   val callbacks : a callbacks
-  val state : a promise_state
+  val state : a state
 end
 
 let queued_callbacks = Queue.create ()

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -99,6 +99,17 @@ external to_internal_resolver : 'a u -> 'a promise = "%identity"
 let cleanup_throttle = 42
 
 
+
+let rec underlying t =
+  match t.state with
+    | Unified_with t' ->
+      let t'' = underlying t' in if t'' != t' then t.state <- Unified_with t''; t''
+    | Resolved _ | Failed _ | Pending _ -> t
+
+let repr t = underlying (to_internal_promise t)
+
+
+
 type 'a key = {
   id : int;
   mutable store : 'a option;
@@ -123,14 +134,6 @@ let get key =
     None
 
 
-
-let rec underlying t =
-  match t.state with
-    | Unified_with t' ->
-      let t'' = underlying t' in if t'' != t' then t.state <- Unified_with t''; t''
-    | Resolved _ | Failed _ | Pending _ -> t
-
-let repr t = underlying (to_internal_promise t)
 
 let async_exception_hook =
   ref (fun exn ->

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -109,15 +109,11 @@ external to_public_promise : 'a promise -> 'a t = "%identity"
 external to_public_resolver : 'a promise -> 'a u = "%identity"
 external to_internal_resolver : 'a u -> 'a promise = "%identity"
 
-type +'a result = ('a, exn) Result.result
+  type +'a lwt_result = ('a, exn) Result.result
 
   let state_of_result = function
     | Result.Ok x -> Resolved x
     | Result.Error exn -> Failed exn
-
-let make_value v = Result.Ok v
-let make_error exn = Result.Error exn
-
 end
 include Public_types
 
@@ -395,8 +391,8 @@ let queued_callbacks = Queue.create ()
       | Resolved _ | Failed _ | Unified_with _ ->
           invalid_arg "Lwt.wakeup_result"
 
-  let wakeup r v = wakeup_result r (make_value v)
-  let wakeup_exn r exn = wakeup_result r (make_error exn)
+  let wakeup r v = wakeup_result r (Result.Ok v)
+  let wakeup_exn r exn = wakeup_result r (Result.Error exn)
 
   let wakeup_later_result (type x) r result =
     let p = underlying (to_internal_resolver r) in
@@ -418,8 +414,8 @@ let queued_callbacks = Queue.create ()
       | Resolved _ | Failed _ | Unified_with _ ->
           invalid_arg "Lwt.wakeup_later_result"
 
-  let wakeup_later r v = wakeup_later_result r (make_value v)
-  let wakeup_later_exn r exn = wakeup_later_result r (make_error exn)
+  let wakeup_later r v = wakeup_later_result r (Result.Ok v)
+  let wakeup_later_exn r exn = wakeup_later_result r (Result.Error exn)
 
 module type Packed_callbacks = sig
   type a
@@ -1271,3 +1267,14 @@ module Infix = struct
   let (<&>) = (<&>)
   let (<?>) = (<?>)
 end
+
+
+
+module Lwt_result_type =
+struct
+  type +'a result = 'a lwt_result
+
+  let make_value v = Result.Ok v
+  let make_error exn = Result.Error exn
+end
+include Lwt_result_type

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -58,46 +58,44 @@ let pack_promise_list (type x) l =
 
 module Main_internal_types =
 struct
+  type 'a promise_state =
+    | Resolved of 'a
+    | Failed of exn
+    | Pending of 'a callbacks
+    | Unified_with of 'a promise
 
-type 'a promise_state =
-  | Resolved of 'a
-  | Failed of exn
-  | Pending of 'a callbacks
-  | Unified_with of 'a promise
+  and 'a promise = {
+    mutable state : 'a promise_state;
+  }
 
-and 'a promise = {
-  mutable state : 'a promise_state;
-}
+  and 'a callbacks = {
+    mutable regular_callbacks : 'a regular_callback_list;
+    mutable cancel_callbacks  : 'a cancel_callback_list;
+    mutable how_to_cancel     : how_to_cancel;
+    mutable cleanups_deferred : int;
+  }
 
-and 'a callbacks = {
-  mutable regular_callbacks : 'a regular_callback_list;
-  mutable cancel_callbacks : 'a cancel_callback_list;
-  mutable how_to_cancel : how_to_cancel;
-  mutable cleanups_deferred : int;
-}
+  and how_to_cancel =
+    | Not_cancelable
+    | Cancel_this_promise
+    | Propagate_cancel_to_one of a_promise
+    | Propagate_cancel_to_several of a_promise_list
 
-and how_to_cancel =
-  | Not_cancelable
-  | Cancel_this_promise
-  | Propagate_cancel_to_one of a_promise
-  | Propagate_cancel_to_several of a_promise_list
+  and 'a regular_callback_list =
+    | Regular_callback_list_empty
+    | Regular_callback_list_concat of
+      'a regular_callback_list * 'a regular_callback_list
+    | Regular_callback_list_explicitly_removable_callback of
+      ('a promise_state -> unit) option ref
+    | Regular_callback_list_implicitly_removed_callback of
+      ('a promise_state -> unit)
 
-and 'a regular_callback_list =
-  | Regular_callback_list_empty
-  | Regular_callback_list_concat of
-    'a regular_callback_list * 'a regular_callback_list
-  | Regular_callback_list_explicitly_removable_callback of
-    ('a promise_state -> unit) option ref
-  | Regular_callback_list_implicitly_removed_callback of
-    ('a promise_state -> unit)
-
-and 'a cancel_callback_list =
-  | Cancel_callback_list_empty
-  | Cancel_callback_list_concat of
-    'a cancel_callback_list * 'a cancel_callback_list
-  | Cancel_callback_list_callback of storage * (unit -> unit)
-  | Cancel_callback_list_remove_sequence_node of 'a u Lwt_sequence.node
-
+  and 'a cancel_callback_list =
+    | Cancel_callback_list_empty
+    | Cancel_callback_list_concat of
+      'a cancel_callback_list * 'a cancel_callback_list
+    | Cancel_callback_list_callback of storage * (unit -> unit)
+    | Cancel_callback_list_remove_sequence_node of 'a u Lwt_sequence.node
 end
 open Main_internal_types
 
@@ -113,9 +111,9 @@ external to_internal_resolver : 'a u -> 'a promise = "%identity"
 
 type +'a result = ('a, exn) Result.result
 
-let state_of_result = function
-  | Result.Ok x -> Resolved x
-  | Result.Error e -> Failed e
+  let state_of_result = function
+    | Result.Ok x -> Resolved x
+    | Result.Error e -> Failed e
 
 let make_value v = Result.Ok v
 let make_error exn = Result.Error exn
@@ -143,48 +141,46 @@ open Basic_helpers
 
 module Sequence_associated_storage =
 struct
+  type 'a key = {
+    id : int;
+    mutable store : 'a option;
+  }
 
-type 'a key = {
-  id : int;
-  mutable store : 'a option;
-}
+  let next_key_id = ref 0
 
-let next_key_id = ref 0
+  let new_key () =
+    let id = !next_key_id in
+    next_key_id := id + 1;
+    { id = id; store = None }
 
-let new_key () =
-  let id = !next_key_id in
-  next_key_id := id + 1;
-  { id = id; store = None }
+  let current_storage = ref Storage_map.empty
 
-let current_storage = ref Storage_map.empty
+  let get key =
+    try
+      Storage_map.find key.id !current_storage ();
+      let value = key.store in
+      key.store <- None;
+      value
+    with Not_found ->
+      None
 
-let get key =
-  try
-    Storage_map.find key.id !current_storage ();
-    let value = key.store in
-    key.store <- None;
-    value
-  with Not_found ->
-    None
-
-let with_value key value f =
-  let save = !current_storage in
-  let data =
-    match value with
-      | Some _ ->
-          Storage_map.add key.id (fun () -> key.store <- value) save
-      | None ->
-          Storage_map.remove key.id save
-  in
-  current_storage := data;
-  try
-    let result = f () in
-    current_storage := save;
-    result
-  with exn ->
-    current_storage := save;
-    raise exn
-
+  let with_value key value f =
+    let save = !current_storage in
+    let data =
+      match value with
+        | Some _ ->
+            Storage_map.add key.id (fun () -> key.store <- value) save
+        | None ->
+            Storage_map.remove key.id save
+    in
+    current_storage := data;
+    try
+      let result = f () in
+      current_storage := save;
+      result
+    with exn ->
+      current_storage := save;
+      raise exn
 end
 include Sequence_associated_storage
 
@@ -192,76 +188,74 @@ include Sequence_associated_storage
 
 module Callbacks =
 struct
+  let concat_regular_callbacks l1 l2 =
+    (match l1, l2 with
+      | Regular_callback_list_empty, _ -> l2
+      | _, Regular_callback_list_empty -> l1
+      | _ -> Regular_callback_list_concat (l1, l2))
+    [@ocaml.warning "-4"]
 
-let concat_regular_callbacks l1 l2 =
-  (match l1, l2 with
-    | Regular_callback_list_empty, _ -> l2
-    | _, Regular_callback_list_empty -> l1
-    | _ -> Regular_callback_list_concat (l1, l2))
-  [@ocaml.warning "-4"]
+  let concat_cancel_callbacks l1 l2 =
+    (match l1, l2 with
+      | Cancel_callback_list_empty, _ -> l2
+      | _, Cancel_callback_list_empty -> l1
+      | _ -> Cancel_callback_list_concat (l1, l2))
+    [@ocaml.warning "-4"]
 
-let concat_cancel_callbacks l1 l2 =
-  (match l1, l2 with
-    | Cancel_callback_list_empty, _ -> l2
-    | _, Cancel_callback_list_empty -> l1
-    | _ -> Cancel_callback_list_concat (l1, l2))
-  [@ocaml.warning "-4"]
+  let rec clean_up_callback_cells = function
+    | Regular_callback_list_explicitly_removable_callback { contents = None } ->
+        Regular_callback_list_empty
+    | Regular_callback_list_concat (l1, l2) ->
+        concat_regular_callbacks (clean_up_callback_cells l1) (clean_up_callback_cells l2)
+    | Regular_callback_list_empty
+    | Regular_callback_list_explicitly_removable_callback _
+    | Regular_callback_list_implicitly_removed_callback _ as ws ->
+        ws
 
-let rec clean_up_callback_cells = function
-  | Regular_callback_list_explicitly_removable_callback { contents = None } ->
-      Regular_callback_list_empty
-  | Regular_callback_list_concat (l1, l2) ->
-      concat_regular_callbacks (clean_up_callback_cells l1) (clean_up_callback_cells l2)
-  | Regular_callback_list_empty
-  | Regular_callback_list_explicitly_removable_callback _
-  | Regular_callback_list_implicitly_removed_callback _ as ws ->
-      ws
+  let cleanup_throttle = 42
 
-let cleanup_throttle = 42
+  let remove_waiters l =
+    List.iter
+      (fun t ->
+         match (repr t).state with
+           | Pending ({ regular_callbacks =
+                   Regular_callback_list_explicitly_removable_callback _; _ } as sleeper) ->
+               sleeper.regular_callbacks <- Regular_callback_list_empty
+           | Pending ({regular_callbacks =
+                   Regular_callback_list_empty
+                 | Regular_callback_list_implicitly_removed_callback _
+                 | Regular_callback_list_concat _; _} as sleeper) ->
+               let removed = sleeper.cleanups_deferred + 1 in
+               if removed > cleanup_throttle then begin
+                 sleeper.cleanups_deferred <- 0;
+                 sleeper.regular_callbacks <- clean_up_callback_cells sleeper.regular_callbacks
+               end else
+                 sleeper.cleanups_deferred <- removed
+           | Resolved _ | Failed _ | Unified_with _ ->
+               ())
+      l
 
-let remove_waiters l =
-  List.iter
-    (fun t ->
-       match (repr t).state with
-         | Pending ({ regular_callbacks =
-                 Regular_callback_list_explicitly_removable_callback _; _ } as sleeper) ->
-             sleeper.regular_callbacks <- Regular_callback_list_empty
-         | Pending ({regular_callbacks =
-                 Regular_callback_list_empty
-               | Regular_callback_list_implicitly_removed_callback _
-               | Regular_callback_list_concat _; _} as sleeper) ->
-             let removed = sleeper.cleanups_deferred + 1 in
-             if removed > cleanup_throttle then begin
-               sleeper.cleanups_deferred <- 0;
-               sleeper.regular_callbacks <- clean_up_callback_cells sleeper.regular_callbacks
-             end else
-               sleeper.cleanups_deferred <- removed
-         | Resolved _ | Failed _ | Unified_with _ ->
-             ())
-    l
+  let add_regular_callback_list_node callbacks node =
+    callbacks.regular_callbacks <- (match callbacks.regular_callbacks with
+                          | Regular_callback_list_empty -> node
+                          | Regular_callback_list_implicitly_removed_callback _
+                          | Regular_callback_list_explicitly_removable_callback _
+                          | Regular_callback_list_concat _ as ws ->
+                            Regular_callback_list_concat (node, ws))
 
-let add_regular_callback_list_node callbacks node =
-  callbacks.regular_callbacks <- (match callbacks.regular_callbacks with
-                        | Regular_callback_list_empty -> node
-                        | Regular_callback_list_implicitly_removed_callback _
-                        | Regular_callback_list_explicitly_removable_callback _
-                        | Regular_callback_list_concat _ as ws ->
-                          Regular_callback_list_concat (node, ws))
+  let add_implicitly_removed_callback callbacks f =
+    add_regular_callback_list_node callbacks (Regular_callback_list_implicitly_removed_callback f)
 
-let add_implicitly_removed_callback callbacks f =
-  add_regular_callback_list_node callbacks (Regular_callback_list_implicitly_removed_callback f)
-
-let add_explicitly_removable_callback_to_each_of ps f =
-  let node = Regular_callback_list_explicitly_removable_callback f in
-  List.iter
-    (fun t ->
-       match (repr t).state with
-         | Pending sleeper ->
-             add_regular_callback_list_node sleeper node
-         | Resolved _ | Failed _ | Unified_with _ ->
-             assert false)
-    ps
-
+  let add_explicitly_removable_callback_to_each_of ps f =
+    let node = Regular_callback_list_explicitly_removable_callback f in
+    List.iter
+      (fun t ->
+         match (repr t).state with
+           | Pending sleeper ->
+               add_regular_callback_list_node sleeper node
+           | Resolved _ | Failed _ | Unified_with _ ->
+               assert false)
+      ps
 end
 open Callbacks
 
@@ -269,23 +263,22 @@ open Callbacks
 
 module Completion_loop =
 struct
+  let async_exception_hook =
+    ref (fun exn ->
+           prerr_string "Fatal error: exception ";
+           prerr_string (Printexc.to_string exn);
+           prerr_char '\n';
+           Printexc.print_backtrace stderr;
+           flush stderr;
+           exit 2)
 
-let async_exception_hook =
-  ref (fun exn ->
-         prerr_string "Fatal error: exception ";
-         prerr_string (Printexc.to_string exn);
-         prerr_char '\n';
-         Printexc.print_backtrace stderr;
-         flush stderr;
-         exit 2)
+  let handle_with_async_exception_hook f v =
+    try
+      f v
+    with exn ->
+      !async_exception_hook exn
 
-let handle_with_async_exception_hook f v =
-  try
-    f v
-  with exn ->
-    !async_exception_hook exn
-
-exception Canceled
+  exception Canceled
 
 let rec run_waiters_rec state ws rem =
   match ws with
@@ -330,24 +323,24 @@ and run_cancel_handlers_rec_next rem =
     | chs :: rem ->
         run_cancel_handlers_rec chs rem
 
-let run_callbacks callbacks result =
-  (match result with
-     | Failed Canceled ->
-         run_cancel_handlers_rec callbacks.cancel_callbacks []
-     | Resolved _ | Failed _ | Pending _ | Unified_with _ ->
-         ());
-  run_waiters_rec result callbacks.regular_callbacks []
+  let run_callbacks callbacks result =
+    (match result with
+       | Failed Canceled ->
+           run_cancel_handlers_rec callbacks.cancel_callbacks []
+       | Resolved _ | Failed _ | Pending _ | Unified_with _ ->
+           ());
+    run_waiters_rec result callbacks.regular_callbacks []
 
-let complete p result =
-  let t = repr p in
-  match t.state with
-    | Pending sleeper ->
-        t.state <- result;
-        run_callbacks sleeper result
-    | Resolved _ | Failed _ | Unified_with _ ->
-        assert false
+  let complete p result =
+    let t = repr p in
+    match t.state with
+      | Pending sleeper ->
+          t.state <- result;
+          run_callbacks sleeper result
+      | Resolved _ | Failed _ | Unified_with _ ->
+          assert false
 
-let currently_in_completion_loop = ref false
+  let currently_in_completion_loop = ref false
 
 module type A_queued_callbacks = sig
   type a
@@ -357,76 +350,76 @@ end
 
 let queued_callbacks = Queue.create ()
 
-let enter_completion_loop () =
-  let snapshot = !current_storage in
-  let already_wakening =
-    if !currently_in_completion_loop then
-      true
-    else begin
-      currently_in_completion_loop := true;
-      false
-    end
-  in
-  (already_wakening, snapshot)
+  let enter_completion_loop () =
+    let snapshot = !current_storage in
+    let already_wakening =
+      if !currently_in_completion_loop then
+        true
+      else begin
+        currently_in_completion_loop := true;
+        false
+      end
+    in
+    (already_wakening, snapshot)
 
-let leave_completion_loop (already_wakening, snapshot) =
-  if not already_wakening then begin
-    while not (Queue.is_empty queued_callbacks) do
-      let closure = Queue.pop queued_callbacks in
-      let module M = (val closure : A_queued_callbacks) in
-      run_callbacks M.callbacks M.state
-    done;
-    currently_in_completion_loop := false;
-    current_storage := snapshot
-  end else
-    current_storage := snapshot
+  let leave_completion_loop (already_wakening, snapshot) =
+    if not already_wakening then begin
+      while not (Queue.is_empty queued_callbacks) do
+        let closure = Queue.pop queued_callbacks in
+        let module M = (val closure : A_queued_callbacks) in
+        run_callbacks M.callbacks M.state
+      done;
+      currently_in_completion_loop := false;
+      current_storage := snapshot
+    end else
+      current_storage := snapshot
 
-(* See https://github.com/ocsigen/lwt/issues/48. *)
-let abandon_wakeups () =
-  if !currently_in_completion_loop then leave_completion_loop (false, Storage_map.empty)
+  (* See https://github.com/ocsigen/lwt/issues/48. *)
+  let abandon_wakeups () =
+    if !currently_in_completion_loop then leave_completion_loop (false, Storage_map.empty)
 
-let run_in_completion_loop sleeper state =
-  let ctx = enter_completion_loop () in
-  run_callbacks sleeper state;
-  leave_completion_loop ctx
+  let run_in_completion_loop sleeper state =
+    let ctx = enter_completion_loop () in
+    run_callbacks sleeper state;
+    leave_completion_loop ctx
 
-let wakeup_result r result =
-  let t = underlying (to_internal_resolver r) in
-  match t.state with
-    | Pending sleeper ->
-        let state = state_of_result result in
-        t.state <- state;
-        run_in_completion_loop sleeper state
-    | Failed Canceled ->
-        ()
-    | Resolved _ | Failed _ | Unified_with _ ->
-        invalid_arg "Lwt.wakeup_result"
-
-let wakeup r v = wakeup_result r (make_value v)
-let wakeup_exn r exn = wakeup_result r (make_error exn)
-
-let wakeup_later_result (type x) r result =
-  let t = underlying (to_internal_resolver r) in
-  match t.state with
-    | Pending sleeper ->
-        let state = state_of_result result in
-        t.state <- state;
-        if !currently_in_completion_loop then begin
-          let module M = struct
-            type a = x
-            let callbacks = sleeper
-            let state = state
-          end in
-          Queue.push (module M : A_queued_callbacks) queued_callbacks
-        end else
+  let wakeup_result r result =
+    let t = underlying (to_internal_resolver r) in
+    match t.state with
+      | Pending sleeper ->
+          let state = state_of_result result in
+          t.state <- state;
           run_in_completion_loop sleeper state
-    | Failed Canceled ->
-        ()
-    | Resolved _ | Failed _ | Unified_with _ ->
-        invalid_arg "Lwt.wakeup_later_result"
+      | Failed Canceled ->
+          ()
+      | Resolved _ | Failed _ | Unified_with _ ->
+          invalid_arg "Lwt.wakeup_result"
 
-let wakeup_later r v = wakeup_later_result r (make_value v)
-let wakeup_later_exn r exn = wakeup_later_result r (make_error exn)
+  let wakeup r v = wakeup_result r (make_value v)
+  let wakeup_exn r exn = wakeup_result r (make_error exn)
+
+  let wakeup_later_result (type x) r result =
+    let t = underlying (to_internal_resolver r) in
+    match t.state with
+      | Pending sleeper ->
+          let state = state_of_result result in
+          t.state <- state;
+          if !currently_in_completion_loop then begin
+            let module M = struct
+              type a = x
+              let callbacks = sleeper
+              let state = state
+            end in
+            Queue.push (module M : A_queued_callbacks) queued_callbacks
+          end else
+            run_in_completion_loop sleeper state
+      | Failed Canceled ->
+          ()
+      | Resolved _ | Failed _ | Unified_with _ ->
+          invalid_arg "Lwt.wakeup_later_result"
+
+  let wakeup_later r v = wakeup_later_result r (make_value v)
+  let wakeup_later_exn r exn = wakeup_later_result r (make_error exn)
 
 module type Packed_callbacks = sig
   type a
@@ -439,38 +432,37 @@ let pack_callbacks (type x) sleeper =
   let module M = struct type a = x let callbacks = sleeper end in
   (module M : Packed_callbacks)
 
-let cancel p =
-  let state = Failed Canceled in
-  let rec collect : 'a. packed_callbacks list -> 'a t -> packed_callbacks list = fun acc t ->
-    let t = repr t in
-    match t.state with
-      | Pending ({ how_to_cancel; _ } as sleeper) -> begin
-          match how_to_cancel with
-            | Not_cancelable ->
-                acc
-            | Cancel_this_promise ->
-                t.state <- state;
-                (pack_callbacks sleeper) :: acc
-            | Propagate_cancel_to_one m ->
-                let module M = (val m : Existential_promise) in
-                collect acc M.promise
-            | Propagate_cancel_to_several m ->
-                let module M = (val m : Existential_promise_list) in
-                List.fold_left collect acc M.promise_list
-        end
-      | Resolved _ | Failed _ | Unified_with _ ->
-          acc
-  in
-  let sleepers = collect [] p in
-  let ctx = enter_completion_loop () in
-  List.iter
-    (fun sleeper ->
-       let module M = (val sleeper : Packed_callbacks) in
-       run_cancel_handlers_rec M.callbacks.cancel_callbacks [];
-       run_waiters_rec state M.callbacks.regular_callbacks [])
-    sleepers;
-  leave_completion_loop ctx
-
+  let cancel p =
+    let state = Failed Canceled in
+    let rec collect : 'a. packed_callbacks list -> 'a t -> packed_callbacks list = fun acc t ->
+      let t = repr t in
+      match t.state with
+        | Pending ({ how_to_cancel; _ } as sleeper) -> begin
+            match how_to_cancel with
+              | Not_cancelable ->
+                  acc
+              | Cancel_this_promise ->
+                  t.state <- state;
+                  (pack_callbacks sleeper) :: acc
+              | Propagate_cancel_to_one m ->
+                  let module M = (val m : Existential_promise) in
+                  collect acc M.promise
+              | Propagate_cancel_to_several m ->
+                  let module M = (val m : Existential_promise_list) in
+                  List.fold_left collect acc M.promise_list
+          end
+        | Resolved _ | Failed _ | Unified_with _ ->
+            acc
+    in
+    let sleepers = collect [] p in
+    let ctx = enter_completion_loop () in
+    List.iter
+      (fun sleeper ->
+         let module M = (val sleeper : Packed_callbacks) in
+         run_cancel_handlers_rec M.callbacks.cancel_callbacks [];
+         run_waiters_rec state M.callbacks.regular_callbacks [])
+      sleepers;
+    leave_completion_loop ctx
 end
 include Completion_loop
 
@@ -490,32 +482,30 @@ let fast_connect_if t state =
 
 module Trivial_promises =
 struct
+  let return v =
+    to_public_promise { state = Resolved v }
 
-let return v =
-  to_public_promise { state = Resolved v }
+  let state_return_unit = Resolved ()
+  let return_unit = to_public_promise { state = state_return_unit }
+  let return_none = return None
+  let return_some x = return (Some x)
+  let return_nil = return []
+  let return_true = return true
+  let return_false = return false
+  let return_ok x = return (Result.Ok x)
+  let return_error x = return (Result.Error x)
 
-let state_return_unit = Resolved ()
-let return_unit = to_public_promise { state = state_return_unit }
-let return_none = return None
-let return_some x = return (Some x)
-let return_nil = return []
-let return_true = return true
-let return_false = return false
-let return_ok x = return (Result.Ok x)
-let return_error x = return (Result.Error x)
+  let of_result result =
+    to_public_promise { state = state_of_result result }
 
-let of_result result =
-  to_public_promise { state = state_of_result result }
+  let fail exn =
+    to_public_promise { state = Failed exn }
 
-let fail exn =
-  to_public_promise { state = Failed exn }
+  let fail_with msg =
+    to_public_promise { state = Failed (Failure msg) }
 
-let fail_with msg =
-  to_public_promise { state = Failed (Failure msg) }
-
-let fail_invalid_arg msg =
-  to_public_promise { state = Failed (Invalid_argument msg) }
-
+  let fail_invalid_arg msg =
+    to_public_promise { state = Failed (Invalid_argument msg) }
 end
 include Trivial_promises
 
@@ -547,9 +537,9 @@ let wait_aux () = {
                   cancel_callbacks = Cancel_callback_list_empty }
 }
 
-let wait () =
-  let t = wait_aux () in
-  (to_public_promise t, to_public_resolver t)
+  let wait () =
+    let t = wait_aux () in
+    (to_public_promise t, to_public_resolver t)
 
 let task_aux () = {
   state = Pending { how_to_cancel = Cancel_this_promise;
@@ -558,47 +548,46 @@ let task_aux () = {
                   cancel_callbacks = Cancel_callback_list_empty }
 }
 
-let task () =
-  let t = task_aux () in
-  (to_public_promise t, to_public_resolver t)
+  let task () =
+    let t = task_aux () in
+    (to_public_promise t, to_public_resolver t)
 
-let add_task_r sequence =
-  let sleeper = {
-    how_to_cancel = Cancel_this_promise;
-    regular_callbacks = Regular_callback_list_empty;
-    cleanups_deferred = 0;
-    cancel_callbacks = Cancel_callback_list_empty
-  } in
-  let t = { state = Pending sleeper } in
-  let node = Lwt_sequence.add_r (to_public_resolver t) sequence in
-  sleeper.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
-  to_public_promise t
+  let add_task_r sequence =
+    let sleeper = {
+      how_to_cancel = Cancel_this_promise;
+      regular_callbacks = Regular_callback_list_empty;
+      cleanups_deferred = 0;
+      cancel_callbacks = Cancel_callback_list_empty
+    } in
+    let t = { state = Pending sleeper } in
+    let node = Lwt_sequence.add_r (to_public_resolver t) sequence in
+    sleeper.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
+    to_public_promise t
 
-let add_task_l sequence =
-  let sleeper = {
-    how_to_cancel = Cancel_this_promise;
-    regular_callbacks = Regular_callback_list_empty;
-    cleanups_deferred = 0;
-    cancel_callbacks = Cancel_callback_list_empty
-  }in
-  let t = { state = Pending sleeper } in
-  let node = Lwt_sequence.add_l (to_public_resolver t) sequence in
-  sleeper.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
-  to_public_promise t
+  let add_task_l sequence =
+    let sleeper = {
+      how_to_cancel = Cancel_this_promise;
+      regular_callbacks = Regular_callback_list_empty;
+      cleanups_deferred = 0;
+      cancel_callbacks = Cancel_callback_list_empty
+    }in
+    let t = { state = Pending sleeper } in
+    let node = Lwt_sequence.add_l (to_public_resolver t) sequence in
+    sleeper.cancel_callbacks <- Cancel_callback_list_remove_sequence_node node;
+    to_public_promise t
 
-let waiter_of_wakener r = to_public_promise (to_internal_resolver r)
+  let waiter_of_wakener r = to_public_promise (to_internal_resolver r)
 
-let no_cancel p =
-  match (repr p).state with
-    | Pending sleeper ->
-        let res = to_public_promise (wait_aux ()) in
-        add_implicitly_removed_callback sleeper (complete res);
-        res
-    | Resolved _ | Failed _ ->
-        p
-    | Unified_with _ ->
-        assert false
-
+  let no_cancel p =
+    match (repr p).state with
+      | Pending sleeper ->
+          let res = to_public_promise (wait_aux ()) in
+          add_implicitly_removed_callback sleeper (complete res);
+          res
+      | Resolved _ | Failed _ ->
+          p
+      | Unified_with _ ->
+          assert false
 end
 include Pending_promises
 
@@ -606,276 +595,275 @@ include Pending_promises
 
 module Sequential_composition =
 struct
+  let unify t1 t2 =
+    let t1 = repr t1 and t2 = repr t2 in
+    match t1.state with
+      | Pending sleeper1 ->
+          if t1 == t2 then
+            ()
+          else begin
+            match t2.state with
+              | Pending sleeper2 ->
+                  t2.state <- Unified_with t1;
 
-let unify t1 t2 =
-  let t1 = repr t1 and t2 = repr t2 in
-  match t1.state with
-    | Pending sleeper1 ->
-        if t1 == t2 then
-          ()
-        else begin
-          match t2.state with
-            | Pending sleeper2 ->
-                t2.state <- Unified_with t1;
+                  sleeper1.how_to_cancel <- sleeper2.how_to_cancel;
 
-                sleeper1.how_to_cancel <- sleeper2.how_to_cancel;
+                  let waiters =
+                    concat_regular_callbacks sleeper1.regular_callbacks sleeper2.regular_callbacks
+                  and removed =
+                    sleeper1.cleanups_deferred + sleeper2.cleanups_deferred in
+                  if removed > cleanup_throttle then begin
+                    sleeper1.cleanups_deferred <- 0;
+                    sleeper1.regular_callbacks <- clean_up_callback_cells waiters
+                  end else begin
+                    sleeper1.cleanups_deferred <- removed;
+                    sleeper1.regular_callbacks <- waiters
+                  end;
+                  sleeper1.cancel_callbacks <-
+                    concat_cancel_callbacks sleeper1.cancel_callbacks sleeper2.cancel_callbacks
+              | Resolved _ | Failed _ | Unified_with _ as state2 ->
+                  t1.state <- state2;
+                  run_callbacks sleeper1 state2
+          end
+      | Resolved _ | Failed _ | Unified_with _ ->
+           assert false
 
-                let waiters =
-                  concat_regular_callbacks sleeper1.regular_callbacks sleeper2.regular_callbacks
-                and removed =
-                  sleeper1.cleanups_deferred + sleeper2.cleanups_deferred in
-                if removed > cleanup_throttle then begin
-                  sleeper1.cleanups_deferred <- 0;
-                  sleeper1.regular_callbacks <- clean_up_callback_cells waiters
-                end else begin
-                  sleeper1.cleanups_deferred <- removed;
-                  sleeper1.regular_callbacks <- waiters
-                end;
-                sleeper1.cancel_callbacks <-
-                  concat_cancel_callbacks sleeper1.cancel_callbacks sleeper2.cancel_callbacks
-            | Resolved _ | Failed _ | Unified_with _ as state2 ->
-                t1.state <- state2;
-                run_callbacks sleeper1 state2
-        end
-    | Resolved _ | Failed _ | Unified_with _ ->
-         assert false
+  let bind p f =
+    let t = repr p in
+    match t.state with
+      | Resolved v ->
+          f v
+      | Failed _ as state ->
+          to_public_promise { state }
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v ->
+                current_storage := data; unify res (try f v with exn -> fail exn)
+               | Failed _ as state -> complete res state
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
-let bind p f =
-  let t = repr p in
-  match t.state with
-    | Resolved v ->
-        f v
-    | Failed _ as state ->
-        to_public_promise { state }
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v ->
-              current_storage := data; unify res (try f v with exn -> fail exn)
-             | Failed _ as state -> complete res state
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
-
-let backtrace_bind add_loc p f =
-  let t = repr p in
-  match t.state with
-    | Resolved v ->
-        f v
-    | Failed exn ->
-        to_public_promise { state = Failed(add_loc exn) }
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v ->
-               current_storage := data; unify res (try f v with exn -> fail (add_loc exn))
-             | Failed exn -> complete res (Failed(add_loc exn))
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let backtrace_bind add_loc p f =
+    let t = repr p in
+    match t.state with
+      | Resolved v ->
+          f v
+      | Failed exn ->
+          to_public_promise { state = Failed(add_loc exn) }
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v ->
+                 current_storage := data; unify res (try f v with exn -> fail (add_loc exn))
+               | Failed exn -> complete res (Failed(add_loc exn))
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
 let (>>=) t f = bind t f
 let (=<<) f t = bind t f
 
-let map f p =
-  let t = repr p in
-  match t.state with
-    | Resolved v ->
-        to_public_promise { state = try Resolved (f v) with exn -> Failed exn }
-    | Failed _ as state ->
-        to_public_promise { state }
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v ->
-               current_storage := data;
-               complete res (try Resolved (f v) with exn -> Failed exn)
-             | Failed _ as state -> complete res state
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let map f p =
+    let t = repr p in
+    match t.state with
+      | Resolved v ->
+          to_public_promise { state = try Resolved (f v) with exn -> Failed exn }
+      | Failed _ as state ->
+          to_public_promise { state }
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v ->
+                 current_storage := data;
+                 complete res (try Resolved (f v) with exn -> Failed exn)
+               | Failed _ as state -> complete res state
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
 let (>|=) t f = map f t
 let (=|<) f t = map f t
 
-let catch f h =
-  let t = repr (try f () with exn -> fail exn) in
-  match t.state with
-    | Resolved _ ->
-        to_public_promise t
-    | Failed exn ->
-        h exn
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _ as state -> complete res state
-             | Failed exn ->
-               current_storage := data; unify res (try h exn with exn -> fail exn)
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let catch f h =
+    let t = repr (try f () with exn -> fail exn) in
+    match t.state with
+      | Resolved _ ->
+          to_public_promise t
+      | Failed exn ->
+          h exn
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _ as state -> complete res state
+               | Failed exn ->
+                 current_storage := data; unify res (try h exn with exn -> fail exn)
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
-let backtrace_catch add_loc f h =
-  let t = repr (try f () with exn -> fail exn) in
-  match t.state with
-    | Resolved _ ->
-        to_public_promise t
-    | Failed exn ->
-        h (add_loc exn)
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _ as state -> complete res state
-             | Failed exn ->
-               current_storage := data; unify res (try h exn with exn -> fail (add_loc exn))
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let backtrace_catch add_loc f h =
+    let t = repr (try f () with exn -> fail exn) in
+    match t.state with
+      | Resolved _ ->
+          to_public_promise t
+      | Failed exn ->
+          h (add_loc exn)
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _ as state -> complete res state
+               | Failed exn ->
+                 current_storage := data; unify res (try h exn with exn -> fail (add_loc exn))
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
-let try_bind f f' h =
-  let t = repr (try f () with exn -> fail exn) in
-  match t.state with
-    | Resolved v ->
-        f' v
-    | Failed exn ->
-        h exn
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v -> current_storage := data; unify res (try f' v with exn -> fail exn)
-             | Failed exn -> current_storage := data; unify res (try h exn with exn -> fail exn)
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let try_bind f f' h =
+    let t = repr (try f () with exn -> fail exn) in
+    match t.state with
+      | Resolved v ->
+          f' v
+      | Failed exn ->
+          h exn
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v -> current_storage := data; unify res (try f' v with exn -> fail exn)
+               | Failed exn -> current_storage := data; unify res (try h exn with exn -> fail exn)
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
-let backtrace_try_bind add_loc f f' h =
-  let t = repr (try f () with exn -> fail exn) in
-  match t.state with
-    | Resolved v ->
-        f' v
-    | Failed exn ->
-        h (add_loc exn)
-    | Pending sleeper ->
-        let res = temp t in
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v ->
-               current_storage := data; unify res (try f' v with exn -> fail (add_loc exn))
-             | Failed exn ->
-               current_storage := data; unify res (try h exn with exn -> fail (add_loc exn))
-             | Pending _ | Unified_with _ -> assert false);
-        res
-    | Unified_with _ ->
-        assert false
+  let backtrace_try_bind add_loc f f' h =
+    let t = repr (try f () with exn -> fail exn) in
+    match t.state with
+      | Resolved v ->
+          f' v
+      | Failed exn ->
+          h (add_loc exn)
+      | Pending sleeper ->
+          let res = temp t in
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v ->
+                 current_storage := data; unify res (try f' v with exn -> fail (add_loc exn))
+               | Failed exn ->
+                 current_storage := data; unify res (try h exn with exn -> fail (add_loc exn))
+               | Pending _ | Unified_with _ -> assert false);
+          res
+      | Unified_with _ ->
+          assert false
 
-let finalize f f' =
-  try_bind f
-    (fun x -> f' () >>= fun () -> return x)
-    (fun e -> f' () >>= fun () -> fail e)
+  let finalize f f' =
+    try_bind f
+      (fun x -> f' () >>= fun () -> return x)
+      (fun e -> f' () >>= fun () -> fail e)
 
-let backtrace_finalize add_loc f f' =
-  backtrace_try_bind add_loc f
-    (fun x -> f' () >>= fun () -> return x)
-    (fun e -> f' () >>= fun () -> fail (add_loc e))
+  let backtrace_finalize add_loc f f' =
+    backtrace_try_bind add_loc f
+      (fun x -> f' () >>= fun () -> return x)
+      (fun e -> f' () >>= fun () -> fail (add_loc e))
 
-let on_cancel p f =
-  match (repr p).state with
-    | Pending sleeper ->
-        let handler = Cancel_callback_list_callback (!current_storage, f) in
-        sleeper.cancel_callbacks <- (
-          match sleeper.cancel_callbacks with
-            | Cancel_callback_list_empty -> handler
-            | Cancel_callback_list_callback _
-            | Cancel_callback_list_remove_sequence_node _
-            | Cancel_callback_list_concat _ as chs ->
-              Cancel_callback_list_concat (handler, chs)
-        )
-    | Failed Canceled ->
-        handle_with_async_exception_hook f ()
-    | Resolved _ | Failed _ | Unified_with _ ->
-        ()
+  let on_cancel p f =
+    match (repr p).state with
+      | Pending sleeper ->
+          let handler = Cancel_callback_list_callback (!current_storage, f) in
+          sleeper.cancel_callbacks <- (
+            match sleeper.cancel_callbacks with
+              | Cancel_callback_list_empty -> handler
+              | Cancel_callback_list_callback _
+              | Cancel_callback_list_remove_sequence_node _
+              | Cancel_callback_list_concat _ as chs ->
+                Cancel_callback_list_concat (handler, chs)
+          )
+      | Failed Canceled ->
+          handle_with_async_exception_hook f ()
+      | Resolved _ | Failed _ | Unified_with _ ->
+          ()
 
-let on_success p f =
-  match (repr p).state with
-    | Resolved v ->
-        handle_with_async_exception_hook f v
-    | Failed _ ->
-        ()
-    | Pending sleeper ->
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v -> current_storage := data; handle_with_async_exception_hook f v
-             | Failed _ -> ()
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
+  let on_success p f =
+    match (repr p).state with
+      | Resolved v ->
+          handle_with_async_exception_hook f v
+      | Failed _ ->
+          ()
+      | Pending sleeper ->
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v -> current_storage := data; handle_with_async_exception_hook f v
+               | Failed _ -> ()
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 
-let on_failure p f =
-  match (repr p).state with
-    | Resolved _ ->
-        ()
-    | Failed exn ->
-        handle_with_async_exception_hook f exn
-    | Pending sleeper ->
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _ -> ()
-             | Failed exn -> current_storage := data; handle_with_async_exception_hook f exn
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
+  let on_failure p f =
+    match (repr p).state with
+      | Resolved _ ->
+          ()
+      | Failed exn ->
+          handle_with_async_exception_hook f exn
+      | Pending sleeper ->
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _ -> ()
+               | Failed exn -> current_storage := data; handle_with_async_exception_hook f exn
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 
-let on_termination p f =
-  match (repr p).state with
-    | Resolved _
-    | Failed _ ->
-        handle_with_async_exception_hook f ()
-    | Pending sleeper ->
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _
-             | Failed _ -> current_storage := data; handle_with_async_exception_hook f ()
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
+  let on_termination p f =
+    match (repr p).state with
+      | Resolved _
+      | Failed _ ->
+          handle_with_async_exception_hook f ()
+      | Pending sleeper ->
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _
+               | Failed _ -> current_storage := data; handle_with_async_exception_hook f ()
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 
-let on_any p f g =
-  match (repr p).state with
-    | Resolved v ->
-        handle_with_async_exception_hook f v
-    | Failed exn ->
-        handle_with_async_exception_hook g exn
-    | Pending sleeper ->
-        let data = !current_storage in
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved v -> current_storage := data; handle_with_async_exception_hook f v
-             | Failed exn -> current_storage := data; handle_with_async_exception_hook g exn
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
+  let on_any p f g =
+    match (repr p).state with
+      | Resolved v ->
+          handle_with_async_exception_hook f v
+      | Failed exn ->
+          handle_with_async_exception_hook g exn
+      | Pending sleeper ->
+          let data = !current_storage in
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved v -> current_storage := data; handle_with_async_exception_hook f v
+               | Failed exn -> current_storage := data; handle_with_async_exception_hook g exn
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 end
 include Sequential_composition
 
@@ -883,167 +871,166 @@ include Sequential_composition
 
 module Concurrent_composition =
 struct
+  let async f =
+    let t = repr (try f () with exn -> fail exn) in
+    match t.state with
+      | Resolved _ ->
+          ()
+      | Failed exn ->
+          !async_exception_hook exn
+      | Pending sleeper ->
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _ -> ()
+               | Failed exn -> !async_exception_hook exn
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 
-let async f =
-  let t = repr (try f () with exn -> fail exn) in
-  match t.state with
-    | Resolved _ ->
-        ()
-    | Failed exn ->
-        !async_exception_hook exn
-    | Pending sleeper ->
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _ -> ()
-             | Failed exn -> !async_exception_hook exn
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
+  let ignore_result p =
+    match (repr p).state with
+      | Resolved _ ->
+          ()
+      | Failed e ->
+          raise e
+      | Pending sleeper ->
+          add_implicitly_removed_callback sleeper
+            (function
+               | Resolved _ -> ()
+               | Failed exn -> !async_exception_hook exn
+               | Pending _ | Unified_with _ -> assert false)
+      | Unified_with _ ->
+          assert false
 
-let ignore_result p =
-  match (repr p).state with
-    | Resolved _ ->
-        ()
-    | Failed e ->
-        raise e
-    | Pending sleeper ->
-        add_implicitly_removed_callback sleeper
-          (function
-             | Resolved _ -> ()
-             | Failed exn -> !async_exception_hook exn
-             | Pending _ | Unified_with _ -> assert false)
-    | Unified_with _ ->
-        assert false
-
-let join ps =
-  let res = temp_many ps
-  and sleeping = ref 0
-  and return_state = ref state_return_unit in
-  let handle_result state =
-    begin
-      match !return_state, state with
-        | Resolved _, Failed _ -> return_state := state
-        | _ -> ()
-    end [@ocaml.warning "-4"];
-    decr sleeping;
-    if !sleeping = 0 then complete res !return_state
-  in
-  let rec init = function
-    | [] ->
-        if !sleeping = 0 then
-          to_public_promise { state = !return_state }
-        else
-          res
-    | t :: rest ->
-        match (repr t).state with
-          | Pending sleeper ->
-              incr sleeping;
-              add_implicitly_removed_callback sleeper handle_result;
-              init rest
-          | Failed _ as state -> begin
-              match !return_state with
-                | Resolved _ ->
-                    return_state := state;
-                    init rest
-                | Failed _ | Pending _ | Unified_with _ ->
-                    init rest
-            end
-          | Resolved _ | Unified_with _ ->
-              init rest
-  in
-  init ps
-
-let count_completed_promises_in ps =
-  List.fold_left (fun acc x ->
-    match (repr x).state with
-    | Pending _ -> acc
-    | Resolved _ | Failed _ | Unified_with _ -> acc + 1) 0 ps
-
-let rec nth_completed ps n =
-  match ps with
-    | [] ->
-        assert false
-    | t :: l ->
-        match (repr t).state with
-          | Pending _ ->
-              nth_completed l n
-          | Resolved _ | Failed _ | Unified_with _ ->
-              if n > 0 then
-                nth_completed l (n - 1)
-              else
-                t
-
-let rec nth_completed_and_cancel_pending ps n =
-  match ps with
-    | [] ->
-        assert false
-    | t :: l ->
-        match (repr t).state with
-          | Pending _ ->
-              cancel t;
-              nth_completed_and_cancel_pending l n
-          | Resolved _ | Failed _ | Unified_with _ ->
-              if n > 0 then
-                nth_completed_and_cancel_pending l (n - 1)
-              else begin
-                List.iter cancel l;
-                t
+  let join ps =
+    let res = temp_many ps
+    and sleeping = ref 0
+    and return_state = ref state_return_unit in
+    let handle_result state =
+      begin
+        match !return_state, state with
+          | Resolved _, Failed _ -> return_state := state
+          | _ -> ()
+      end [@ocaml.warning "-4"];
+      decr sleeping;
+      if !sleeping = 0 then complete res !return_state
+    in
+    let rec init = function
+      | [] ->
+          if !sleeping = 0 then
+            to_public_promise { state = !return_state }
+          else
+            res
+      | t :: rest ->
+          match (repr t).state with
+            | Pending sleeper ->
+                incr sleeping;
+                add_implicitly_removed_callback sleeper handle_result;
+                init rest
+            | Failed _ as state -> begin
+                match !return_state with
+                  | Resolved _ ->
+                      return_state := state;
+                      init rest
+                  | Failed _ | Pending _ | Unified_with _ ->
+                      init rest
               end
-
-(* The PRNG state is initialized with a constant to make non-IO-based
-   programs deterministic. *)
-let prng = lazy (Random.State.make [||])
-
-let choose ps =
-  let ready = count_completed_promises_in ps in
-  if ready > 0 then
-    if ready = 1 then
-      nth_completed ps 0
-    else
-      nth_completed ps (Random.State.int (Lazy.force prng) ready)
-  else begin
-    let res = temp_many ps in
-    let rec waiter = ref (Some handle_result)
-    and handle_result state =
-      waiter := None;
-      remove_waiters ps;
-      complete res state
+            | Resolved _ | Unified_with _ ->
+                init rest
     in
-    add_explicitly_removable_callback_to_each_of ps waiter;
-    res
-  end
+    init ps
 
-let pick ps =
-  let ready = count_completed_promises_in ps in
-  if ready > 0 then
-    if ready = 1 then
-      nth_completed_and_cancel_pending ps 0
-    else
-      nth_completed_and_cancel_pending ps (Random.State.int (Lazy.force prng) ready)
-  else begin
-    let res = temp_many ps in
-    let rec waiter = ref (Some handle_result)
-    and handle_result state =
-      waiter := None;
-      remove_waiters ps;
-      List.iter cancel ps;
-      complete res state
-    in
-    add_explicitly_removable_callback_to_each_of ps waiter;
-    res
-  end
+  let count_completed_promises_in ps =
+    List.fold_left (fun acc x ->
+      match (repr x).state with
+      | Pending _ -> acc
+      | Resolved _ | Failed _ | Unified_with _ -> acc + 1) 0 ps
 
-let rec finish_nchoose_or_npick_after_pending to_complete results = function
-  | [] ->
-      complete to_complete (Resolved (List.rev results))
-  | t :: l ->
-      match (repr t).state with
-        | Resolved x ->
-            finish_nchoose_or_npick_after_pending to_complete (x :: results) l
-        | Failed _ as state ->
-            complete to_complete state
-        | Pending _ | Unified_with _ ->
-            finish_nchoose_or_npick_after_pending to_complete results l
+  let rec nth_completed ps n =
+    match ps with
+      | [] ->
+          assert false
+      | t :: l ->
+          match (repr t).state with
+            | Pending _ ->
+                nth_completed l n
+            | Resolved _ | Failed _ | Unified_with _ ->
+                if n > 0 then
+                  nth_completed l (n - 1)
+                else
+                  t
+
+  let rec nth_completed_and_cancel_pending ps n =
+    match ps with
+      | [] ->
+          assert false
+      | t :: l ->
+          match (repr t).state with
+            | Pending _ ->
+                cancel t;
+                nth_completed_and_cancel_pending l n
+            | Resolved _ | Failed _ | Unified_with _ ->
+                if n > 0 then
+                  nth_completed_and_cancel_pending l (n - 1)
+                else begin
+                  List.iter cancel l;
+                  t
+                end
+
+  (* The PRNG state is initialized with a constant to make non-IO-based
+     programs deterministic. *)
+  let prng = lazy (Random.State.make [||])
+
+  let choose ps =
+    let ready = count_completed_promises_in ps in
+    if ready > 0 then
+      if ready = 1 then
+        nth_completed ps 0
+      else
+        nth_completed ps (Random.State.int (Lazy.force prng) ready)
+    else begin
+      let res = temp_many ps in
+      let rec waiter = ref (Some handle_result)
+      and handle_result state =
+        waiter := None;
+        remove_waiters ps;
+        complete res state
+      in
+      add_explicitly_removable_callback_to_each_of ps waiter;
+      res
+    end
+
+  let pick ps =
+    let ready = count_completed_promises_in ps in
+    if ready > 0 then
+      if ready = 1 then
+        nth_completed_and_cancel_pending ps 0
+      else
+        nth_completed_and_cancel_pending ps (Random.State.int (Lazy.force prng) ready)
+    else begin
+      let res = temp_many ps in
+      let rec waiter = ref (Some handle_result)
+      and handle_result state =
+        waiter := None;
+        remove_waiters ps;
+        List.iter cancel ps;
+        complete res state
+      in
+      add_explicitly_removable_callback_to_each_of ps waiter;
+      res
+    end
+
+  let rec finish_nchoose_or_npick_after_pending to_complete results = function
+    | [] ->
+        complete to_complete (Resolved (List.rev results))
+    | t :: l ->
+        match (repr t).state with
+          | Resolved x ->
+              finish_nchoose_or_npick_after_pending to_complete (x :: results) l
+          | Failed _ as state ->
+              complete to_complete state
+          | Pending _ | Unified_with _ ->
+              finish_nchoose_or_npick_after_pending to_complete results l
 
 let nchoose_sleep ps =
   let res = temp_many ps in
@@ -1056,31 +1043,31 @@ let nchoose_sleep ps =
   add_explicitly_removable_callback_to_each_of ps waiter;
   res
 
-let nchoose ps =
-  let rec init = function
-    | [] ->
-        nchoose_sleep ps
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect [x] l
-          | Failed _ as state ->
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              init l
-  and collect acc = function
-    | [] ->
-        return (List.rev acc)
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect (x :: acc) l
-          | Failed _ as state ->
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              collect acc l
-  in
-  init ps
+  let nchoose ps =
+    let rec init = function
+      | [] ->
+          nchoose_sleep ps
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect [x] l
+            | Failed _ as state ->
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                init l
+    and collect acc = function
+      | [] ->
+          return (List.rev acc)
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect (x :: acc) l
+            | Failed _ as state ->
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                collect acc l
+    in
+    init ps
 
 let npick_sleep ps =
   let res = temp_many ps in
@@ -1094,34 +1081,34 @@ let npick_sleep ps =
   add_explicitly_removable_callback_to_each_of ps waiter;
   res
 
-let npick ps =
-  let rec init = function
-    | [] ->
-        npick_sleep ps
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect [x] l
-          | Failed _ as state ->
-              List.iter cancel ps;
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              init l
-  and collect acc = function
-    | [] ->
-        List.iter cancel ps;
-        return (List.rev acc)
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect (x :: acc) l
-          | Failed _ as state ->
-              List.iter cancel ps;
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              collect acc l
-  in
-  init ps
+  let npick ps =
+    let rec init = function
+      | [] ->
+          npick_sleep ps
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect [x] l
+            | Failed _ as state ->
+                List.iter cancel ps;
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                init l
+    and collect acc = function
+      | [] ->
+          List.iter cancel ps;
+          return (List.rev acc)
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect (x :: acc) l
+            | Failed _ as state ->
+                List.iter cancel ps;
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                collect acc l
+    in
+    init ps
 
 let rec nchoose_split_terminate res acc_terminated acc_sleeping = function
   | [] ->
@@ -1146,31 +1133,31 @@ let nchoose_split_sleep l =
   add_explicitly_removable_callback_to_each_of l waiter;
   res
 
-let nchoose_split ps =
-  let rec init acc_sleeping = function
-    | [] ->
-        nchoose_split_sleep ps
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect [x] acc_sleeping l
-          | Failed _ as state ->
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              init (t :: acc_sleeping) l
-  and collect acc_terminated acc_sleeping = function
-    | [] ->
-        return (List.rev acc_terminated, acc_sleeping)
-    | t :: l ->
-        match (repr t).state with
-          | Resolved x ->
-              collect (x :: acc_terminated) acc_sleeping l
-          | Failed _ as state ->
-              to_public_promise { state }
-          | Pending _ | Unified_with _ ->
-              collect acc_terminated (t :: acc_sleeping) l
-  in
-  init [] ps
+  let nchoose_split ps =
+    let rec init acc_sleeping = function
+      | [] ->
+          nchoose_split_sleep ps
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect [x] acc_sleeping l
+            | Failed _ as state ->
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                init (t :: acc_sleeping) l
+    and collect acc_terminated acc_sleeping = function
+      | [] ->
+          return (List.rev acc_terminated, acc_sleeping)
+      | t :: l ->
+          match (repr t).state with
+            | Resolved x ->
+                collect (x :: acc_terminated) acc_sleeping l
+            | Failed _ as state ->
+                to_public_promise { state }
+            | Pending _ | Unified_with _ ->
+                collect acc_terminated (t :: acc_sleeping) l
+    in
+    init [] ps
 
 let protected p =
   match (repr p).state with
@@ -1207,13 +1194,13 @@ module State = struct
     | Sleep
 end
 
-let state t = match (repr t).state with
-  | Resolved v -> State.Return v
-  | Failed exn -> State.Fail exn
-  | Pending _ -> State.Sleep
-  | Unified_with _ -> assert false
+  let state t = match (repr t).state with
+    | Resolved v -> State.Return v
+    | Failed exn -> State.Fail exn
+    | Pending _ -> State.Sleep
+    | Unified_with _ -> assert false
 
-include State
+  include State
 
 let rec is_sleeping_rec t =
   match t.state with
@@ -1224,54 +1211,53 @@ let rec is_sleeping_rec t =
     | Unified_with t ->
         is_sleeping_rec t
 
-let is_sleeping p = is_sleeping_rec (to_internal_promise p)
+  let is_sleeping p = is_sleeping_rec (to_internal_promise p)
 
-let poll p =
-  match (repr p).state with
-    | Failed e -> raise e
-    | Resolved v -> Some v
-    | Pending _ -> None
-    | Unified_with _ -> assert false
+  let poll p =
+    match (repr p).state with
+      | Failed e -> raise e
+      | Resolved v -> Some v
+      | Pending _ -> None
+      | Unified_with _ -> assert false
 
-let apply f x = try f x with e -> fail e
+  let apply f x = try f x with e -> fail e
 
-let wrap f = try return (f ()) with exn -> fail exn
+  let wrap f = try return (f ()) with exn -> fail exn
 
-let wrap1 f x1 = try return (f x1) with exn -> fail exn
-let wrap2 f x1 x2 = try return (f x1 x2) with exn -> fail exn
-let wrap3 f x1 x2 x3 = try return (f x1 x2 x3) with exn -> fail exn
-let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
-let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
-let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
-let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
+  let wrap1 f x1 = try return (f x1) with exn -> fail exn
+  let wrap2 f x1 x2 = try return (f x1 x2) with exn -> fail exn
+  let wrap3 f x1 x2 x3 = try return (f x1 x2 x3) with exn -> fail exn
+  let wrap4 f x1 x2 x3 x4 = try return (f x1 x2 x3 x4) with exn -> fail exn
+  let wrap5 f x1 x2 x3 x4 x5 = try return (f x1 x2 x3 x4 x5) with exn -> fail exn
+  let wrap6 f x1 x2 x3 x4 x5 x6 = try return (f x1 x2 x3 x4 x5 x6) with exn -> fail exn
+  let wrap7 f x1 x2 x3 x4 x5 x6 x7 = try return (f x1 x2 x3 x4 x5 x6 x7) with exn -> fail exn
 
 
 
-let pause_hook = ref ignore
+  let pause_hook = ref ignore
 
-let paused = Lwt_sequence.create ()
-let paused_count = ref 0
+  let paused = Lwt_sequence.create ()
+  let paused_count = ref 0
 
-let pause () =
-  let waiter = add_task_r paused in
-  incr paused_count;
-  !pause_hook !paused_count;
-  waiter
+  let pause () =
+    let waiter = add_task_r paused in
+    incr paused_count;
+    !pause_hook !paused_count;
+    waiter
 
-let wakeup_paused () =
-  if Lwt_sequence.is_empty paused then
-    paused_count := 0
-  else begin
-    let tmp = Lwt_sequence.create () in
-    Lwt_sequence.transfer_r paused tmp;
-    paused_count := 0;
-    Lwt_sequence.iter_l (fun wakener -> wakeup wakener ()) tmp
-  end
+  let wakeup_paused () =
+    if Lwt_sequence.is_empty paused then
+      paused_count := 0
+    else begin
+      let tmp = Lwt_sequence.create () in
+      Lwt_sequence.transfer_r paused tmp;
+      paused_count := 0;
+      Lwt_sequence.iter_l (fun wakener -> wakeup wakener ()) tmp
+    end
 
-let register_pause_notifier f = pause_hook := f
+  let register_pause_notifier f = pause_hook := f
 
-let paused_count () = !paused_count
-
+  let paused_count () = !paused_count
 end
 include Miscellaneous
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -160,11 +160,11 @@
    2. Resolvers
 
    Resolvers are given to the user by [Lwt.wait] and [Lwt.task], and can be used
-   by the user to resolve the corresponding promises. Note that this means the
+   by the user to complete the corresponding promises. Note that this means the
    user only ever gets resolvers for initial promises.
 
    Internally, resolvers are the exact same objects as the promises they
-   resolve, even though the resolver is exposed as a reference of a different
+   complete, even though the resolver is exposed as a reference of a different
    type by [lwt.mli].
 
 
@@ -669,7 +669,7 @@ struct
      pending promise [p] and return it to the user.
 
      They do not return a corresponding resolver. That means that only the
-     function itself (typically, a callback registered by it) can resolve [p].
+     function itself (typically, a callback registered by it) can complete [p].
      The only thing the user can do directly is try to cancel [p], but, since
      [p] is not an initial promise, the cancelation attempt simply propagates
      past [p] to [p]'s predecessors. If that eventually results in canceling
@@ -1646,17 +1646,17 @@ struct
 
      The reasons proxying is used, instead of adding a callback to
      [~user_provided_promise] to complete [~outer_promise] when the former
-     becomes resolved probably are:
+     becomes completed probably are:
 
      - Promises have more behaviors than completion. One would have to add a
        cancelation handler to [~outer_promise] to propagate the cancelation back
        to [~user_provided_promise], for example. It may be easier to just think
        of them as the same promise.
-     - If using callbacks, resolving [~user_provided_promise] would not
-       immediately resolve [~outer_promise]. Another callback added to
-       [~user_provided_promise] might see [~user_provided_promise] resolved, but
-       [~outer_promise] still pending, depending on the order in which callbacks
-       are run. *)
+     - If using callbacks, completing [~user_provided_promise] would not
+       immediately complete [~outer_promise]. Another callback added to
+       [~user_provided_promise] might see [~user_provided_promise] completed,
+       but [~outer_promise] still pending, depending on the order in which
+       callbacks are run. *)
   let make_into_proxy
       (type c)
       in_completion_loop
@@ -2425,10 +2425,10 @@ struct
           collect_already_resolved_promises_or_fail acc ps
     in
 
-    (* Looks for already-resolved promises in [ps]. If none are resolved or
+    (* Looks for already-completed promises in [ps]. If none are resolved or
        failed, adds a callback to all promises in [ps] (all of which are
        pending). *)
-    let rec check_for_already_resolved_promises ps' =
+    let rec check_for_already_completed_promises ps' =
       match ps' with
       | [] ->
         let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
@@ -2454,10 +2454,10 @@ struct
           to_public_promise {state = result}
 
         | Pending _ ->
-          check_for_already_resolved_promises ps
+          check_for_already_completed_promises ps
     in
 
-    let p = check_for_already_resolved_promises ps in
+    let p = check_for_already_completed_promises ps in
     p
 
   (* See [nchoose]. This function differs only in having additional calls to
@@ -2483,7 +2483,7 @@ struct
           collect_already_resolved_promises_or_fail acc ps'
     in
 
-    let rec check_for_already_resolved_promises ps' =
+    let rec check_for_already_completed_promises ps' =
       match ps' with
       | [] ->
         let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
@@ -2511,10 +2511,10 @@ struct
           to_public_promise {state = result}
 
         | Pending _ ->
-          check_for_already_resolved_promises ps'
+          check_for_already_completed_promises ps'
     in
 
-    let p = check_for_already_resolved_promises ps in
+    let p = check_for_already_completed_promises ps in
     p
 
 


### PR DESCRIPTION
This PR *heavily* updates `lwt.ml` to make it much more legible and friendly.

What the [new `lwt.ml`][lwt-full] looks like...

- [in the ordinary view][lwt-full], where you can see it in all its glory, read the friendly Reading Guide and Overview, and browse all the code,
- [with internal modules folded (94 lines)][lwt-modules], where you can neatly see the high-level structure of the Lwt core, and
- [with internal signatures expanded (282 lines)][lwt-signatures], where you can see what belongs where.

For comparison, what the previous `lwt.ml` looks like: [[link]][lwt-original].

[lwt-modules]: https://gist.github.com/aantron/9fab0bdead98a60fccf06e0189186863#file-lwt-modules-ml-L20
[lwt-signatures]: https://gist.github.com/aantron/97b58520d5bb4858ccac6f54700a24d7#file-lwt-sigs-ml-L32
[lwt-full]: https://github.com/ocsigen/lwt/blob/fdff5c09d47d2b020d4998ebed922acf383a2e9d/src/core/lwt.ml#L27
[lwt-original]: https://github.com/ocsigen/lwt/blob/8a397d68691a665320fefbdc72061967917fc2b5/src/core/lwt.ml#L29

<br/>

### Why?

This PR is a series of gradual refactorings of `lwt.ml` to make it more legible, such that the final version shares almost no lines in common with the original, though the ASTs are still largely similar. There are two main purposes:

- Make it much easier to contribute to Lwt. I've seen several comments along the lines of "I wanted to contribute, but I couldn't read `lwt.ml`," and *I* couldn't read it well either. Even if someone can't read the new `lwt.ml`, they should feel welcomed and encouraged to ask about it.
- Have enough people actually understand the semantics of `lwt.ml` deeply to be able to do some combination of

    - write the manual (#304),
    - adapt to effects,
    - adapt better to JS, and/or
    - change the semantics in various ways (e.g. #329).

    Ideally, enough people can read `lwt.ml` for the semantics to enter the community's organizational memory. This will hopefully free Lwt from some paralysis and inertia.

    I found that, while reading `lwt.ml`, I needed to refactor it in some places, to be able to continue reading it more and more deeply, instead of getting stuck on superficial difficulties. That eventually led to this whole PR.

<br/>

### Highlights of the new code

The new `lwt.ml` has:

- **Thorough documentation**, including the mentioned Reading Guide and Overview, as well as many implementation detail comments. The Overview discusses all concepts necessary to understand everything in `lwt.ml`.
- **Sectioning** with internal modules. Signatures limit the scope of helpers, and provide type-checked tables of contents. Internal modules can be folded by text editors that support code folding. Functions are reordered by category, compared to the original `lwt.ml`.
- Lots of renaming for clearer, **self-descriptive terminology**, and a switch to the "promise" language.
- General refactoring and cleanup to organize the code.
- GADTs to eliminate a large number of `assert false` cases. The original code had 35 `assert false` expressions, which correspond to a considerably larger number of cases, because many appear under or-patterns. The new code has four `assert false` expressions.
- Explicit annotation and documentation of promise state changes. Encoding (mutable) promise state in a GADT requires casts when state changes, and these casts explicitly document the state changes Lwt believes are possible between when Lwt gives a promise to a user, and when Lwt uses that promises again later.
- No first-class modules. These were used for encoding existential types, and have been replaced by GADTs.

It's undoubtedly possible to improve the code even further, but I'd like to commit this as a starting point for that process.

<br/>

### How to review

This PR is broken up into 57 commits, of which:

- The first 40 are trivial renamings, reorderings, and whitespace changes.
- The next 11, from "be explicit about public/internal casts" to "refactor nchoose, npick, nchoose_split" are non-trivial changes that require true thinking. Of these, "make promise state into a GADT" is the most involved. Many of these have detailed commit messages.
- The remaining 6 are again trivial renamings, reorderings, and whitespace changes.

It's still a lot to deal with, but hopefully this way of breaking up the history makes it somewhat possible to review the PR. It should also give `lwt.ml` fairly sane blame.

Each commit passes the Lwt [test suite](https://github.com/ocsigen/lwt/pull/339). Code coverage is 98%, though the test suite is more thorough than just achieving high coverage.

<br/>

### Pings and notes

I have to thank @dkim for some suggestions on improving the Overview. Thanks!

@talex5 Obviously, this affects tracing. Ultimately, I hope it makes tracing easier to maintain. We should probably also work on getting it maintained in the main Lwt repo at some point (#180).

This code should be bug-for-bug compatible with the previous code. That includes the assertion failures and segfaults we recently saw in #315 and #349. In fact, this code is likely to have worse behavior in such situations, due to having fewer assertion expressions. Preserved bugs also include #340.

Some of the stuff in the overview belongs in `lwt.mli`, and may get moved there when working on the manual.

I would appreciate it if anyone with access to a stress test, or any other non-trivial Lwt code, would give this rewrite a try (@mfp, @copy, @domsj?). The command to pin it should be:

```
opam pin add lwt https://github.com/ocsigen/lwt.git\#wat
```

<br/>

Thanks!