### PR TITLE
Fixed `lwt_list` test suite name

### DIFF
--- a/tests/core/test_lwt_list.ml
+++ b/tests/core/test_lwt_list.ml
@@ -152,7 +152,7 @@ let test_rev_map f =
   f (fun n -> return (n*2)) l >>= fun after ->
   return (after = [6;4;2])
 
-let suite = suite "lwt_util" [
+let suite = suite "lwt_list" [
     test "iter_p"
       (fun () ->
          test_iter Lwt_list.iter_p [1;0;1];


### PR DESCRIPTION
This is pretty straight-forward, and resolves #397.

The test suite for [`src/core/lwt_list.ml`](src/core/lwt_list.ml) is now called `lwt_list` instead of `lwt_util`.