### PR TITLE
Making Lwt even more welcoming to new contributors (CONTRIBUTING.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,289 @@
+# Contributing to the Lwt code
+
+Contributing to Lwt doesn't only mean writing code. Asking questions, fixing
+docs, etc., are all valuable contributions! For notes on contributing in
+general, see [Contributing][contributing] in the Lwt `README`. This file
+contains extra information for those contributors that want to work on the code
+specifically.
+
+This file is meant to be a friendly aid, not a hindrance. If you think you
+already have a good idea of what to do, you can go ahead and not read any of
+this file! Nobody will hold it against you :)
+
+Those things having been noted, thank you! :tada:
+
+
+<br/>
+
+#### Table of contents
+
+- [General](#General)
+- [OPAM+git workflow](#Workflow)
+  - [Getting the code](#Checkout)
+  - [Testing](#Testing)
+  - [Getting your change merged](#Getting_your_change_merged)
+  - [Making additional changes](#Making_additional_changes)
+  - [Cleaning up](#Cleaning_up)
+- [Internal documentation](#Documentation)
+- [Code overview](#Code_overview)
+
+
+<br/>
+
+<a id="General"></a>
+## General
+
+1. If you get stuck, or have any question, please [ask][contact]!
+
+2. If these contributing docs are bad in any way, [tell][contact] maintainers
+   about it! This file should be made as helpful as possible.
+
+3. If you start working, but then life interferes and you don't want to
+   continue, there is no shame in stopping. This can be for any reason
+   whatsoever, and you on't have to tell anyone what that reason is. Lwt
+   respects your time and your needs. You don't really even have to tell anyone
+   that you stopped working, but it would be nice if you did :)
+
+4. If a maintainer is wasting your patience (hopefully by accident) by making
+   you fix too many nits, do excessive history rewriting, or something else like
+   that, please let them know! It's good to have a clean history and everything,
+   but it's more important to accomodate the human beings that actually work on
+   Lwt.
+
+    This might result in a PR being finished off by a maintainer, in additional
+    commits, or in the maintainer just letting go of their requests. In all
+    cases, this will be done by mutual agreement, and you will be credited for
+    your work.
+
+    Lwt doesn't want to burn you out!
+
+5. To find something to work on, you can look at the [easy issues][easy]. If
+   those don't look interesting, some [medium issues][medium] are
+   self-contained. If you [contact][contact] the maintainers, they may be able
+   to suggest a few. Otherwise, you are welcome to work on anything at all.
+
+6. If you begin working on an issue, it's good to leave a comment on it to claim
+   it. This prevents multiple people from doing the same work.
+
+[contact]: https://github.com/ocsigen/lwt#contact
+[contributing]: https://github.com/ocsigen/lwt#contributing
+[easy]: https://github.com/ocsigen/lwt/labels/easy
+[medium]: https://github.com/ocsigen/lwt/labels/medium
+
+
+<br/>
+
+<a id="Workflow"></a>
+## OPAM+git workflow
+
+<a id="Checkout"></a>
+#### Getting the code
+
+To get started, fork the Lwt repo by clicking on the "Fork" button in GitHub.
+You will now have a repository at `https://github.com/your-user-name/lwt`. Let's
+clone it to your machine:
+
+```
+git clone https://github.com/your-user-name/lwt.git
+cd lwt/
+```
+
+We'll use Lwt's own [`opam`][opam-depends] file to install Lwt's dependencies
+automatically. Before doing that, you may want to switch to a special OPAM
+switch just for Lwt:
+
+```
+opam switch 4.04-lwt --alias-of 4.04.1   # optional
+eval `opam config env`                   # optional
+opam pin add --no-action lwt .
+opam install --deps-only lwt
+```
+
+[opam-depends]: https://github.com/ocsigen/lwt/blob/8bff603ae6d976e69698fa08e8ce08fe9615489d/opam/opam#L35-L44
+
+On most systems, you should also install libev:
+
+```
+your-package-manager install libev-devel
+opam install conf-libev
+```
+
+Now, check out a new branch, and make your changes:
+
+```
+git checkout -b my-awesome-change
+# code!
+```
+
+<a id="Testing"></a>
+#### Testing
+
+To build Lwt and run its unit tests, first do:
+
+```
+ocaml setup.ml -configure --enable-tests
+```
+
+After that, each time you are ready to test, run
+
+```
+make test
+```
+
+If you want to test your development branch using another OPAM package that
+depends on Lwt, install your development copy of Lwt with:
+
+```
+opam install lwt
+```
+
+If you make further changes, you can install your updated code with:
+
+```
+opam upgrade lwt
+```
+
+Since Lwt is pinned, these commands will install Lwt from your modified code.
+All installed OPAM packages that depend on Lwt will be rebuilt against your
+modified code when you run these commands.
+
+<a id="Getting_your_change_merged"></a>
+#### Getting your change merged
+
+When you are ready, commit your change:
+
+```
+git commit
+```
+
+You can see examples of commit messages in the Git log; run `git log`. Now,
+upload your commit(s) to your fork:
+
+```
+git push -u origin my-awesome-change
+```
+
+Go to the GitHub web interface for your Lwt fork
+(`https://github.com/your-user-name/lwt`), and click on the New Pull Request
+button. Follow the instructions, write a nice description, and open the pull
+request.
+
+This will trigger automatic building and testing of your change on many versions
+of OCaml, and several operating systems, in [Travis][travis-ci] and
+[AppVeyor][appveyor-ci]. You can even a submit a preliminary PR just to trigger
+these tests – just say in the description that it's not ready for review!
+
+At about the same time, a (hopefully!) friendly maintainer will review your
+change and start a conversation with you. Ultimately, this will result in a
+merged PR and a "thank you!" :smiley: You'll be immortalized in the history,
+mentioned in the changelog, and you will have helped a bunch of users have an
+easier time with Lwt.
+
+Finally, take a nice break :) This process can be a lot!
+
+<a id="Making_additional_changes"></a>
+#### Making additional changes
+
+If additional changes are needed after you open the PR, make them in your branch
+locally, commit them, and run:
+
+```
+git push
+```
+
+This will push the changes to your fork, and GitHub will automatically update
+the PR.
+
+<a id="Cleaning_up"></a>
+#### Cleaning up
+
+If you don't want a development Lwt installed in your OPAM switch anymore, you
+can do
+
+```
+opam pin remove lwt
+```
+
+However, if you need your change for your purposes, you may want to keep your
+development copy pinned until the next Lwt release.
+
+[travis-ci]: https://travis-ci.org/ocsigen/lwt
+[appveyor-ci]: https://ci.appveyor.com/project/aantron/lwt
+
+
+<br/>
+
+<a id="Documentation"></a>
+## Internal documentation
+
+Lwt internal documentation is currently pretty sparse, but we are working on
+fixing that.
+
+- The bulk of documentation is still the [manual][manual].
+- If you'd like to understand how Lwt works at the core, don't read the current
+  `lwt.ml`. Read [the one from PR #354][new-lwt.ml] instead. This contains a
+  thorough explanation of everything. Reviews of [that PR][pr354] would also be
+  appreciated.
+- Everything else is sparsely documented in comments.
+
+[manual]: https://ocsigen.org/lwt/manual/
+[new-lwt.ml]: https://github.com/ocsigen/lwt/blob/fdff5c09d47d2b020d4998ebed922acf383a2e9d/src/core/lwt.ml#L27
+[pr354]: https://github.com/ocsigen/lwt/pull/354
+
+
+<br/>
+
+<a id="Code_overview"></a>
+## Code overview
+
+Lwt is separated into several layers and sub-libraries, grouped by directory.
+This list surveys them, roughly in order of importance.
+
+- `src/core/` is the "core" library. It is written in pure OCaml, so it is
+  portable across all systems and to JavaScript.
+
+  The major file here is `src/core/lwt.ml`, which implements the main type,
+  `'a Lwt.t`. Also here are some pure-OCaml data structures and synchronization
+  primitives. Most of the modules besides `Lwt` are relatively trivial – the
+  only exception to this is `Lwt_stream`.
+
+  The code in `src/core/` doesn't know how to do I/O – that is system specific.
+  On Unix (including Windows), I/O is provided by the Unix binding (see below).
+  On js_of_ocaml, it is provided by `Lwt_js`, a module distributed with
+  js_of_ocaml.
+
+- `src/ppx/` is the Lwt PPX. It is also portable, but separated into its own
+  little code base, as it is an optional separate library.
+
+- `src/unix/` is the Unix binding, i.e. `Lwt_unix`, `Lwt_io`, `Lwt_main`, some
+  other related modules, and a bunch of C code. This is what actually does I/O,
+  maintains a worker thread pool, etc. Obviously, this is not portable to
+  JavaScript. It supports Unix and Windows. We want to write a future pair of
+  Node.js and Unix/Windows bindings, so that code using them is portable, even
+  if two separate sets of bindings are required.
+
+  Some of the C code in the Unix binding is generated by
+  `src/unix/gen_stubs.ml`.
+
+- `src/preemptive/` provides `Lwt_preemptive` if the threaded runtime is
+  available. This is almost always the case when compiling to native code (i.e.,
+  when the Unix binding is available).
+
+- `src/logger/` provides `Lwt_log`. This library is separated into two portions,
+  `Lwt_log_core` is portable, as the Lwt core is, and `Lwt_log` proper assumes
+  a Unix system. `Lwt_log` is in the Unix binding.
+
+- `src/ssl/`, `src/react/`, `src/glib/` provide the separate libraries
+  `Lwt_ssl`, `Lwt_react`, `Lwt_glib`, respectively. These are basically
+  independent projects that live in the Lwt repo.
+
+- `src/util/` contains various scripts, such as the configure script
+  `src/util/discover.ml`, Travis and AppVeyor scripts, etc.
+
+- *deprecated* `src/camlp4/` contains the Camlp4 syntax extension, which is
+  deprecated in favor of the PPX (in `src/ppx`).
+
+- *deprecated* `src/simple_top/` contains the Lwt top-level, which is deprecated
+  in favor of [utop][utop].
+
+[utop]: https://github.com/diml/utop

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ the visible OCaml code is run in a single thread, but Lwt internally uses a
 combination of worker threads and non-blocking file descriptors to resolve in
 parallel the promises that do I/O.
 
+
 <br/>
 
 ## Installing
@@ -63,6 +64,7 @@ parallel the promises that do I/O.
 ```
 opam install lwt
 ```
+
 
 <br/>
 
@@ -89,6 +91,7 @@ promise, and has nothing to do with system or preemptive threads.*
 [mirage-tutorial]: https://mirage.io/wiki/tutorial-lwt
 [counter-server]: http://www.baturin.org/code/lwt-counter-server/
 
+
 <br/>
 
 ## Contact
@@ -103,7 +106,6 @@ releases. It is less noisy than watching the whole repository. Announcements are
 also made in [/r/ocaml][reddit], on the [OCaml mailing list][caml-list], and on
 [discuss.ocaml.org][discourse].
 
-[issues]: https://github.com/ocsigen/lwt/issues/new
 [gitter]: https://gitter.im/ocaml-lwt/Lobby
 [irc]:    http://webchat.freenode.net/?channels=#ocaml
 [so]:     http://stackoverflow.com/questions/ask?tags=ocaml,lwt,ocaml-lwt
@@ -111,32 +113,71 @@ also made in [/r/ocaml][reddit], on the [OCaml mailing list][caml-list], and on
 [reddit]: https://www.reddit.com/r/ocaml/
 [caml-list]: https://sympa.inria.fr/sympa/arc/caml-list
 [discourse]: https://discuss.ocaml.org/c/lwt
+[issues]: https://github.com/ocsigen/lwt/issues/new
+
 
 <br/>
 
 ## Contributing
 
-Lwt is a very mature library, but there is considerable room for improvement.
-Contributions are welcome. To clone the source and install a development
-version,
+What counts as a contribution to Lwt? All kinds of things make the project
+better, and are very much appreciated:
 
-```
-opam source --dev-repo --pin lwt
-```
+- [Asking](#contact) anything. This helps everyone understand Lwt, including
+  long-time maintainers!
+- Making or requesting edits to the [docs](#documentation), or just reading
+  them.
+- Reading any [issue or PR][issues-and-prs], and, optionally, adding your
+  opinion or requesting clarification.
+- Explaining how to make Lwt easier to contribute to, finding problems with the
+  [contributing docs][contributing-md], etc.
+- Helping other people with Lwt, whether in this repo, or elsewhere in the
+  world.
+- Writing or clarifying [test cases][tests].
+- And, of course, the traditional kind of contribution, picking up
+  [issues][all-issues] and writing code :)
 
-This will also install the development dependency OASIS.
+Contributing to Lwt is not only for OCaml "experts!" If you are near the
+beginning of your OCaml journey, we'd love to give you a little help by
+recommending appropriate issues, or even just chatting about Lwt or OCaml.
+Newcomers make valuable contributions, that maintainers often learn from – not
+the least because newcomers bring a fresh, valuable perspective :) Don't be
+afraid to ask anything.
 
-A list of [project suggestions][projects] and a [roadmap][roadmap] can be found
-on the wiki.
+We hope you'll join us to work in a friendly community around Lwt :) On behalf
+of all users of, and contributors to, Lwt: Thank you! :tada:
 
-[projects]: https://github.com/ocsigen/lwt/wiki/Plan#projects
-[roadmap]:  https://github.com/ocsigen/lwt/wiki/Plan#roadmap
+#### Resources
+
+There are several resources to help you get started:
+
+- If you'd like to ask a question, or otherwise talk, there is the
+  [contact](#contact) information.
+- Lwt maintains a list of [easy issues][easy-issues], which you can use to try
+  out the code contribution workflow. This list works two ways! Please
+  contribute to it: if you find something that needs a fix, open an issue. It
+  might be an easy issue that another contributor would love to solve :)
+- [`CONTRIBUTING.md`][contributing-md] contains optional tips for working on the
+  code of Lwt, instructions on how to check the code out, and a high-level
+  outline of the code base.
+- The project [roadmap][roadmap] contains a list of long-term, large-scale
+  projects, so you can get an idea of where Lwt is headed, as a whole. Planned
+  upcoming releases are also listed there.
+- Watch this repository :)
+
+[issues-and-prs]: https://github.com/ocsigen/lwt/issues?utf8=%E2%9C%93&q=is%3Aopen
+[all-issues]: https://github.com/ocsigen/lwt/issues
+[roadmap]:  https://github.com/ocsigen/lwt/wiki/Roadmap
+[easy-issues]: https://github.com/ocsigen/lwt/labels/easy
+[contributing-md]: https://github.com/ocsigen/lwt/blob/master/CONTRIBUTING.md
+[tests]: https://github.com/ocsigen/lwt/tree/master/tests
+
 
 <br/>
 
 ## License
 
-Lwt is released under the LGPL, with the OpenSSL linking exception. See
+Lwt is released under the LGPL, with an OpenSSL linking exception. See
 [`COPYING`][copying].
 
 [copying]: https://github.com/ocsigen/lwt/blob/master/doc/COPYING


### PR DESCRIPTION
Let's continue making Lwt more welcoming to contributors. This PR adds some basic contributing documentation:

- The Contributing section of the `README` is [expanded](https://github.com/ocsigen/lwt/tree/contributing#contributing).
- Added [`CONTRIBUTING.md`](https://github.com/ocsigen/lwt/blob/contributing/CONTRIBUTING.md).

These should be considered as drafts; I just can't keep looking directly at them – feeling a sort of "writing lock" from thinking about them for days straight :) Maybe others have some fresh ideas :)

I've also added:

- A [list of easy issues](https://github.com/ocsigen/lwt/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy).
- A [summary of current large projects](https://github.com/ocsigen/lwt/wiki/Roadmap).

Easy issues should usually be left for new contributors. They should contain a thorough description of how to do the change, including testing.

I plan to later add guides on specific tasks to `CONTRIBUTING.md`. Ideally, this would make some otherwise-difficult issues easy, as contributors can be linked to the guides, and can then follow them rather closely. Potential topics for guides:

- How to make a non-blocking function binding (e.g. for the current [`getcwd` issue](https://github.com/ocsigen/lwt/issues/342).
- How to make/prepare for a breaking change.
- How to find users of a particular API in OPAM by searching the reverse dependencies.

cc @vramana: thanks for linking me to [that video](https://www.youtube.com/watch?v=AHprJNUCgQ0) full of ideas. I'd appreciate your thoughts on this :)