### PR TITLE
Test Lwt_io.with_connection at a lower level

### DIFF
--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -410,6 +410,21 @@ val with_connection :
       connection to the given address and passes the channels to
       [f] *)
 
+(**/**)
+
+(** This function is not public API and can be changed or removed without
+    notice. It is exposed in order to test [with_connection].
+
+    [with_close_connection f (ic, oc)] calls [f (ic, oc)] and makes sure that
+    [ic] and [oc] are closed, whether [f] returns or fails with an exception.
+    Does not fail if [ic] or [oc] is already closed. *)
+val with_close_connection :
+  (input_channel * output_channel -> 'a Lwt.t) ->
+  input_channel * output_channel ->
+  'a Lwt.t
+
+(**/**)
+
 type server
   (** Type of a server *)
 


### PR DESCRIPTION
As reported in #350, `Test_lwt_io` uses a fragile a test helper to close file descriptors in order to trigger errors in "context manager"-like functions. Those are functions that take a function in argument channel parameters: `with_connection` and `establish_server`.

Since the tear-down part of these functions is not exposed, it is hard to test. This exposes the tear-down part of `with_connection` as `with_close_connection` (in the `.mli` file but marked as nonpublic API and hidden in a stop comment). This function is tested and the corresponding fragile test is removed.

Similar tests exist for `establish_server`, but I just only deleted the fragile tests. Shall I extract and test its teardown part as well? It's a bit different since it handles `no_close` and runs `Lwt.async_exception_hook` by hand, but it should be possible to handle it in the same way.

Thanks!