### PR TITLE
unix: put fd non-blocking flag changes inside the lazy blocking value

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -304,16 +304,16 @@ let is_blocking ?blocking ?(set_flags=true) fd =
         | Some state, false ->
             lazy(Lwt.return state)
         | Some true, true ->
-            Unix.clear_nonblock fd;
-            lazy(Lwt.return_true)
+            lazy(Unix.clear_nonblock fd;
+                 Lwt.return_true)
         | Some false, true ->
-            Unix.set_nonblock fd;
-            lazy(Lwt.return_false)
+            lazy(Unix.set_nonblock fd;
+                 Lwt.return_false)
         | None, false ->
             lazy(Lwt.return_false)
         | None, true ->
-            Unix.set_nonblock fd;
-            lazy(Lwt.return_false)
+            lazy(Unix.set_nonblock fd;
+                 Lwt.return_false)
     else
       match blocking with
         | Some state ->
@@ -325,11 +325,11 @@ let is_blocking ?blocking ?(set_flags=true) fd =
       | Some state, false ->
           lazy(Lwt.return state)
       | Some true, true ->
-          Unix.clear_nonblock fd;
-          lazy(Lwt.return_true)
+          lazy(Unix.clear_nonblock fd;
+               Lwt.return_true)
       | Some false, true ->
-          Unix.set_nonblock fd;
-          lazy(Lwt.return_false)
+          lazy(Unix.set_nonblock fd;
+               Lwt.return_false)
       | None, false ->
           lazy(guess_blocking fd)
       | None, true ->


### PR DESCRIPTION
This design makes me mildly nauseous but with this patch it's merely really bad instead of catastrophic. Fixes #356.