### PR TITLE
Make the function cst_to_constr static in lwt_unix_unix.c

### DIFF
--- a/src/unix/lwt_unix_unix.c
+++ b/src/unix/lwt_unix_unix.c
@@ -2836,7 +2836,7 @@ struct job_getaddrinfo {
   char data[];
 };
 
-value cst_to_constr(int n, int *tbl, int size, int deflt)
+static value cst_to_constr(int n, int *tbl, int size, int deflt)
 {
   int i;
   for (i = 0; i < size; i++)


### PR DESCRIPTION
It is already publicly exposed [here](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/unix/cst2constr.h), causing link error in some cases. The latter could probably be used directly now but I didn't check since when it's available.