### PR TITLE
Formatted C files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Google
+BreakBeforeBraces: Linux
+IndentWidth: 4

--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -31,12 +31,12 @@
 #include <assert.h>
 
 #include <caml/alloc.h>
-#include <caml/fail.h>
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
-#include <caml/signals.h>
-#include <caml/custom.h>
 #include <caml/callback.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
 #include <ev.h>
 
 /* +-----------------------------------------------------------------+
@@ -52,18 +52,24 @@ enum {
   val_EVBACKEND_PORT
 };
 
-static unsigned int backend_val(value v)
-{
-  switch (Int_val(v))
-  {
-  case val_EVBACKEND_DEFAULT : return 0;
-  case val_EVBACKEND_SELECT  : return EVBACKEND_SELECT;
-  case val_EVBACKEND_POLL    : return EVBACKEND_POLL;
-  case val_EVBACKEND_EPOLL   : return EVBACKEND_EPOLL;
-  case val_EVBACKEND_KQUEUE  : return EVBACKEND_KQUEUE;
-  case val_EVBACKEND_DEVPOLL : return EVBACKEND_DEVPOLL;
-  case val_EVBACKEND_PORT    : return EVBACKEND_PORT;
-  default: assert(0);
+static unsigned int backend_val(value v) {
+  switch (Int_val(v)) {
+    case val_EVBACKEND_DEFAULT:
+      return 0;
+    case val_EVBACKEND_SELECT:
+      return EVBACKEND_SELECT;
+    case val_EVBACKEND_POLL:
+      return EVBACKEND_POLL;
+    case val_EVBACKEND_EPOLL:
+      return EVBACKEND_EPOLL;
+    case val_EVBACKEND_KQUEUE:
+      return EVBACKEND_KQUEUE;
+    case val_EVBACKEND_DEVPOLL:
+      return EVBACKEND_DEVPOLL;
+    case val_EVBACKEND_PORT:
+      return EVBACKEND_PORT;
+    default:
+      assert(0);
   }
 }
 
@@ -71,24 +77,15 @@ static unsigned int backend_val(value v)
    | Loops                                                           |
    +-----------------------------------------------------------------+ */
 
-static int compare_loops(value a, value b)
-{
-  return (int)((char*)Ev_loop_val(a) - (char*)Ev_loop_val(b));
+static int compare_loops(value a, value b) {
+  return (int)((char *)Ev_loop_val(a) - (char *)Ev_loop_val(b));
 }
 
-static long hash_loop(value loop)
-{
-  return (long)Ev_loop_val(loop);
-}
+static long hash_loop(value loop) { return (long)Ev_loop_val(loop); }
 
 static struct custom_operations loop_ops = {
-  "lwt.libev.loop",
-  custom_finalize_default,
-  compare_loops,
-  hash_loop,
-  custom_serialize_default,
-  custom_deserialize_default
-};
+    "lwt.libev.loop", custom_finalize_default,  compare_loops,
+    hash_loop,        custom_serialize_default, custom_deserialize_default};
 
 /* Do nothing.
 
@@ -97,41 +94,36 @@ static struct custom_operations loop_ops = {
    it is executed in a blocking section and callbacks must be executed
    outside.
  */
-static void nop(struct ev_loop *loop)
-{
-}
+static void nop(struct ev_loop *loop) {}
 
-CAMLprim value lwt_libev_init(value backend)
-{
+CAMLprim value lwt_libev_init(value backend) {
   struct ev_loop *loop = ev_loop_new(EVFLAG_FORKCHECK | backend_val(backend));
   if (!loop) caml_failwith("lwt_libev_init");
   /* Remove the invoke_pending callback. */
   ev_set_invoke_pending_cb(loop, nop);
-  value result = caml_alloc_custom(&loop_ops, sizeof(struct ev_loop*), 0, 1);
+  value result = caml_alloc_custom(&loop_ops, sizeof(struct ev_loop *), 0, 1);
   Ev_loop_val(result) = loop;
   return result;
 }
 
-CAMLprim value lwt_libev_stop(value loop)
-{
+CAMLprim value lwt_libev_stop(value loop) {
   ev_loop_destroy(Ev_loop_val(loop));
   return Val_unit;
 }
 
-CAMLprim value lwt_libev_loop(value val_loop, value val_block)
-{
+CAMLprim value lwt_libev_loop(value val_loop, value val_block) {
   struct ev_loop *loop = Ev_loop_val(val_loop);
   /* Call the event loop inside a blocking section. */
   caml_enter_blocking_section();
-  ev_loop(loop, Bool_val(val_block) ? EVLOOP_ONESHOT : EVLOOP_ONESHOT | EVLOOP_NONBLOCK);
+  ev_loop(loop, Bool_val(val_block) ? EVLOOP_ONESHOT
+                                    : EVLOOP_ONESHOT | EVLOOP_NONBLOCK);
   caml_leave_blocking_section();
   /* Invoke callbacks now, i.e. outside the blocking section. */
   ev_invoke_pending(loop);
   return Val_unit;
 }
 
-CAMLprim value lwt_libev_unloop(value loop)
-{
+CAMLprim value lwt_libev_unloop(value loop) {
   ev_unloop(Ev_loop_val(loop), EVUNLOOP_ONE);
   return Val_unit;
 }
@@ -140,70 +132,57 @@ CAMLprim value lwt_libev_unloop(value loop)
    | Watchers                                                        |
    +-----------------------------------------------------------------+ */
 
-#define Ev_io_val(v) *(struct ev_io**)Data_custom_val(v)
-#define Ev_timer_val(v) *(struct ev_timer**)Data_custom_val(v)
+#define Ev_io_val(v) *(struct ev_io **)Data_custom_val(v)
+#define Ev_timer_val(v) *(struct ev_timer **)Data_custom_val(v)
 
-static int compare_watchers(value a, value b)
-{
-  return (int)((char*)Ev_io_val(a) - (char*)Ev_io_val(b));
+static int compare_watchers(value a, value b) {
+  return (int)((char *)Ev_io_val(a) - (char *)Ev_io_val(b));
 }
 
-static long hash_watcher(value watcher)
-{
-  return (long)Ev_io_val(watcher);
-}
+static long hash_watcher(value watcher) { return (long)Ev_io_val(watcher); }
 
 static struct custom_operations watcher_ops = {
-  "lwt.libev.watcher",
-  custom_finalize_default,
-  compare_watchers,
-  hash_watcher,
-  custom_serialize_default,
-  custom_deserialize_default
-};
+    "lwt.libev.watcher", custom_finalize_default,  compare_watchers,
+    hash_watcher,        custom_serialize_default, custom_deserialize_default};
 
 /* +-----------------------------------------------------------------+
    | IO watchers                                                     |
    +-----------------------------------------------------------------+ */
 
-static void handle_io(struct ev_loop *loop, ev_io *watcher, int revents)
-{
+static void handle_io(struct ev_loop *loop, ev_io *watcher, int revents) {
   caml_callback((value)watcher->data, Val_unit);
 }
 
-static value lwt_libev_io_init(struct ev_loop *loop, int fd, int event, value callback)
-{
+static value lwt_libev_io_init(struct ev_loop *loop, int fd, int event,
+                               value callback) {
   CAMLparam1(callback);
   CAMLlocal1(result);
   /* Create and initialise the watcher */
-  struct ev_io* watcher = lwt_unix_new(struct ev_io);
+  struct ev_io *watcher = lwt_unix_new(struct ev_io);
   ev_io_init(watcher, handle_io, fd, event);
   /* Wrap the watcher into a custom caml value */
-  result = caml_alloc_custom(&watcher_ops, sizeof(struct ev_io*), 0, 1);
+  result = caml_alloc_custom(&watcher_ops, sizeof(struct ev_io *), 0, 1);
   Ev_io_val(result) = watcher;
   /* Store the callback in the watcher, and register it as a root */
-  watcher->data = (void*)callback;
-  caml_register_generational_global_root((value*)(&(watcher->data)));
+  watcher->data = (void *)callback;
+  caml_register_generational_global_root((value *)(&(watcher->data)));
   /* Start the event */
   ev_io_start(loop, watcher);
   CAMLreturn(result);
 }
 
-CAMLprim value lwt_libev_readable_init(value loop, value fd, value callback)
-{
+CAMLprim value lwt_libev_readable_init(value loop, value fd, value callback) {
   return lwt_libev_io_init(Ev_loop_val(loop), FD_val(fd), EV_READ, callback);
 }
 
-CAMLprim value lwt_libev_writable_init(value loop, value fd, value callback)
-{
+CAMLprim value lwt_libev_writable_init(value loop, value fd, value callback) {
   return lwt_libev_io_init(Ev_loop_val(loop), FD_val(fd), EV_WRITE, callback);
 }
 
-CAMLprim value lwt_libev_io_stop(value loop, value val_watcher)
-{
+CAMLprim value lwt_libev_io_stop(value loop, value val_watcher) {
   CAMLparam2(loop, val_watcher);
-  struct ev_io* watcher = Ev_io_val(val_watcher);
-  caml_remove_generational_global_root((value*)(&(watcher->data)));
+  struct ev_io *watcher = Ev_io_val(val_watcher);
+  caml_remove_generational_global_root((value *)(&(watcher->data)));
   ev_io_stop(Ev_loop_val(loop), watcher);
   free(watcher);
   CAMLreturn(Val_unit);
@@ -213,38 +192,36 @@ CAMLprim value lwt_libev_io_stop(value loop, value val_watcher)
    | Timer watchers                                                  |
    +-----------------------------------------------------------------+ */
 
-static void handle_timer(struct ev_loop *loop, ev_timer *watcher, int revents)
-{
+static void handle_timer(struct ev_loop *loop, ev_timer *watcher, int revents) {
   caml_callback((value)watcher->data, Val_unit);
 }
 
-CAMLprim value lwt_libev_timer_init(value loop, value delay, value repeat, value callback)
-{
+CAMLprim value lwt_libev_timer_init(value loop, value delay, value repeat,
+                                    value callback) {
   CAMLparam4(loop, delay, repeat, callback);
   CAMLlocal1(result);
   /* Create and initialise the watcher */
-  struct ev_timer* watcher = lwt_unix_new(struct ev_timer);
+  struct ev_timer *watcher = lwt_unix_new(struct ev_timer);
   if (Bool_val(repeat))
     ev_timer_init(watcher, handle_timer, Double_val(delay), Double_val(delay));
   else
     ev_timer_init(watcher, handle_timer, Double_val(delay), 0.0);
 
   /* Wrap the watcher into a custom caml value */
-  result = caml_alloc_custom(&watcher_ops, sizeof(struct ev_timer*), 0, 1);
+  result = caml_alloc_custom(&watcher_ops, sizeof(struct ev_timer *), 0, 1);
   Ev_timer_val(result) = watcher;
   /* Store the callback in the watcher, and register it as a root */
-  watcher->data = (void*)callback;
-  caml_register_generational_global_root((value*)(&(watcher->data)));
+  watcher->data = (void *)callback;
+  caml_register_generational_global_root((value *)(&(watcher->data)));
   /* Start the event */
   ev_timer_start(Ev_loop_val(loop), watcher);
   CAMLreturn(result);
 }
 
-CAMLprim value lwt_libev_timer_stop(value loop, value val_watcher)
-{
+CAMLprim value lwt_libev_timer_stop(value loop, value val_watcher) {
   CAMLparam2(loop, val_watcher);
-  struct ev_timer* watcher = Ev_timer_val(val_watcher);
-  caml_remove_generational_global_root((value*)(&(watcher->data)));
+  struct ev_timer *watcher = Ev_timer_val(val_watcher);
+  caml_remove_generational_global_root((value *)(&(watcher->data)));
   ev_timer_stop(Ev_loop_val(loop), watcher);
   free(watcher);
   CAMLreturn(Val_unit);

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -27,12 +27,11 @@
 
 #define CAML_NAME_SPACE
 
-#include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
+#include <caml/memory.h>
 
-static HANDLE get_handle(value opt)
-{
+static HANDLE get_handle(value opt) {
   value fd;
   if (Is_block(opt)) {
     fd = Field(opt, 0);
@@ -48,8 +47,8 @@ static HANDLE get_handle(value opt)
 
 #define string_option(opt) (Is_block(opt) ? String_val(Field(opt, 0)) : NULL)
 
-CAMLprim value lwt_process_create_process(value prog, value cmdline, value env, value fds)
-{
+CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
+                                          value fds) {
   CAMLparam4(prog, cmdline, env, fds);
   CAMLlocal1(result);
 
@@ -64,7 +63,8 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env, 
   si.hStdOutput = get_handle(Field(fds, 1));
   si.hStdError = get_handle(Field(fds, 2));
 
-  if (!CreateProcess(string_option(prog), String_val(cmdline), NULL, NULL, TRUE, 0, string_option(env), NULL, &si, &pi)) {
+  if (!CreateProcess(string_option(prog), String_val(cmdline), NULL, NULL, TRUE,
+                     0, string_option(env), NULL, &si, &pi)) {
     win32_maperr(GetLastError());
     uerror("CreateProcess", Nothing);
   }
@@ -82,13 +82,11 @@ struct job_wait {
   HANDLE handle;
 };
 
-static void worker_wait(struct job_wait *job)
-{
+static void worker_wait(struct job_wait *job) {
   WaitForSingleObject(job->handle, INFINITE);
 }
 
-static value result_wait(struct job_wait *job)
-{
+static value result_wait(struct job_wait *job) {
   DWORD code, error;
   if (!GetExitCodeProcess(job->handle, &code)) {
     error = GetLastError();
@@ -102,15 +100,13 @@ static value result_wait(struct job_wait *job)
   return Val_int(code);
 }
 
-CAMLprim value lwt_process_wait_job(value handle)
-{
+CAMLprim value lwt_process_wait_job(value handle) {
   LWT_UNIX_INIT_JOB(job, wait, 0);
   job->handle = Handle_val(handle);
   return lwt_unix_alloc_job(&(job->job));
 }
 
-CAMLprim value lwt_process_terminate_process(value handle, value code)
-{
+CAMLprim value lwt_process_terminate_process(value handle, value code) {
   if (!TerminateProcess(Handle_val(handle), Int_val(code))) {
     win32_maperr(GetLastError());
     uerror("TerminateProcess", Nothing);
@@ -122,8 +118,6 @@ CAMLprim value lwt_process_terminate_process(value handle, value code)
 
 /* This is used to suppress a warning from ranlib about the object file having
    no symbols. */
-void lwt_process_dummy_symbol()
-{
-}
+void lwt_process_dummy_symbol() {}
 
 #endif /* defined(LWT_ON_WINDOWS) */

--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -24,20 +24,21 @@
 
 #define CAML_NAME_SPACE
 
-#include <lwt_config.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
+#include <lwt_config.h>
+
 #include <caml/socketaddr.h>
 
 /* The macro to get the file-descriptor from a value. */
 #if defined(LWT_ON_WINDOWS)
-#  define FD_val(value) win_CRT_fd_of_filedescr(value)
+#define FD_val(value) win_CRT_fd_of_filedescr(value)
 #else
-#  define FD_val(value) Int_val(value)
+#define FD_val(value) Int_val(value)
 #endif
 
 /* Macro to extract a libev loop from a caml value. */
-#define Ev_loop_val(value) *(struct ev_loop**)Data_custom_val(value)
+#define Ev_loop_val(value) *(struct ev_loop **)Data_custom_val(value)
 
 /* +-----------------------------------------------------------------+
    | Utils                                                           |
@@ -53,30 +54,42 @@ void *lwt_unix_realloc(void *ptr, size_t size);
 char *lwt_unix_strdup(char *string);
 
 /* Helpers for allocating structures. */
-#define lwt_unix_new(type) (type*)lwt_unix_malloc(sizeof(type))
-#define lwt_unix_new_plus(type, size) (type*)lwt_unix_malloc(sizeof(type) + size)
+#define lwt_unix_new(type) (type *)lwt_unix_malloc(sizeof(type))
+#define lwt_unix_new_plus(type, size) \
+    (type *)lwt_unix_malloc(sizeof(type) + size)
 
 /* Raise [Lwt_unix.Not_available]. */
 void lwt_unix_not_available(char const *feature) Noreturn;
 
 #define LWT_NOT_AVAILABLE1(prim) \
-  CAMLprim value lwt_ ## prim(value a1) \
-  { lwt_unix_not_available(#prim); }
-#define LWT_NOT_AVAILABLE2(prim) \
-  CAMLprim value lwt_ ## prim(value a1, value a2) \
-  { lwt_unix_not_available(#prim); }
-#define LWT_NOT_AVAILABLE3(prim) \
-  CAMLprim value lwt_ ## prim(value a1, value a2, value a3) \
-  { lwt_unix_not_available(#prim); }
-#define LWT_NOT_AVAILABLE4(prim) \
-  CAMLprim value lwt_ ## prim(value a1, value a2, value a3, value a4) \
-  { lwt_unix_not_available(#prim); }
-#define LWT_NOT_AVAILABLE5(prim) \
-  CAMLprim value lwt_ ## prim(value a1, value a2, value a3, value a4, value a5) \
-  { lwt_unix_not_available(#prim); }
-#define LWT_NOT_AVAILABLE6(prim) \
-  CAMLprim value lwt_ ## prim(value a1, value a2, value a3, value a4, value a5, value a6) \
-  { lwt_unix_not_available(#prim); }
+    CAMLprim value lwt_##prim(value a1) { lwt_unix_not_available(#prim); }
+#define LWT_NOT_AVAILABLE2(prim)                  \
+    CAMLprim value lwt_##prim(value a1, value a2) \
+    {                                             \
+        lwt_unix_not_available(#prim);            \
+    }
+#define LWT_NOT_AVAILABLE3(prim)                            \
+    CAMLprim value lwt_##prim(value a1, value a2, value a3) \
+    {                                                       \
+        lwt_unix_not_available(#prim);                      \
+    }
+#define LWT_NOT_AVAILABLE4(prim)                                      \
+    CAMLprim value lwt_##prim(value a1, value a2, value a3, value a4) \
+    {                                                                 \
+        lwt_unix_not_available(#prim);                                \
+    }
+#define LWT_NOT_AVAILABLE5(prim)                                      \
+    CAMLprim value lwt_##prim(value a1, value a2, value a3, value a4, \
+                              value a5)                               \
+    {                                                                 \
+        lwt_unix_not_available(#prim);                                \
+    }
+#define LWT_NOT_AVAILABLE6(prim)                                      \
+    CAMLprim value lwt_##prim(value a1, value a2, value a3, value a4, \
+                              value a5, value a6)                     \
+    {                                                                 \
+        lwt_unix_not_available(#prim);                                \
+    }
 
 /* +-----------------------------------------------------------------+
    | Notifications                                                   |
@@ -106,7 +119,7 @@ typedef struct lwt_unix_condition lwt_unix_condition;
 #endif
 
 /* Launch a thread in detached mode. */
-void lwt_unix_launch_thread(void* (*start)(void*), void* data);
+void lwt_unix_launch_thread(void *(*start)(void *), void *data);
 
 /* Return a handle to the currently running thread. */
 lwt_unix_thread lwt_unix_thread_self();
@@ -139,7 +152,8 @@ void lwt_unix_condition_signal(lwt_unix_condition *condition);
 void lwt_unix_condition_broadcast(lwt_unix_condition *condition);
 
 /* Wait for a signal on a condition variable. */
-void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mutex);
+void lwt_unix_condition_wait(lwt_unix_condition *condition,
+                             lwt_unix_mutex *mutex);
 
 /* +-----------------------------------------------------------------+
    | Detached jobs                                                   |
@@ -147,15 +161,15 @@ void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mute
 
 /* How job are executed. */
 enum lwt_unix_async_method {
-  /* Synchronously. */
-  LWT_UNIX_ASYNC_METHOD_NONE = 0,
+    /* Synchronously. */
+    LWT_UNIX_ASYNC_METHOD_NONE = 0,
 
-  /* Asynchronously, on another thread. */
-  LWT_UNIX_ASYNC_METHOD_DETACH = 1,
+    /* Asynchronously, on another thread. */
+    LWT_UNIX_ASYNC_METHOD_DETACH = 1,
 
-  /* Asynchronously, on the main thread, switcing to another thread if
-     necessary. */
-  LWT_UNIX_ASYNC_METHOD_SWITCH = 2
+    /* Asynchronously, on the main thread, switcing to another thread if
+       necessary. */
+    LWT_UNIX_ASYNC_METHOD_SWITCH = 2
 };
 
 /* Type of job execution modes. */
@@ -163,59 +177,59 @@ typedef enum lwt_unix_async_method lwt_unix_async_method;
 
 /* State of a job. */
 enum lwt_unix_job_state {
-  /* The job has not yet started. */
-  LWT_UNIX_JOB_STATE_PENDING,
+    /* The job has not yet started. */
+    LWT_UNIX_JOB_STATE_PENDING,
 
-  /* The job is running. */
-  LWT_UNIX_JOB_STATE_RUNNING,
+    /* The job is running. */
+    LWT_UNIX_JOB_STATE_RUNNING,
 
-  /* The job is done. */
-  LWT_UNIX_JOB_STATE_DONE
+    /* The job is done. */
+    LWT_UNIX_JOB_STATE_DONE
 };
 
 /* A job descriptor. */
 struct lwt_unix_job {
-  /* The next job in the queue. */
-  struct lwt_unix_job *next;
+    /* The next job in the queue. */
+    struct lwt_unix_job *next;
 
-  /* Id used to notify the main thread in case the job do not
-     terminate immediately. */
-  intnat notification_id;
+    /* Id used to notify the main thread in case the job do not
+       terminate immediately. */
+    intnat notification_id;
 
-  /* The function to call to do the work.
+    /* The function to call to do the work.
 
-     This function must not:
-     - access or allocate OCaml block values (tuples, strings, ...),
-     - call OCaml code. */
-  void (*worker)(struct lwt_unix_job *job);
+       This function must not:
+       - access or allocate OCaml block values (tuples, strings, ...),
+       - call OCaml code. */
+    void (*worker)(struct lwt_unix_job *job);
 
-  /* The function to call to extract the result and free memory
-     allocated by the job.
+    /* The function to call to extract the result and free memory
+       allocated by the job.
 
-     Note: if you want to raise an excpetion, be sure to free
-     resources before raising it!
+       Note: if you want to raise an excpetion, be sure to free
+       resources before raising it!
 
-     It has been introduced in Lwt 2.3.3. */
-  value (*result)(struct lwt_unix_job *job);
+       It has been introduced in Lwt 2.3.3. */
+    value (*result)(struct lwt_unix_job *job);
 
-  /* State of the job. */
-  enum lwt_unix_job_state state;
+    /* State of the job. */
+    enum lwt_unix_job_state state;
 
-  /* Is the main thread still waiting for the job ? */
-  int fast;
+    /* Is the main thread still waiting for the job ? */
+    int fast;
 
-  /* Mutex to protect access to [state] and [fast]. */
-  lwt_unix_mutex mutex;
+    /* Mutex to protect access to [state] and [fast]. */
+    lwt_unix_mutex mutex;
 
-  /* Thread running the job. */
-  lwt_unix_thread thread;
+    /* Thread running the job. */
+    lwt_unix_thread thread;
 
-  /* The async method in used by the job. */
-  lwt_unix_async_method async_method;
+    /* The async method in used by the job. */
+    lwt_unix_async_method async_method;
 };
 
 /* Type of job descriptors. */
-typedef struct lwt_unix_job* lwt_unix_job;
+typedef struct lwt_unix_job *lwt_unix_job;
 
 /* Type of worker functions. */
 typedef void (*lwt_unix_job_worker)(lwt_unix_job job);
@@ -241,21 +255,21 @@ void lwt_unix_free_job(lwt_unix_job job);
    - SIZE is the dynamic size to allocate at the end of the structure,
      in case it ends ends with something of the form: char data[]);
 */
-#define LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE)                              \
-  struct job_##FUNC *VAR = lwt_unix_new_plus(struct job_##FUNC, SIZE);  \
-  VAR->job.worker = (lwt_unix_job_worker)worker_##FUNC;                 \
-  VAR->job.result = (lwt_unix_job_result)result_##FUNC
+#define LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE)                               \
+    struct job_##FUNC *VAR = lwt_unix_new_plus(struct job_##FUNC, SIZE); \
+    VAR->job.worker = (lwt_unix_job_worker)worker_##FUNC;                \
+    VAR->job.result = (lwt_unix_job_result)result_##FUNC
 
 /* Same as LWT_UNIX_INIT_JOB, but also stores a string argument named
    ARG at the end of the job structure. The offset of the copied
    string is assigned to the field VAR->ARG.
 
    The structure must ends with: char data[]; */
-#define LWT_UNIX_INIT_JOB_STRING(VAR, FUNC, SIZE, ARG)  \
-  mlsize_t __len = caml_string_length(ARG);             \
-  LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE + __len + 1);       \
-  VAR->ARG = VAR->data + SIZE;                          \
-  memcpy(VAR->ARG, String_val(ARG), __len + 1)
+#define LWT_UNIX_INIT_JOB_STRING(VAR, FUNC, SIZE, ARG) \
+    mlsize_t __len = caml_string_length(ARG);          \
+    LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE + __len + 1);    \
+    VAR->ARG = VAR->data + SIZE;                       \
+    memcpy(VAR->ARG, String_val(ARG), __len + 1)
 
 /* Same as LWT_UNIX_INIT_JOB, but also stores two string arguments
    named ARG1 and ARG2 at the end of the job structure. The offsets of
@@ -263,34 +277,34 @@ void lwt_unix_free_job(lwt_unix_job job);
    VAR->ARG2.
 
    The structure definition must ends with: char data[]; */
-#define LWT_UNIX_INIT_JOB_STRING2(VAR, FUNC, SIZE, ARG1, ARG2)          \
-  mlsize_t __len1 = caml_string_length(ARG1);                           \
-  mlsize_t __len2 = caml_string_length(ARG2);                           \
-  LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE + __len1 + __len2 + 2);             \
-  VAR->ARG1 = VAR->data + SIZE;                                         \
-  VAR->ARG2 = VAR->data + SIZE + __len1 + 1;                            \
-  memcpy(VAR->ARG1, String_val(ARG1), __len1 + 1);                      \
-  memcpy(VAR->ARG2, String_val(ARG2), __len2 + 1)
+#define LWT_UNIX_INIT_JOB_STRING2(VAR, FUNC, SIZE, ARG1, ARG2) \
+    mlsize_t __len1 = caml_string_length(ARG1);                \
+    mlsize_t __len2 = caml_string_length(ARG2);                \
+    LWT_UNIX_INIT_JOB(VAR, FUNC, SIZE + __len1 + __len2 + 2);  \
+    VAR->ARG1 = VAR->data + SIZE;                              \
+    VAR->ARG2 = VAR->data + SIZE + __len1 + 1;                 \
+    memcpy(VAR->ARG1, String_val(ARG1), __len1 + 1);           \
+    memcpy(VAR->ARG2, String_val(ARG2), __len2 + 1)
 
 /* If TEST is true, it frees the job and raises Unix.Unix_error using
    the value of errno stored in the field error_code. */
-#define LWT_UNIX_CHECK_JOB(VAR, TEST, NAME)                             \
-  if (TEST) {                                                           \
-    int error_code = VAR->error_code;                                   \
-    lwt_unix_free_job(&VAR->job);                                       \
-    unix_error(error_code, NAME, Nothing);                              \
-  }
+#define LWT_UNIX_CHECK_JOB(VAR, TEST, NAME)    \
+    if (TEST) {                                \
+        int error_code = VAR->error_code;      \
+        lwt_unix_free_job(&VAR->job);          \
+        unix_error(error_code, NAME, Nothing); \
+    }
 
 /* If TEST is true, it frees the job and raises Unix.Unix_error using
    the value of errno stored in the field error_code and uses the C
    string ARG for the third field of Unix.Unix_error. */
-#define LWT_UNIX_CHECK_JOB_ARG(VAR, TEST, NAME, ARG)                    \
-  if (TEST) {                                                           \
-    int error_code = VAR->error_code;                                   \
-    value arg = caml_copy_string(ARG);                                  \
-    lwt_unix_free_job(&VAR->job);                                       \
-    unix_error(error_code, NAME, arg);                                  \
-  }
+#define LWT_UNIX_CHECK_JOB_ARG(VAR, TEST, NAME, ARG) \
+    if (TEST) {                                      \
+        int error_code = VAR->error_code;            \
+        value arg = caml_copy_string(ARG);           \
+        lwt_unix_free_job(&VAR->job);                \
+        unix_error(error_code, NAME, arg);           \
+    }
 
 /* +-----------------------------------------------------------------+
    | Deprecated                                                      |
@@ -298,20 +312,20 @@ void lwt_unix_free_job(lwt_unix_job job);
 
 /* Define not implement methods. Deprecated: it is for the old
    mechanism with three externals. */
-#define LWT_UNIX_JOB_NOT_IMPLEMENTED(name)      \
-  CAMLprim value lwt_unix_##name##_job(value Unit)        \
-  {                                             \
-    caml_invalid_argument("not implemented");	\
-  }                                             \
-                                                \
-  CAMLprim value lwt_unix_##name##_result(value Unit)     \
-  {                                             \
-    caml_invalid_argument("not implemented");	\
-  }                                             \
-                                                \
-  CAMLprim value lwt_unix_##name##_free(value Unit)       \
-  {                                             \
-    caml_invalid_argument("not implemented");	\
-  }
+#define LWT_UNIX_JOB_NOT_IMPLEMENTED(name)              \
+    CAMLprim value lwt_unix_##name##_job(value Unit)    \
+    {                                                   \
+        caml_invalid_argument("not implemented");       \
+    }                                                   \
+                                                        \
+    CAMLprim value lwt_unix_##name##_result(value Unit) \
+    {                                                   \
+        caml_invalid_argument("not implemented");       \
+    }                                                   \
+                                                        \
+    CAMLprim value lwt_unix_##name##_free(value Unit)   \
+    {                                                   \
+        caml_invalid_argument("not implemented");       \
+    }
 
 #endif /* __LWT_UNIX_H */

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -27,19 +27,19 @@
 #define CAML_NAME_SPACE
 
 #include <caml/alloc.h>
-#include <caml/fail.h>
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
-#include <caml/signals.h>
-#include <caml/config.h>
-#include <caml/custom.h>
 #include <caml/bigarray.h>
 #include <caml/callback.h>
+#include <caml/config.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
 
 #include <assert.h>
-#include <stdio.h>
-#include <signal.h>
 #include <errno.h>
+#include <signal.h>
+#include <stdio.h>
 
 #if !defined(LWT_ON_WINDOWS) && defined(SIGRTMIN) && defined(SIGRTMAX)
 #define LWT_UNIX_SIGNAL_ASYNC_SWITCH SIGRTMIN
@@ -51,36 +51,41 @@
 #include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
-#  include <unistd.h>
-#  include <sys/socket.h>
-#  include <sys/types.h>
-#  include <sys/stat.h>
-#  include <sys/param.h>
-#  include <sys/un.h>
-#  include <sys/mman.h>
-#  include <string.h>
-#  include <fcntl.h>
-#  include <dirent.h>
-#  include <pwd.h>
-#  include <grp.h>
-#  include <netdb.h>
-#  include <termios.h>
-#  include <sched.h>
-#  include <netinet/in.h>
-#  include <arpa/inet.h>
+#include <arpa/inet.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pwd.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <termios.h>
+#include <unistd.h>
 #endif
 
 #if defined(HAVE_EVENTFD)
-#  include <sys/eventfd.h>
+#include <sys/eventfd.h>
 #endif
 
 //#define DEBUG_MODE
 
 #if defined(DEBUG_MODE)
-#  include <sys/syscall.h>
-#  define DEBUG(fmt, ...) { fprintf(stderr, "lwt-debug[%d]: %s: " fmt "\n", (pid_t)syscall(SYS_gettid), __FUNCTION__, ##__VA_ARGS__); fflush(stderr); }
+#include <sys/syscall.h>
+#define DEBUG(fmt, ...)                                               \
+  {                                                                   \
+    fprintf(stderr, "lwt-debug[%d]: %s: " fmt "\n",                   \
+            (pid_t)syscall(SYS_gettid), __FUNCTION__, ##__VA_ARGS__); \
+    fflush(stderr);                                                   \
+  }
 #else
-#  define DEBUG(fmt, ...)
+#define DEBUG(fmt, ...)
 #endif
 
 /* +-----------------------------------------------------------------+
@@ -88,17 +93,16 @@
    +-----------------------------------------------------------------+ */
 
 #if defined(LWT_ON_WINDOWS)
-#  include "lwt_unix_windows.h"
+#include "lwt_unix_windows.h"
 #else
-#  include "lwt_unix_unix.h"
+#include "lwt_unix_unix.h"
 #endif
 
 /* +-----------------------------------------------------------------+
    | Utils                                                           |
    +-----------------------------------------------------------------+ */
 
-void *lwt_unix_malloc(size_t size)
-{
+void *lwt_unix_malloc(size_t size) {
   void *ptr = malloc(size);
   if (ptr == NULL) {
     perror("cannot allocate memory");
@@ -107,8 +111,7 @@ void *lwt_unix_malloc(size_t size)
   return ptr;
 }
 
-void *lwt_unix_realloc(void *ptr, size_t size)
-{
+void *lwt_unix_realloc(void *ptr, size_t size) {
   void *new_ptr = realloc(ptr, size);
   if (new_ptr == NULL) {
     perror("cannot allocate memory");
@@ -117,8 +120,7 @@ void *lwt_unix_realloc(void *ptr, size_t size)
   return new_ptr;
 }
 
-char *lwt_unix_strdup(char *str)
-{
+char *lwt_unix_strdup(char *str) {
   char *new_str = strdup(str);
   if (new_str == NULL) {
     perror("cannot allocate memory");
@@ -127,47 +129,48 @@ char *lwt_unix_strdup(char *str)
   return new_str;
 }
 
-void lwt_unix_not_available(char const *feature)
-{
-  caml_raise_with_arg(*caml_named_value("lwt:not-available"), caml_copy_string(feature));
+void lwt_unix_not_available(char const *feature) {
+  caml_raise_with_arg(*caml_named_value("lwt:not-available"),
+                      caml_copy_string(feature));
 }
 
 /* +-----------------------------------------------------------------+
    | Operation on bigarrays                                          |
    +-----------------------------------------------------------------+ */
 
-CAMLprim value lwt_unix_blit(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
-{
-  memmove((char*)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
-         (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
-         Long_val(val_len));
+CAMLprim value lwt_unix_blit(value val_buf1, value val_ofs1, value val_buf2,
+                             value val_ofs2, value val_len) {
+  memmove((char *)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+          (char *)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+          Long_val(val_len));
   return Val_unit;
 }
 
-CAMLprim value lwt_unix_blit_from_bytes(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
-{
-  memcpy((char*)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
-         String_val(val_buf1) + Long_val(val_ofs1),
-         Long_val(val_len));
+CAMLprim value lwt_unix_blit_from_bytes(value val_buf1, value val_ofs1,
+                                        value val_buf2, value val_ofs2,
+                                        value val_len) {
+  memcpy((char *)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+         String_val(val_buf1) + Long_val(val_ofs1), Long_val(val_len));
   return Val_unit;
 }
 
-CAMLprim value lwt_unix_blit_to_bytes(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
-{
+CAMLprim value lwt_unix_blit_to_bytes(value val_buf1, value val_ofs1,
+                                      value val_buf2, value val_ofs2,
+                                      value val_len) {
   memcpy(String_val(val_buf2) + Long_val(val_ofs2),
-         (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+         (char *)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
          Long_val(val_len));
   return Val_unit;
 }
 
-CAMLprim value lwt_unix_fill_bytes(value val_buf, value val_ofs, value val_len, value val_char)
-{
-  memset((char*)Caml_ba_data_val(val_buf) + Long_val(val_ofs), Int_val(val_char), Long_val(val_len));
+CAMLprim value lwt_unix_fill_bytes(value val_buf, value val_ofs, value val_len,
+                                   value val_char) {
+  memset((char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs),
+         Int_val(val_char), Long_val(val_len));
   return Val_unit;
 }
 
-CAMLprim value lwt_unix_mapped(value v_bstr)
-{
+CAMLprim value lwt_unix_mapped(value v_bstr) {
   return Val_bool(Caml_ba_array_val(v_bstr)->flags & CAML_BA_MAPPED_FILE);
 }
 
@@ -175,8 +178,7 @@ CAMLprim value lwt_unix_mapped(value v_bstr)
    | Byte order                                                      |
    +-----------------------------------------------------------------+ */
 
-value lwt_unix_system_byte_order()
-{
+value lwt_unix_system_byte_order() {
 #ifdef ARCH_BIG_ENDIAN
   return Val_int(1);
 #else
@@ -190,8 +192,7 @@ value lwt_unix_system_byte_order()
 
 #if defined(HAVE_PTHREAD)
 
-void lwt_unix_launch_thread(void* (*start)(void*), void* data)
-{
+void lwt_unix_launch_thread(void *(*start)(void *), void *data) {
   pthread_t thread;
   pthread_attr_t attr;
   int result;
@@ -206,99 +207,75 @@ void lwt_unix_launch_thread(void* (*start)(void*), void* data)
 
   if (result) unix_error(result, "launch_thread", Nothing);
 
-  pthread_attr_destroy (&attr);
+  pthread_attr_destroy(&attr);
 }
 
-lwt_unix_thread lwt_unix_thread_self()
-{
-  return pthread_self();
-}
+lwt_unix_thread lwt_unix_thread_self() { return pthread_self(); }
 
-int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2)
-{
+int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2) {
   return pthread_equal(thread1, thread2);
 }
 
-void lwt_unix_mutex_init(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_init(lwt_unix_mutex *mutex) {
   pthread_mutex_init(mutex, NULL);
 }
 
-void lwt_unix_mutex_destroy(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_destroy(lwt_unix_mutex *mutex) {
   pthread_mutex_destroy(mutex);
 }
 
-void lwt_unix_mutex_lock(lwt_unix_mutex *mutex)
-{
-  pthread_mutex_lock(mutex);
-}
+void lwt_unix_mutex_lock(lwt_unix_mutex *mutex) { pthread_mutex_lock(mutex); }
 
-void lwt_unix_mutex_unlock(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_unlock(lwt_unix_mutex *mutex) {
   pthread_mutex_unlock(mutex);
 }
 
-void lwt_unix_condition_init(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_init(lwt_unix_condition *condition) {
   pthread_cond_init(condition, NULL);
 }
 
-void lwt_unix_condition_destroy(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_destroy(lwt_unix_condition *condition) {
   pthread_cond_destroy(condition);
 }
 
-void lwt_unix_condition_signal(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_signal(lwt_unix_condition *condition) {
   pthread_cond_signal(condition);
 }
 
-void lwt_unix_condition_broadcast(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_broadcast(lwt_unix_condition *condition) {
   pthread_cond_broadcast(condition);
 }
 
-void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mutex)
-{
+void lwt_unix_condition_wait(lwt_unix_condition *condition,
+                             lwt_unix_mutex *mutex) {
   pthread_cond_wait(condition, mutex);
 }
 
 #elif defined(LWT_ON_WINDOWS)
 
-void lwt_unix_launch_thread(void* (*start)(void*), void* data)
-{
-  HANDLE handle = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)start, data, 0, NULL);
+void lwt_unix_launch_thread(void *(*start)(void *), void *data) {
+  HANDLE handle =
+      CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)start, data, 0, NULL);
   if (handle) CloseHandle(handle);
 }
 
-lwt_unix_thread lwt_unix_thread_self()
-{
-  return GetCurrentThreadId();
-}
+lwt_unix_thread lwt_unix_thread_self() { return GetCurrentThreadId(); }
 
-int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2)
-{
+int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2) {
   return thread1 == thread2;
 }
 
-void lwt_unix_mutex_init(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_init(lwt_unix_mutex *mutex) {
   InitializeCriticalSection(mutex);
 }
 
-void lwt_unix_mutex_destroy(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_destroy(lwt_unix_mutex *mutex) {
   DeleteCriticalSection(mutex);
 }
 
-void lwt_unix_mutex_lock(lwt_unix_mutex *mutex)
-{
-  EnterCriticalSection(mutex);
-}
+void lwt_unix_mutex_lock(lwt_unix_mutex *mutex) { EnterCriticalSection(mutex); }
 
-void lwt_unix_mutex_unlock(lwt_unix_mutex *mutex)
-{
+void lwt_unix_mutex_unlock(lwt_unix_mutex *mutex) {
   LeaveCriticalSection(mutex);
 }
 
@@ -312,19 +289,16 @@ struct lwt_unix_condition {
   struct wait_list *waiters;
 };
 
-void lwt_unix_condition_init(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_init(lwt_unix_condition *condition) {
   InitializeCriticalSection(&condition->mutex);
   condition->waiters = NULL;
 }
 
-void lwt_unix_condition_destroy(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_destroy(lwt_unix_condition *condition) {
   DeleteCriticalSection(&condition->mutex);
 }
 
-void lwt_unix_condition_signal(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_signal(lwt_unix_condition *condition) {
   struct wait_list *node;
   EnterCriticalSection(&condition->mutex);
 
@@ -336,8 +310,7 @@ void lwt_unix_condition_signal(lwt_unix_condition *condition)
   LeaveCriticalSection(&condition->mutex);
 }
 
-void lwt_unix_condition_broadcast(lwt_unix_condition *condition)
-{
+void lwt_unix_condition_broadcast(lwt_unix_condition *condition) {
   struct wait_list *node;
   EnterCriticalSection(&condition->mutex);
   for (node = condition->waiters; node; node = node->next)
@@ -346,8 +319,8 @@ void lwt_unix_condition_broadcast(lwt_unix_condition *condition)
   LeaveCriticalSection(&condition->mutex);
 }
 
-void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mutex)
-{
+void lwt_unix_condition_wait(lwt_unix_condition *condition,
+                             lwt_unix_mutex *mutex) {
   struct wait_list node;
 
   /* Create the event for the notification. */
@@ -374,7 +347,7 @@ void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mute
 
 #else
 
-#  error "no threading library available!"
+#error "no threading library available!"
 
 #endif
 
@@ -384,8 +357,8 @@ void lwt_unix_condition_wait(lwt_unix_condition *condition, lwt_unix_mutex *mute
 
 #if defined(LWT_ON_WINDOWS)
 
-static void lwt_unix_socketpair(int domain, int type, int protocol, SOCKET sockets[2])
-{
+static void lwt_unix_socketpair(int domain, int type, int protocol,
+                                SOCKET sockets[2]) {
   union {
     struct sockaddr_in inaddr;
     struct sockaddr addr;
@@ -399,45 +372,40 @@ static void lwt_unix_socketpair(int domain, int type, int protocol, SOCKET socke
   sockets[1] = INVALID_SOCKET;
 
   listener = socket(domain, type, protocol);
-  if (listener == INVALID_SOCKET)
-    goto failure;
+  if (listener == INVALID_SOCKET) goto failure;
 
   memset(&a, 0, sizeof(a));
   a.inaddr.sin_family = domain;
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_port = 0;
 
-  if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (char*) &reuse, sizeof(reuse)) == -1)
+  if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse,
+                 sizeof(reuse)) == -1)
     goto failure;
 
-  if  (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
-    goto failure;
+  if (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR) goto failure;
 
   memset(&a, 0, sizeof(a));
-  if  (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR)
-    goto failure;
+  if (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR) goto failure;
 
   a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   a.inaddr.sin_family = AF_INET;
 
-  if (listen(listener, 1) == SOCKET_ERROR)
-    goto failure;
+  if (listen(listener, 1) == SOCKET_ERROR) goto failure;
 
   sockets[0] = socket(domain, type, protocol);
-  if (sockets[0] == INVALID_SOCKET)
-    goto failure;
+  if (sockets[0] == INVALID_SOCKET) goto failure;
 
   if (connect(sockets[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
     goto failure;
 
   sockets[1] = accept(listener, NULL, NULL);
-  if (sockets[1] == INVALID_SOCKET)
-    goto failure;
+  if (sockets[1] == INVALID_SOCKET) goto failure;
 
   closesocket(listener);
   return;
 
- failure:
+failure:
   err = WSAGetLastError();
   closesocket(listener);
   closesocket(sockets[0]);
@@ -446,22 +414,18 @@ static void lwt_unix_socketpair(int domain, int type, int protocol, SOCKET socke
   uerror("socketpair", Nothing);
 }
 
-static int socket_domain_table[] = {
-  PF_UNIX, PF_INET
-};
+static int socket_domain_table[] = {PF_UNIX, PF_INET};
 
-static int socket_type_table[] = {
-  SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET
-};
+static int socket_type_table[] = {SOCK_STREAM, SOCK_DGRAM, SOCK_RAW,
+                                  SOCK_SEQPACKET};
 
-CAMLprim value lwt_unix_socketpair_stub(value domain, value type, value protocol)
-{
+CAMLprim value lwt_unix_socketpair_stub(value domain, value type,
+                                        value protocol) {
   CAMLparam3(domain, type, protocol);
   CAMLlocal1(result);
   SOCKET sockets[2];
   lwt_unix_socketpair(socket_domain_table[Int_val(domain)],
-                      socket_type_table[Int_val(type)],
-                      Int_val(protocol),
+                      socket_type_table[Int_val(type)], Int_val(protocol),
                       sockets);
   result = caml_alloc_tuple(2);
   Store_field(result, 0, win_alloc_socket(sockets[0]));
@@ -506,7 +470,8 @@ enum notification_mode {
 };
 
 /* The current notification mode. */
-static enum notification_mode notification_mode = NOTIFICATION_MODE_NOT_INITIALIZED;
+static enum notification_mode notification_mode =
+    NOTIFICATION_MODE_NOT_INITIALIZED;
 
 /* Send one notification. */
 static int (*notification_send)();
@@ -514,25 +479,25 @@ static int (*notification_send)();
 /* Read one notification. */
 static int (*notification_recv)();
 
-static void init_notifications()
-{
+static void init_notifications() {
   lwt_unix_mutex_init(&notification_mutex);
   notification_count = 4096;
-  notifications = (intnat*)lwt_unix_malloc(notification_count * sizeof(intnat));
+  notifications =
+      (intnat *)lwt_unix_malloc(notification_count * sizeof(intnat));
 }
 
-static void resize_notifications()
-{
+static void resize_notifications() {
   long new_notification_count = notification_count * 2;
-  intnat *new_notifications = (intnat*)lwt_unix_malloc(new_notification_count * sizeof(intnat));
-  memcpy((void*)new_notifications, (void*)notifications, notification_count * sizeof(intnat));
+  intnat *new_notifications =
+      (intnat *)lwt_unix_malloc(new_notification_count * sizeof(intnat));
+  memcpy((void *)new_notifications, (void *)notifications,
+         notification_count * sizeof(intnat));
   free(notifications);
   notifications = new_notifications;
   notification_count = new_notification_count;
 }
 
-void lwt_unix_send_notification(intnat id)
-{
+void lwt_unix_send_notification(intnat id) {
   int ret;
 #if !defined(LWT_ON_WINDOWS)
   sigset_t new_mask;
@@ -557,9 +522,9 @@ void lwt_unix_send_notification(intnat id)
     if (ret == SOCKET_ERROR) {
       error = WSAGetLastError();
       if (error != WSANOTINITIALISED) {
-	lwt_unix_mutex_unlock(&notification_mutex);
-	win32_maperr(error);
-	uerror("send_notification", Nothing);
+        lwt_unix_mutex_unlock(&notification_mutex);
+        win32_maperr(error);
+        uerror("send_notification", Nothing);
       } /* else we're probably shutting down, so ignore the error */
     }
 #else
@@ -577,14 +542,12 @@ void lwt_unix_send_notification(intnat id)
 #endif
 }
 
-value lwt_unix_send_notification_stub(value id)
-{
+value lwt_unix_send_notification_stub(value id) {
   lwt_unix_send_notification(Long_val(id));
   return Val_unit;
 }
 
-value lwt_unix_recv_notifications()
-{
+value lwt_unix_recv_notifications() {
   int ret, i, current_index;
   value result;
 #if !defined(LWT_ON_WINDOWS)
@@ -627,8 +590,7 @@ value lwt_unix_recv_notifications()
     result = caml_alloc_tuple(current_index);
     lwt_unix_mutex_lock(&notification_mutex);
     /* check that no new notifications appeared meanwhile (rare) */
-  }
-  while (current_index != notification_index);
+  } while (current_index != notification_index);
 
   /* Read all pending notifications. */
   for (i = 0; i < notification_index; i++)
@@ -644,12 +606,11 @@ value lwt_unix_recv_notifications()
 
 #if defined(LWT_ON_WINDOWS)
 
-static SOCKET set_close_on_exec(SOCKET socket)
-{
+static SOCKET set_close_on_exec(SOCKET socket) {
   SOCKET new_socket;
-  if (!DuplicateHandle(GetCurrentProcess(), (HANDLE)socket,
-                       GetCurrentProcess(), (HANDLE*)&new_socket,
-                       0L, FALSE, DUPLICATE_SAME_ACCESS)) {
+  if (!DuplicateHandle(GetCurrentProcess(), (HANDLE)socket, GetCurrentProcess(),
+                       (HANDLE *)&new_socket, 0L, FALSE,
+                       DUPLICATE_SAME_ACCESS)) {
     win32_maperr(GetLastError());
     uerror("set_close_on_exec", Nothing);
   }
@@ -659,36 +620,33 @@ static SOCKET set_close_on_exec(SOCKET socket)
 
 static SOCKET socket_r, socket_w;
 
-static int windows_notification_send()
-{
+static int windows_notification_send() {
   char buf = '!';
   return send(socket_w, &buf, 1, 0);
 }
 
-static int windows_notification_recv()
-{
+static int windows_notification_recv() {
   char buf;
   return recv(socket_r, &buf, 1, 0);
 }
 
-value lwt_unix_init_notification()
-{
+value lwt_unix_init_notification() {
   SOCKET sockets[2];
 
   switch (notification_mode) {
-  case NOTIFICATION_MODE_NOT_INITIALIZED:
-    notification_mode = NOTIFICATION_MODE_NONE;
-    init_notifications();
-    break;
-  case NOTIFICATION_MODE_WINDOWS:
-    notification_mode = NOTIFICATION_MODE_NONE;
-    closesocket(socket_r);
-    closesocket(socket_w);
-    break;
-  case NOTIFICATION_MODE_NONE:
-    break;
-  default:
-    caml_failwith("notification system in unknown state");
+    case NOTIFICATION_MODE_NOT_INITIALIZED:
+      notification_mode = NOTIFICATION_MODE_NONE;
+      init_notifications();
+      break;
+    case NOTIFICATION_MODE_WINDOWS:
+      notification_mode = NOTIFICATION_MODE_NONE;
+      closesocket(socket_r);
+      closesocket(socket_w);
+      break;
+    case NOTIFICATION_MODE_NONE:
+      break;
+    default:
+      caml_failwith("notification system in unknown state");
   }
 
   /* Since pipes do not works with select, we need to use a pair of
@@ -705,8 +663,7 @@ value lwt_unix_init_notification()
 
 #else /* defined(LWT_ON_WINDOWS) */
 
-static void set_close_on_exec(int fd)
-{
+static void set_close_on_exec(int fd) {
   int flags = fcntl(fd, F_GETFD, 0);
   if (flags == -1 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1)
     uerror("set_close_on_exec", Nothing);
@@ -716,56 +673,51 @@ static void set_close_on_exec(int fd)
 
 static int notification_fd;
 
-static int eventfd_notification_send()
-{
+static int eventfd_notification_send() {
   uint64_t buf = 1;
-  return write(notification_fd, (char*)&buf, 8);
+  return write(notification_fd, (char *)&buf, 8);
 }
 
-static int eventfd_notification_recv()
-{
+static int eventfd_notification_recv() {
   uint64_t buf;
-  return read(notification_fd, (char*)&buf, 8);
+  return read(notification_fd, (char *)&buf, 8);
 }
 
 #endif /* defined(HAVE_EVENTFD) */
 
 static int notification_fds[2];
 
-static int pipe_notification_send()
-{
+static int pipe_notification_send() {
   char buf;
   return write(notification_fds[1], &buf, 1);
 }
 
-static int pipe_notification_recv()
-{
+static int pipe_notification_recv() {
   char buf;
   return read(notification_fds[0], &buf, 1);
 }
 
-value lwt_unix_init_notification()
-{
+value lwt_unix_init_notification() {
   switch (notification_mode) {
 #if defined(HAVE_EVENTFD)
-  case NOTIFICATION_MODE_EVENTFD:
-    notification_mode = NOTIFICATION_MODE_NONE;
-    if (close(notification_fd) == -1) uerror("close", Nothing);
-    break;
+    case NOTIFICATION_MODE_EVENTFD:
+      notification_mode = NOTIFICATION_MODE_NONE;
+      if (close(notification_fd) == -1) uerror("close", Nothing);
+      break;
 #endif
-  case NOTIFICATION_MODE_PIPE:
-    notification_mode = NOTIFICATION_MODE_NONE;
-    if (close(notification_fds[0]) == -1) uerror("close", Nothing);
-    if (close(notification_fds[1]) == -1) uerror("close", Nothing);
-    break;
-  case NOTIFICATION_MODE_NOT_INITIALIZED:
-    notification_mode = NOTIFICATION_MODE_NONE;
-    init_notifications();
-    break;
-  case NOTIFICATION_MODE_NONE:
-    break;
-  default:
-    caml_failwith("notification system in unknown state");
+    case NOTIFICATION_MODE_PIPE:
+      notification_mode = NOTIFICATION_MODE_NONE;
+      if (close(notification_fds[0]) == -1) uerror("close", Nothing);
+      if (close(notification_fds[1]) == -1) uerror("close", Nothing);
+      break;
+    case NOTIFICATION_MODE_NOT_INITIALIZED:
+      notification_mode = NOTIFICATION_MODE_NONE;
+      init_notifications();
+      break;
+    case NOTIFICATION_MODE_NONE:
+      break;
+    default:
+      caml_failwith("notification system in unknown state");
   }
 
 #if defined(HAVE_EVENTFD)
@@ -801,11 +753,10 @@ value lwt_unix_init_notification()
 /* Notifications id for each monitored signal. */
 static intnat signal_notifications[NSIG];
 
-CAMLextern int caml_convert_signal_number (int);
+CAMLextern int caml_convert_signal_number(int);
 
 /* Send a notification when a signal is received. */
-static void handle_signal(int signum)
-{
+static void handle_signal(int signum) {
   if (signum >= 0 && signum < NSIG) {
     intnat id = signal_notifications[signum];
     if (id != -1) {
@@ -821,18 +772,17 @@ static void handle_signal(int signum)
 
 #if defined(LWT_ON_WINDOWS)
 /* Handle Ctrl+C on windows. */
-static BOOL WINAPI handle_break(DWORD event)
-{
+static BOOL WINAPI handle_break(DWORD event) {
   intnat id = signal_notifications[SIGINT];
-  if (id == -1 || (event != CTRL_C_EVENT && event != CTRL_BREAK_EVENT)) return FALSE;
+  if (id == -1 || (event != CTRL_C_EVENT && event != CTRL_BREAK_EVENT))
+    return FALSE;
   lwt_unix_send_notification(id);
   return TRUE;
 }
 #endif
 
 /* Install a signal handler. */
-CAMLprim value lwt_unix_set_signal(value val_signum, value val_notification)
-{
+CAMLprim value lwt_unix_set_signal(value val_signum, value val_notification) {
 #if !defined(LWT_ON_WINDOWS)
   struct sigaction sa;
 #endif
@@ -870,8 +820,7 @@ CAMLprim value lwt_unix_set_signal(value val_signum, value val_notification)
 }
 
 /* Remove a signal handler. */
-CAMLprim value lwt_unix_remove_signal(value val_signum)
-{
+CAMLprim value lwt_unix_remove_signal(value val_signum) {
 #if !defined(LWT_ON_WINDOWS)
   struct sigaction sa;
 #endif
@@ -894,11 +843,9 @@ CAMLprim value lwt_unix_remove_signal(value val_signum)
 }
 
 /* Mark all signals as non-monitored. */
-CAMLprim value lwt_unix_init_signals(value Unit)
-{
+CAMLprim value lwt_unix_init_signals(value Unit) {
   int i;
-  for (i = 0; i < NSIG; i++)
-    signal_notifications[i] = -1;
+  for (i = 0; i < NSIG; i++) signal_notifications[i] = -1;
   return Val_unit;
 }
 
@@ -907,8 +854,7 @@ CAMLprim value lwt_unix_init_signals(value Unit)
    +-----------------------------------------------------------------+ */
 
 /* Execute the given job. */
-static void execute_job(lwt_unix_job job)
-{
+static void execute_job(lwt_unix_job job) {
   DEBUG("executing the job");
 
   lwt_unix_mutex_lock(&job->mutex);
@@ -1034,8 +980,7 @@ static struct stack_frame *blocking_call_frame = NULL;
 static int stack_allocated;
 
 /* Function executed on an alternative stack. */
-static void altstack_worker()
-{
+static void altstack_worker() {
   struct stack_frame *node;
   sigjmp_buf buf;
 
@@ -1046,7 +991,6 @@ static void altstack_worker()
   node = lwt_unix_new(struct stack_frame);
 
   if (sigsetjmp(node->checkpoint, 1) == 0) {
-
     /* Add it to the list of available stack frames. */
     lwt_unix_mutex_lock(&blocking_call_enter_mutex);
     node->next = blocking_call_enter;
@@ -1054,7 +998,6 @@ static void altstack_worker()
     lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
 
   } else {
-
     /* Save the job to execute and the current stack frame before
        another thread can become the main thread. */
     lwt_unix_job job = blocking_call;
@@ -1118,8 +1061,7 @@ static void altstack_worker()
 }
 
 /* Allocate a new stack for doing blocking calls. */
-void alloc_new_stack()
-{
+void alloc_new_stack() {
   DEBUG("allocate a new stack");
 
   stack_t old_stack, new_stack;
@@ -1161,8 +1103,7 @@ void alloc_new_stack()
 static int threading_initialized = 0;
 
 /* Initialize the pool of thread. */
-void initialize_threading()
-{
+void initialize_threading() {
   if (threading_initialized == 0) {
     lwt_unix_mutex_init(&pool_mutex);
     lwt_unix_condition_init(&pool_condition);
@@ -1181,8 +1122,7 @@ void initialize_threading()
    +-----------------------------------------------------------------+ */
 
 /* Function executed by threads of the pool. */
-static void* worker_loop(void *data)
-{
+static void *worker_loop(void *data) {
   lwt_unix_job job = (lwt_unix_job)data;
 #if defined(LWT_UNIX_HAVE_ASYNC_SWITCH)
   struct stack_frame *node;
@@ -1209,7 +1149,7 @@ static void* worker_loop(void *data)
 
     DEBUG("waiting for something to do");
 
-    /* Wait for something to do. */
+/* Wait for something to do. */
 #if defined(LWT_UNIX_HAVE_ASYNC_SWITCH)
     while (pool_queue == NULL && main_state == STATE_RUNNING)
       lwt_unix_condition_wait(&pool_condition, &pool_mutex);
@@ -1254,7 +1194,7 @@ static void* worker_loop(void *data)
       DEBUG("transformation to worker done");
 
       /* This thread is not running caml code anymore. */
-      //caml_c_thread_unregister();
+      // caml_c_thread_unregister();
 
       /* Release this mutex. It was locked before the jump. */
       lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
@@ -1290,33 +1230,25 @@ static void* worker_loop(void *data)
 
 /* Description of jobs. */
 struct custom_operations job_ops = {
-  "lwt.unix.job",
-  custom_finalize_default,
-  custom_compare_default,
-  custom_hash_default,
-  custom_serialize_default,
-  custom_deserialize_default
-};
+    "lwt.unix.job",      custom_finalize_default,  custom_compare_default,
+    custom_hash_default, custom_serialize_default, custom_deserialize_default};
 
 /* Get the job structure contained in a custom value. */
-#define Job_val(v) *(lwt_unix_job*)Data_custom_val(v)
+#define Job_val(v) *(lwt_unix_job *)Data_custom_val(v)
 
-value lwt_unix_alloc_job(lwt_unix_job job)
-{
+value lwt_unix_alloc_job(lwt_unix_job job) {
   value val_job = caml_alloc_custom(&job_ops, sizeof(lwt_unix_job), 0, 1);
   Job_val(val_job) = job;
   return val_job;
 }
 
-void lwt_unix_free_job(lwt_unix_job job)
-{
+void lwt_unix_free_job(lwt_unix_job job) {
   if (job->async_method != LWT_UNIX_ASYNC_METHOD_NONE)
     lwt_unix_mutex_destroy(&job->mutex);
   free(job);
 }
 
-CAMLprim value lwt_unix_start_job(value val_job, value val_async_method)
-{
+CAMLprim value lwt_unix_start_job(value val_job, value val_async_method) {
   lwt_unix_job job = Job_val(val_job);
 #if defined(LWT_UNIX_HAVE_ASYNC_SWITCH)
   struct stack_frame *node;
@@ -1326,7 +1258,8 @@ CAMLprim value lwt_unix_start_job(value val_job, value val_async_method)
 
   /* Fallback to synchronous call if there is no worker available and
      we can not launch more threads. */
-  if (async_method != LWT_UNIX_ASYNC_METHOD_NONE && thread_waiting_count == 0 && thread_count >= pool_size)
+  if (async_method != LWT_UNIX_ASYNC_METHOD_NONE && thread_waiting_count == 0 &&
+      thread_count >= pool_size)
     async_method = LWT_UNIX_ASYNC_METHOD_NONE;
 
   /* Initialises job parameters. */
@@ -1335,168 +1268,164 @@ CAMLprim value lwt_unix_start_job(value val_job, value val_async_method)
   job->async_method = async_method;
 
   switch (async_method) {
-
-  case LWT_UNIX_ASYNC_METHOD_NONE:
-    /* Execute the job synchronously. */
-    caml_enter_blocking_section();
-    job->worker(job);
-    caml_leave_blocking_section();
-    return Val_true;
-
-  case LWT_UNIX_ASYNC_METHOD_DETACH:
-    if (threading_initialized == 0) initialize_threading();
-
-    lwt_unix_mutex_init(&job->mutex);
-
-    lwt_unix_mutex_lock(&pool_mutex);
-    if (thread_waiting_count == 0) {
-      /* Launch a new worker. */
-      thread_count++;
-      lwt_unix_mutex_unlock(&pool_mutex);
-      lwt_unix_launch_thread(worker_loop, (void*)job);
-    } else {
-      /* Add the job at the end of the queue. */
-      if (pool_queue == NULL) {
-        pool_queue = job;
-        job->next = job;
-      } else {
-        job->next = pool_queue->next;
-        pool_queue->next = job;
-        pool_queue = job;
-      }
-      /* Wakeup one worker. */
-      lwt_unix_condition_signal(&pool_condition);
-      lwt_unix_mutex_unlock(&pool_mutex);
-    }
-
-    done = job->state == LWT_UNIX_JOB_STATE_DONE;
-    if (done) {
-      /* Wait for the mutex to be released because the job is going to
-         be freed immediately. */
-      lwt_unix_mutex_lock(&job->mutex);
-      lwt_unix_mutex_unlock(&job->mutex);
-    }
-
-    return Val_bool(done);
-
-  case LWT_UNIX_ASYNC_METHOD_SWITCH:
-#if defined(LWT_UNIX_SIGNAL_ASYNC_SWITCH)
-    if (SIGRTMIN > SIGRTMAX) caml_invalid_argument("the switch method is not supported");
-
-    if (threading_initialized == 0) initialize_threading();
-
-    lwt_unix_mutex_init(&job->mutex);
-    job->thread = main_thread;
-
-    /* Ensures there is at least one thread that can become the main
-       thread. */
-    if (thread_waiting_count == 0) {
-      thread_count++;
-      lwt_unix_launch_thread(worker_loop, NULL);
-    }
-
-    if (blocking_call_enter == NULL) alloc_new_stack();
-
-    DEBUG("taking a stack frame for doing a blocking call");
-
-    /* Take and remove the first available stack frame for system
-       calls. */
-    lwt_unix_mutex_lock(&blocking_call_enter_mutex);
-    assert(blocking_call_enter != NULL);
-    node = blocking_call_enter;
-    blocking_call_enter = node->next;
-    lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
-
-    /* Save the stack frame to leave the blocking call. */
-    switch (sigsetjmp(blocking_call_leave, 1)) {
-    case 0:
-      /* Save the job to do. */
-      blocking_call = job;
-
-      /* Save the stack frame that will be used for this call in case
-         it get scheduled. */
-      blocking_call_frame = node;
-
-      DEBUG("jumping to do a blocking call");
-
-      /* Jump to an alternative stack and do the call. */
-      siglongjmp(node->checkpoint, 1);
-
-    case CALL_SUCCEEDED:
-      DEBUG("resuming without being scheduled");
-
-      /* Re-add the stack frame used for the call to the list of
-         available ones. */
-      lwt_unix_mutex_lock(&blocking_call_enter_mutex);
-      node->next = blocking_call_enter;
-      blocking_call_enter = node;
-      lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
+    case LWT_UNIX_ASYNC_METHOD_NONE:
+      /* Execute the job synchronously. */
+      caml_enter_blocking_section();
+      job->worker(job);
+      caml_leave_blocking_section();
       return Val_true;
 
-    case CALL_SCHEDULED:
-      DEBUG("resuming after being scheduled");
+    case LWT_UNIX_ASYNC_METHOD_DETACH:
+      if (threading_initialized == 0) initialize_threading();
 
-      /* This mutex was locked before we did the jump. */
-      lwt_unix_mutex_unlock(&pool_mutex);
+      lwt_unix_mutex_init(&job->mutex);
 
-      /* This thread is now running caml code. */
-      //caml_c_thread_register();
+      lwt_unix_mutex_lock(&pool_mutex);
+      if (thread_waiting_count == 0) {
+        /* Launch a new worker. */
+        thread_count++;
+        lwt_unix_mutex_unlock(&pool_mutex);
+        lwt_unix_launch_thread(worker_loop, (void *)job);
+      } else {
+        /* Add the job at the end of the queue. */
+        if (pool_queue == NULL) {
+          pool_queue = job;
+          job->next = job;
+        } else {
+          job->next = pool_queue->next;
+          pool_queue->next = job;
+          pool_queue = job;
+        }
+        /* Wakeup one worker. */
+        lwt_unix_condition_signal(&pool_condition);
+        lwt_unix_mutex_unlock(&pool_mutex);
+      }
 
       done = job->state == LWT_UNIX_JOB_STATE_DONE;
       if (done) {
+        /* Wait for the mutex to be released because the job is going to
+           be freed immediately. */
         lwt_unix_mutex_lock(&job->mutex);
         lwt_unix_mutex_unlock(&job->mutex);
       }
 
       return Val_bool(done);
-    }
+
+    case LWT_UNIX_ASYNC_METHOD_SWITCH:
+#if defined(LWT_UNIX_SIGNAL_ASYNC_SWITCH)
+      if (SIGRTMIN > SIGRTMAX)
+        caml_invalid_argument("the switch method is not supported");
+
+      if (threading_initialized == 0) initialize_threading();
+
+      lwt_unix_mutex_init(&job->mutex);
+      job->thread = main_thread;
+
+      /* Ensures there is at least one thread that can become the main
+         thread. */
+      if (thread_waiting_count == 0) {
+        thread_count++;
+        lwt_unix_launch_thread(worker_loop, NULL);
+      }
+
+      if (blocking_call_enter == NULL) alloc_new_stack();
+
+      DEBUG("taking a stack frame for doing a blocking call");
+
+      /* Take and remove the first available stack frame for system
+         calls. */
+      lwt_unix_mutex_lock(&blocking_call_enter_mutex);
+      assert(blocking_call_enter != NULL);
+      node = blocking_call_enter;
+      blocking_call_enter = node->next;
+      lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
+
+      /* Save the stack frame to leave the blocking call. */
+      switch (sigsetjmp(blocking_call_leave, 1)) {
+        case 0:
+          /* Save the job to do. */
+          blocking_call = job;
+
+          /* Save the stack frame that will be used for this call in case
+             it get scheduled. */
+          blocking_call_frame = node;
+
+          DEBUG("jumping to do a blocking call");
+
+          /* Jump to an alternative stack and do the call. */
+          siglongjmp(node->checkpoint, 1);
+
+        case CALL_SUCCEEDED:
+          DEBUG("resuming without being scheduled");
+
+          /* Re-add the stack frame used for the call to the list of
+             available ones. */
+          lwt_unix_mutex_lock(&blocking_call_enter_mutex);
+          node->next = blocking_call_enter;
+          blocking_call_enter = node;
+          lwt_unix_mutex_unlock(&blocking_call_enter_mutex);
+          return Val_true;
+
+        case CALL_SCHEDULED:
+          DEBUG("resuming after being scheduled");
+
+          /* This mutex was locked before we did the jump. */
+          lwt_unix_mutex_unlock(&pool_mutex);
+
+          /* This thread is now running caml code. */
+          // caml_c_thread_register();
+
+          done = job->state == LWT_UNIX_JOB_STATE_DONE;
+          if (done) {
+            lwt_unix_mutex_lock(&job->mutex);
+            lwt_unix_mutex_unlock(&job->mutex);
+          }
+
+          return Val_bool(done);
+      }
 
 #else /* defined(LWT_UNIX_SIGNAL_ASYNC_SWITCH) */
-    caml_invalid_argument("the switch method is not supported");
+      caml_invalid_argument("the switch method is not supported");
 #endif
   }
 
   return Val_false;
 }
 
-CAMLprim value lwt_unix_check_job(value val_job, value val_notification_id)
-{
+CAMLprim value lwt_unix_check_job(value val_job, value val_notification_id) {
   lwt_unix_job job = Job_val(val_job);
   value result;
 
   DEBUG("checking job");
 
   switch (job->async_method) {
+    case LWT_UNIX_ASYNC_METHOD_NONE:
+      return Val_int(1);
 
-  case LWT_UNIX_ASYNC_METHOD_NONE:
-    return Val_int(1);
+    case LWT_UNIX_ASYNC_METHOD_DETACH:
+    case LWT_UNIX_ASYNC_METHOD_SWITCH:
+      lwt_unix_mutex_lock(&job->mutex);
+      /* We are not waiting anymore. */
+      job->fast = 0;
+      /* Set the notification id for asynchronous wakeup. */
+      job->notification_id = Long_val(val_notification_id);
+      result = Val_bool(job->state == LWT_UNIX_JOB_STATE_DONE);
+      lwt_unix_mutex_unlock(&job->mutex);
 
-  case LWT_UNIX_ASYNC_METHOD_DETACH:
-  case LWT_UNIX_ASYNC_METHOD_SWITCH:
-    lwt_unix_mutex_lock(&job->mutex);
-    /* We are not waiting anymore. */
-    job->fast = 0;
-    /* Set the notification id for asynchronous wakeup. */
-    job->notification_id = Long_val(val_notification_id);
-    result = Val_bool(job->state == LWT_UNIX_JOB_STATE_DONE);
-    lwt_unix_mutex_unlock(&job->mutex);
+      DEBUG("job done: %d", Int_val(result));
 
-    DEBUG("job done: %d", Int_val(result));
-
-    return result;
+      return result;
   }
 
   return Val_int(0);
 }
 
-CAMLprim value lwt_unix_self_result(value val_job)
-{
+CAMLprim value lwt_unix_self_result(value val_job) {
   lwt_unix_job job = Job_val(val_job);
   return job->result(job);
 }
 
-CAMLprim value lwt_unix_run_job_sync(value val_job)
-{
+CAMLprim value lwt_unix_run_job_sync(value val_job) {
   lwt_unix_job job = Job_val(val_job);
   /* So lwt_unix_free_job won't try to destroy the mutex. */
   job->async_method = LWT_UNIX_ASYNC_METHOD_NONE;
@@ -1506,12 +1435,11 @@ CAMLprim value lwt_unix_run_job_sync(value val_job)
   return job->result(job);
 }
 
-CAMLprim value lwt_unix_reset_after_fork(value Unit)
-{
+CAMLprim value lwt_unix_reset_after_fork(value Unit) {
   if (threading_initialized) {
 #if defined(LWT_UNIX_HAVE_ASYNC_SWITCH)
     /* Reset the main thread. */
-    main_thread = lwt_unix_thread_self ();
+    main_thread = lwt_unix_thread_self();
 #endif
 
     /* There is no more waiting threads. */
@@ -1531,23 +1459,17 @@ CAMLprim value lwt_unix_reset_after_fork(value Unit)
    | Statistics and control                                          |
    +-----------------------------------------------------------------+ */
 
-CAMLprim value lwt_unix_pool_size(value Unit)
-{
-  return Val_int(pool_size);
-}
+CAMLprim value lwt_unix_pool_size(value Unit) { return Val_int(pool_size); }
 
-CAMLprim value lwt_unix_set_pool_size(value val_size)
-{
+CAMLprim value lwt_unix_set_pool_size(value val_size) {
   pool_size = Int_val(val_size);
   return Val_unit;
 }
 
-CAMLprim value lwt_unix_thread_count(value Unit)
-{
+CAMLprim value lwt_unix_thread_count(value Unit) {
   return Val_int(thread_count);
 }
 
-CAMLprim value lwt_unix_thread_waiting_count(value Unit)
-{
+CAMLprim value lwt_unix_thread_waiting_count(value Unit) {
   return Val_int(thread_waiting_count);
 }

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -25,14 +25,14 @@
 
 #define ARGS(args...) args
 
-#include <caml/version.h>
 #include <caml/unixsupport.h>
+#include <caml/version.h>
+#include <poll.h>
+#include <sys/resource.h>
+#include <sys/time.h>
 #include <sys/uio.h>
 #include <sys/un.h>
-#include <sys/time.h>
-#include <sys/resource.h>
 #include <sys/wait.h>
-#include <poll.h>
 #include <unistd.h>
 
 /* +-----------------------------------------------------------------+
@@ -41,24 +41,22 @@
 
 CAMLprim value lwt_unix_readable(value fd)
 {
-  struct pollfd pollfd;
-  pollfd.fd = Int_val(fd);
-  pollfd.events = POLLIN;
-  pollfd.revents = 0;
-  if (poll(&pollfd, 1, 0) < 0)
-    uerror("readable", Nothing);
-  return (Val_bool(pollfd.revents & POLLIN));
+    struct pollfd pollfd;
+    pollfd.fd = Int_val(fd);
+    pollfd.events = POLLIN;
+    pollfd.revents = 0;
+    if (poll(&pollfd, 1, 0) < 0) uerror("readable", Nothing);
+    return (Val_bool(pollfd.revents & POLLIN));
 }
 
 CAMLprim value lwt_unix_writable(value fd)
 {
-  struct pollfd pollfd;
-  pollfd.fd = Int_val(fd);
-  pollfd.events = POLLOUT;
-  pollfd.revents = 0;
-  if (poll(&pollfd, 1, 0) < 0)
-    uerror("writable", Nothing);
-  return (Val_bool(pollfd.revents & POLLOUT));
+    struct pollfd pollfd;
+    pollfd.fd = Int_val(fd);
+    pollfd.events = POLLOUT;
+    pollfd.revents = 0;
+    if (poll(&pollfd, 1, 0) < 0) uerror("writable", Nothing);
+    return (Val_bool(pollfd.revents & POLLOUT));
 }
 
 /* +-----------------------------------------------------------------+
@@ -66,27 +64,24 @@ CAMLprim value lwt_unix_writable(value fd)
    +-----------------------------------------------------------------+ */
 
 static int advise_table[] = {
-  MADV_NORMAL,
-  MADV_RANDOM,
-  MADV_SEQUENTIAL,
-  MADV_WILLNEED,
-  MADV_DONTNEED,
+    MADV_NORMAL, MADV_RANDOM, MADV_SEQUENTIAL, MADV_WILLNEED, MADV_DONTNEED,
 };
 
-CAMLprim value lwt_unix_madvise (value val_buffer, value val_offset, value val_length, value val_advice)
+CAMLprim value lwt_unix_madvise(value val_buffer, value val_offset,
+                                value val_length, value val_advice)
 {
-  int ret = madvise((char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset),
-                    Long_val(val_length),
-                    advise_table[Int_val(val_advice)]);
-  if (ret == -1)  uerror("madvise", Nothing);
-  return Val_unit;
+    int ret =
+        madvise((char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset),
+                Long_val(val_length), advise_table[Int_val(val_advice)]);
+    if (ret == -1) uerror("madvise", Nothing);
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_get_page_size(value Unit)
 {
-  long page_size = sysconf(_SC_PAGESIZE);
-  if (page_size < 0) page_size = 4096;
-  return Val_long(page_size);
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0) page_size = 4096;
+    return Val_long(page_size);
 }
 
 #ifdef __CYGWIN__
@@ -94,20 +89,21 @@ LWT_NOT_AVAILABLE4(unix_mincore)
 #else
 
 #ifdef HAVE_BSD_MINCORE
-#   define MINCORE_VECTOR_TYPE char
+#define MINCORE_VECTOR_TYPE char
 #else
-#   define MINCORE_VECTOR_TYPE unsigned char
+#define MINCORE_VECTOR_TYPE unsigned char
 #endif
 
-CAMLprim value lwt_unix_mincore(value val_buffer, value val_offset, value val_length, value val_states)
+CAMLprim value lwt_unix_mincore(value val_buffer, value val_offset,
+                                value val_length, value val_states)
 {
-  long len = Wosize_val(val_states);
-  MINCORE_VECTOR_TYPE vec[len];
-  mincore((char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset), Long_val(val_length), vec);
-  long i;
-  for (i = 0; i < len; i++)
-    Field(val_states, i) = Val_bool(vec[i] & 1);
-  return Val_unit;
+    long len = Wosize_val(val_states);
+    MINCORE_VECTOR_TYPE vec[len];
+    mincore((char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset),
+            Long_val(val_length), vec);
+    long i;
+    for (i = 0; i < len; i++) Field(val_states, i) = Val_bool(vec[i] & 1);
+    return Val_unit;
 }
 
 #undef MINCORE_VECTOR_TYPE
@@ -118,39 +114,47 @@ CAMLprim value lwt_unix_mincore(value val_buffer, value val_offset, value val_le
    | read/write                                                      |
    +-----------------------------------------------------------------+ */
 
-CAMLprim value lwt_unix_read(value val_fd, value val_buf, value val_ofs, value val_len)
+CAMLprim value lwt_unix_read(value val_fd, value val_buf, value val_ofs,
+                             value val_len)
 {
-  long ret;
-  ret = read(Int_val(val_fd), &Byte(String_val(val_buf), Long_val(val_ofs)), Long_val(val_len));
-  if (ret == -1) uerror("read", Nothing);
-  return Val_long(ret);
+    long ret;
+    ret = read(Int_val(val_fd), &Byte(String_val(val_buf), Long_val(val_ofs)),
+               Long_val(val_len));
+    if (ret == -1) uerror("read", Nothing);
+    return Val_long(ret);
 }
 
-CAMLprim value lwt_unix_bytes_read(value val_fd, value val_buf, value val_ofs, value val_len)
+CAMLprim value lwt_unix_bytes_read(value val_fd, value val_buf, value val_ofs,
+                                   value val_len)
 {
-  long ret;
-  ret = read(Int_val(val_fd), (char*)Caml_ba_array_val(val_buf)->data + Long_val(val_ofs), Long_val(val_len));
-  if (ret == -1) uerror("read", Nothing);
-  return Val_long(ret);
+    long ret;
+    ret = read(Int_val(val_fd),
+               (char *)Caml_ba_array_val(val_buf)->data + Long_val(val_ofs),
+               Long_val(val_len));
+    if (ret == -1) uerror("read", Nothing);
+    return Val_long(ret);
 }
 
-CAMLprim value lwt_unix_write(value val_fd, value val_buf, value val_ofs, value val_len)
+CAMLprim value lwt_unix_write(value val_fd, value val_buf, value val_ofs,
+                              value val_len)
 {
-  long ret;
-  ret = write(Int_val(val_fd), &Byte(String_val(val_buf), Long_val(val_ofs)), Long_val(val_len));
-  if (ret == -1) uerror("write", Nothing);
-  return Val_long(ret);
+    long ret;
+    ret = write(Int_val(val_fd), &Byte(String_val(val_buf), Long_val(val_ofs)),
+                Long_val(val_len));
+    if (ret == -1) uerror("write", Nothing);
+    return Val_long(ret);
 }
 
-CAMLprim value lwt_unix_bytes_write(value val_fd, value val_buf, value val_ofs, value val_len)
+CAMLprim value lwt_unix_bytes_write(value val_fd, value val_buf, value val_ofs,
+                                    value val_len)
 {
-  long ret;
-  ret = write(Int_val(val_fd), (char*)Caml_ba_array_val(val_buf)->data + Long_val(val_ofs), Long_val(val_len));
-  if (ret == -1) uerror("write", Nothing);
-  return Val_long(ret);
+    long ret;
+    ret = write(Int_val(val_fd),
+                (char *)Caml_ba_array_val(val_buf)->data + Long_val(val_ofs),
+                Long_val(val_len));
+    if (ret == -1) uerror("write", Nothing);
+    return Val_long(ret);
 }
-
-
 
 /* readv, writev */
 
@@ -169,7 +173,7 @@ struct readv_copy_to {
 
 /* Tags for each of the constructors of type Lwt_unix.IO_vectors._buffer. The
    order must correspond to that in lwt_unix.ml. */
-enum {IO_vectors_bytes, IO_vectors_bigarray};
+enum { IO_vectors_bytes, IO_vectors_bigarray };
 
 /* Given an uninitialized array of iovec structures `iovecs`, and an OCaml value
    `io_vectors` of type Lwt_unix.IO_vectors._io_vector list, writes pointers to
@@ -190,9 +194,9 @@ enum {IO_vectors_bytes, IO_vectors_bigarray};
    a temporary buffer for each OCaml bytes buffer. Pointers to the buffers are
    stored in `read_buffers`, together with GC roots for the corresponding OCaml
    buffers. */
-static void flatten_io_vectors(
-    struct iovec *iovecs, value io_vectors, size_t count, char **buffer_copies,
-    struct readv_copy_to *read_buffers)
+static void flatten_io_vectors(struct iovec *iovecs, value io_vectors,
+                               size_t count, char **buffer_copies,
+                               struct readv_copy_to *read_buffers)
 {
     CAMLparam1(io_vectors);
     CAMLlocal3(node, io_vector, buffer);
@@ -202,7 +206,6 @@ static void flatten_io_vectors(
 
     for (node = io_vectors, index = 0; index < count;
          node = Field(node, 1), ++index) {
-
         io_vector = Field(node, 0);
 
         intnat offset = Long_val(Field(io_vector, 1));
@@ -214,14 +217,12 @@ static void flatten_io_vectors(
         if (Tag_val(Field(io_vector, 0)) == IO_vectors_bytes) {
             if (buffer_copies != NULL) {
                 buffer_copies[copy_index] = lwt_unix_malloc(length);
-                memcpy(
-                    buffer_copies[copy_index],
-                    &Byte(String_val(buffer), offset), length);
+                memcpy(buffer_copies[copy_index],
+                       &Byte(String_val(buffer), offset), length);
 
                 iovecs[index].iov_base = buffer_copies[copy_index];
                 ++copy_index;
-            }
-            else if (read_buffers != NULL) {
+            } else if (read_buffers != NULL) {
                 read_buffers[copy_index].temporary_buffer =
                     lwt_unix_malloc(length);
                 read_buffers[copy_index].length = length;
@@ -233,27 +234,20 @@ static void flatten_io_vectors(
                 iovecs[index].iov_base =
                     read_buffers[copy_index].temporary_buffer;
                 ++copy_index;
-            }
-            else
+            } else
                 iovecs[index].iov_base = &Byte(String_val(buffer), offset);
-        }
-        else
-            iovecs[index].iov_base = &((char*)Caml_ba_data_val(buffer))[offset];
+        } else
+            iovecs[index].iov_base =
+                &((char *)Caml_ba_data_val(buffer))[offset];
     }
 
-    if (buffer_copies != NULL)
-        buffer_copies[copy_index] = NULL;
-    if (read_buffers != NULL)
-        read_buffers[copy_index].temporary_buffer = NULL;
+    if (buffer_copies != NULL) buffer_copies[copy_index] = NULL;
+    if (read_buffers != NULL) read_buffers[copy_index].temporary_buffer = NULL;
 
     CAMLreturn0;
 }
 
-CAMLprim value lwt_unix_iov_max(value unit)
-{
-    return Val_int(IOV_MAX);
-}
-
+CAMLprim value lwt_unix_iov_max(value unit) { return Val_int(IOV_MAX); }
 /* writev */
 
 /* writev primitive for non-blocking file descriptors. */
@@ -269,8 +263,7 @@ CAMLprim value lwt_unix_writev(value fd, value io_vectors, value val_count)
 
     ssize_t result = writev(Int_val(fd), iovecs, count);
 
-    if (result == -1)
-        uerror("writev", Nothing);
+    if (result == -1) uerror("writev", Nothing);
 
     CAMLreturn(Val_long(result));
 }
@@ -300,7 +293,6 @@ static value result_writev(struct job_writev *job)
     char **buffer_copy;
     for (buffer_copy = job->buffer_copies; *buffer_copy != NULL;
          ++buffer_copy) {
-
         free(*buffer_copy);
     }
     free(job->buffer_copies);
@@ -324,9 +316,9 @@ CAMLprim value lwt_unix_writev_job(value fd, value io_vectors, value val_count)
     job->iovecs = lwt_unix_malloc(job->count * sizeof(struct iovec));
     /* The extra (+ 1) pointer is for the NULL terminator, in case all buffer
        slices are in bytes buffers. */
-    job->buffer_copies = lwt_unix_malloc((job->count + 1) * sizeof(char*));
-    flatten_io_vectors(
-        job->iovecs, io_vectors, job->count, job->buffer_copies, NULL);
+    job->buffer_copies = lwt_unix_malloc((job->count + 1) * sizeof(char *));
+    flatten_io_vectors(job->iovecs, io_vectors, job->count, job->buffer_copies,
+                       NULL);
 
     CAMLreturn(lwt_unix_alloc_job(&job->job));
 }
@@ -348,8 +340,7 @@ CAMLprim value lwt_unix_readv(value fd, value io_vectors, value val_count)
        afterwards. */
     ssize_t result = readv(Int_val(fd), iovecs, count);
 
-    if (result == -1)
-      uerror("readv", Nothing);
+    if (result == -1) uerror("readv", Nothing);
 
     CAMLreturn(Val_long(result));
 }
@@ -384,19 +375,15 @@ static value result_readv(struct job_readv *job)
     if (job->result != -1) {
         for (read_buffer = job->buffers; read_buffer->temporary_buffer != NULL;
              ++read_buffer) {
-
-            memcpy(
-                &Byte(String_val(read_buffer->caml_buffer),
-                      read_buffer->offset),
-                read_buffer->temporary_buffer,
-                read_buffer->length);
+            memcpy(&Byte(String_val(read_buffer->caml_buffer),
+                         read_buffer->offset),
+                   read_buffer->temporary_buffer, read_buffer->length);
         }
     }
 
     /* Free heap-allocated structures and buffers. */
     for (read_buffer = job->buffers; read_buffer->temporary_buffer != NULL;
          ++read_buffer) {
-
         free(read_buffer->temporary_buffer);
         caml_remove_generational_global_root(&read_buffer->caml_buffer);
     }
@@ -428,50 +415,50 @@ CAMLprim value lwt_unix_readv_job(value fd, value io_vectors, value val_count)
     CAMLreturn(lwt_unix_alloc_job(&job->job));
 }
 
-
-
 /* +-----------------------------------------------------------------+
    | recv/send                                                       |
    +-----------------------------------------------------------------+ */
 
-static int msg_flag_table[] = {
-  MSG_OOB, MSG_DONTROUTE, MSG_PEEK
-};
+static int msg_flag_table[] = {MSG_OOB, MSG_DONTROUTE, MSG_PEEK};
 
 value lwt_unix_recv(value fd, value buf, value ofs, value len, value flags)
 {
-  int ret;
-  ret = recv(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)), Long_val(len),
-             caml_convert_flag_list(flags, msg_flag_table));
-  if (ret == -1) uerror("recv", Nothing);
-  return Val_int(ret);
+    int ret;
+    ret = recv(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)),
+               Long_val(len), caml_convert_flag_list(flags, msg_flag_table));
+    if (ret == -1) uerror("recv", Nothing);
+    return Val_int(ret);
 }
 
-value lwt_unix_bytes_recv(value fd, value buf, value ofs, value len, value flags)
+value lwt_unix_bytes_recv(value fd, value buf, value ofs, value len,
+                          value flags)
 {
-  int ret;
-  ret = recv(Int_val(fd), (char*)Caml_ba_array_val(buf)->data + Long_val(ofs), Long_val(len),
-             caml_convert_flag_list(flags, msg_flag_table));
-  if (ret == -1) uerror("recv", Nothing);
-  return Val_int(ret);
+    int ret;
+    ret =
+        recv(Int_val(fd), (char *)Caml_ba_array_val(buf)->data + Long_val(ofs),
+             Long_val(len), caml_convert_flag_list(flags, msg_flag_table));
+    if (ret == -1) uerror("recv", Nothing);
+    return Val_int(ret);
 }
 
 value lwt_unix_send(value fd, value buf, value ofs, value len, value flags)
 {
-  int ret;
-  ret = send(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)), Long_val(len),
-             caml_convert_flag_list(flags, msg_flag_table));
-  if (ret == -1) uerror("send", Nothing);
-  return Val_int(ret);
+    int ret;
+    ret = send(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)),
+               Long_val(len), caml_convert_flag_list(flags, msg_flag_table));
+    if (ret == -1) uerror("send", Nothing);
+    return Val_int(ret);
 }
 
-value lwt_unix_bytes_send(value fd, value buf, value ofs, value len, value flags)
+value lwt_unix_bytes_send(value fd, value buf, value ofs, value len,
+                          value flags)
 {
-  int ret;
-  ret = send(Int_val(fd), (char*)Caml_ba_array_val(buf)->data + Long_val(ofs), Long_val(len),
-             caml_convert_flag_list(flags, msg_flag_table));
-  if (ret == -1) uerror("send", Nothing);
-  return Val_int(ret);
+    int ret;
+    ret =
+        send(Int_val(fd), (char *)Caml_ba_array_val(buf)->data + Long_val(ofs),
+             Long_val(len), caml_convert_flag_list(flags, msg_flag_table));
+    if (ret == -1) uerror("send", Nothing);
+    return Val_int(ret);
 }
 
 /* +-----------------------------------------------------------------+
@@ -483,80 +470,84 @@ extern int socket_type_table[];
 
 value lwt_unix_recvfrom(value fd, value buf, value ofs, value len, value flags)
 {
-  CAMLparam5(fd, buf, ofs, len, flags);
-  CAMLlocal2(result, address);
-  int ret;
-  union sock_addr_union addr;
-  socklen_t addr_len;
-  addr_len = sizeof(addr);
-  ret = recvfrom(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)), Long_val(len),
-                 caml_convert_flag_list(flags, msg_flag_table),
-                 &addr.s_gen, &addr_len);
-  if (ret == -1) uerror("recvfrom", Nothing);
-  address = alloc_sockaddr(&addr, addr_len, -1);
-  result = caml_alloc_tuple(2);
-  Field(result, 0) = Val_int(ret);
-  Field(result, 1) = address;
-  CAMLreturn(result);
+    CAMLparam5(fd, buf, ofs, len, flags);
+    CAMLlocal2(result, address);
+    int ret;
+    union sock_addr_union addr;
+    socklen_t addr_len;
+    addr_len = sizeof(addr);
+    ret = recvfrom(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)),
+                   Long_val(len), caml_convert_flag_list(flags, msg_flag_table),
+                   &addr.s_gen, &addr_len);
+    if (ret == -1) uerror("recvfrom", Nothing);
+    address = alloc_sockaddr(&addr, addr_len, -1);
+    result = caml_alloc_tuple(2);
+    Field(result, 0) = Val_int(ret);
+    Field(result, 1) = address;
+    CAMLreturn(result);
 }
 
-value lwt_unix_bytes_recvfrom(value fd, value buf, value ofs, value len, value flags)
+value lwt_unix_bytes_recvfrom(value fd, value buf, value ofs, value len,
+                              value flags)
 {
-  CAMLparam5(fd, buf, ofs, len, flags);
-  CAMLlocal2(result, address);
-  int ret;
-  union sock_addr_union addr;
-  socklen_t addr_len;
-  addr_len = sizeof(addr);
-  ret = recvfrom(Int_val(fd), (char*)Caml_ba_data_val(buf) + Long_val(ofs), Long_val(len),
-                 caml_convert_flag_list(flags, msg_flag_table),
-                 &addr.s_gen, &addr_len);
-  if (ret == -1) uerror("recvfrom", Nothing);
-  address = alloc_sockaddr(&addr, addr_len, -1);
-  result = caml_alloc_tuple(2);
-  Field(result, 0) = Val_int(ret);
-  Field(result, 1) = address;
-  CAMLreturn(result);
+    CAMLparam5(fd, buf, ofs, len, flags);
+    CAMLlocal2(result, address);
+    int ret;
+    union sock_addr_union addr;
+    socklen_t addr_len;
+    addr_len = sizeof(addr);
+    ret = recvfrom(Int_val(fd), (char *)Caml_ba_data_val(buf) + Long_val(ofs),
+                   Long_val(len), caml_convert_flag_list(flags, msg_flag_table),
+                   &addr.s_gen, &addr_len);
+    if (ret == -1) uerror("recvfrom", Nothing);
+    address = alloc_sockaddr(&addr, addr_len, -1);
+    result = caml_alloc_tuple(2);
+    Field(result, 0) = Val_int(ret);
+    Field(result, 1) = address;
+    CAMLreturn(result);
 }
 
-extern void get_sockaddr (value mladdr,
-                          union sock_addr_union * addr /*out*/,
-                          socklen_t * addr_len /*out*/);
+extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
+                         socklen_t *addr_len /*out*/);
 
-value lwt_unix_sendto(value fd, value buf, value ofs, value len, value flags, value dest)
+value lwt_unix_sendto(value fd, value buf, value ofs, value len, value flags,
+                      value dest)
 {
-  union sock_addr_union addr;
-  socklen_t addr_len;
-  int ret;
-  get_sockaddr(dest, &addr, &addr_len);
-  ret = sendto(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)), Long_val(len),
-               caml_convert_flag_list(flags, msg_flag_table),
-               &addr.s_gen, addr_len);
-  if (ret == -1) uerror("send", Nothing);
-  return Val_int(ret);
+    union sock_addr_union addr;
+    socklen_t addr_len;
+    int ret;
+    get_sockaddr(dest, &addr, &addr_len);
+    ret = sendto(Int_val(fd), &Byte(String_val(buf), Long_val(ofs)),
+                 Long_val(len), caml_convert_flag_list(flags, msg_flag_table),
+                 &addr.s_gen, addr_len);
+    if (ret == -1) uerror("send", Nothing);
+    return Val_int(ret);
 }
 
 CAMLprim value lwt_unix_sendto_byte(value *argv, int argc)
 {
-  return lwt_unix_sendto(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+    return lwt_unix_sendto(argv[0], argv[1], argv[2], argv[3], argv[4],
+                           argv[5]);
 }
 
-value lwt_unix_bytes_sendto(value fd, value buf, value ofs, value len, value flags, value dest)
+value lwt_unix_bytes_sendto(value fd, value buf, value ofs, value len,
+                            value flags, value dest)
 {
-  union sock_addr_union addr;
-  socklen_t addr_len;
-  int ret;
-  get_sockaddr(dest, &addr, &addr_len);
-  ret = sendto(Int_val(fd), (char*)Caml_ba_data_val(buf) + Long_val(ofs), Long_val(len),
-               caml_convert_flag_list(flags, msg_flag_table),
-               &addr.s_gen, addr_len);
-  if (ret == -1) uerror("send", Nothing);
-  return Val_int(ret);
+    union sock_addr_union addr;
+    socklen_t addr_len;
+    int ret;
+    get_sockaddr(dest, &addr, &addr_len);
+    ret = sendto(Int_val(fd), (char *)Caml_ba_data_val(buf) + Long_val(ofs),
+                 Long_val(len), caml_convert_flag_list(flags, msg_flag_table),
+                 &addr.s_gen, addr_len);
+    if (ret == -1) uerror("send", Nothing);
+    return Val_int(ret);
 }
 
 CAMLprim value lwt_unix_bytes_sendto_byte(value *argv, int argc)
 {
-  return lwt_unix_bytes_sendto(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+    return lwt_unix_bytes_sendto(argv[0], argv[1], argv[2], argv[3], argv[4],
+                                 argv[5]);
 }
 
 /* +-----------------------------------------------------------------+
@@ -567,135 +558,141 @@ CAMLprim value lwt_unix_bytes_sendto_byte(value *argv, int argc)
    structures */
 static void store_iovs(struct iovec *iovs, value iovs_val)
 {
-  CAMLparam0();
-  CAMLlocal2(list, x);
-  for(list = iovs_val; Is_block(list); list = Field(list, 1), iovs++) {
-    x = Field(list, 0);
-    iovs->iov_base = &Byte(String_val(Field(x, 0)), Long_val(Field(x, 1)));
-    iovs->iov_len = Long_val(Field(x, 2));
-  }
-  CAMLreturn0;
+    CAMLparam0();
+    CAMLlocal2(list, x);
+    for (list = iovs_val; Is_block(list); list = Field(list, 1), iovs++) {
+        x = Field(list, 0);
+        iovs->iov_base = &Byte(String_val(Field(x, 0)), Long_val(Field(x, 1)));
+        iovs->iov_len = Long_val(Field(x, 2));
+    }
+    CAMLreturn0;
 }
 
 static void bytes_store_iovs(struct iovec *iovs, value iovs_val)
 {
-  CAMLparam0();
-  CAMLlocal2(list, x);
-  for(list = iovs_val; Is_block(list); list = Field(list, 1), iovs++) {
-    x = Field(list, 0);
-    iovs->iov_base = (char*)Caml_ba_data_val(Field(x, 0)) + Long_val(Field(x, 1));
-    iovs->iov_len = Long_val(Field(x, 2));
-  }
-  CAMLreturn0;
+    CAMLparam0();
+    CAMLlocal2(list, x);
+    for (list = iovs_val; Is_block(list); list = Field(list, 1), iovs++) {
+        x = Field(list, 0);
+        iovs->iov_base =
+            (char *)Caml_ba_data_val(Field(x, 0)) + Long_val(Field(x, 1));
+        iovs->iov_len = Long_val(Field(x, 2));
+    }
+    CAMLreturn0;
 }
 
 static value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs)
 {
-  CAMLparam0();
-  CAMLlocal3(list, result, x);
+    CAMLparam0();
+    CAMLlocal3(list, result, x);
 
-  struct msghdr msg;
-  memset(&msg, 0, sizeof(msg));
-  msg.msg_iov = iovs;
-  msg.msg_iovlen = n_iovs;
+    struct msghdr msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = iovs;
+    msg.msg_iovlen = n_iovs;
 #if defined(HAVE_FD_PASSING)
-  msg.msg_controllen = CMSG_SPACE(256 * sizeof(int));
-  msg.msg_control = alloca(msg.msg_controllen);
-  memset(msg.msg_control, 0, msg.msg_controllen);
+    msg.msg_controllen = CMSG_SPACE(256 * sizeof(int));
+    msg.msg_control = alloca(msg.msg_controllen);
+    memset(msg.msg_control, 0, msg.msg_controllen);
 #endif
 
-  int ret = recvmsg(fd, &msg, 0);
-  if (ret == -1) uerror("recv_msg", Nothing);
+    int ret = recvmsg(fd, &msg, 0);
+    if (ret == -1) uerror("recv_msg", Nothing);
 
-  list = Val_int(0);
+    list = Val_int(0);
 #if defined(HAVE_FD_PASSING)
-  struct cmsghdr *cm;
-  for (cm = CMSG_FIRSTHDR(&msg); cm; cm = CMSG_NXTHDR(&msg, cm))
-    if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
-      int *fds = (int*)CMSG_DATA(cm);
-      int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
-      int i;
-      for(i = nfds - 1; i >= 0; i--) {
-        x = caml_alloc_tuple(2);
-        Store_field(x, 0, Val_int(fds[i]));
-        Store_field(x, 1, list);
-        list = x;
-      };
-      break;
-    };
+    struct cmsghdr *cm;
+    for (cm = CMSG_FIRSTHDR(&msg); cm; cm = CMSG_NXTHDR(&msg, cm))
+        if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
+            int *fds = (int *)CMSG_DATA(cm);
+            int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+            int i;
+            for (i = nfds - 1; i >= 0; i--) {
+                x = caml_alloc_tuple(2);
+                Store_field(x, 0, Val_int(fds[i]));
+                Store_field(x, 1, list);
+                list = x;
+            };
+            break;
+        };
 #endif
 
-  result = caml_alloc_tuple(2);
-  Store_field(result, 0, Val_int(ret));
-  Store_field(result, 1, list);
-  CAMLreturn(result);
+    result = caml_alloc_tuple(2);
+    Store_field(result, 0, Val_int(ret));
+    Store_field(result, 1, list);
+    CAMLreturn(result);
 }
 
 CAMLprim value lwt_unix_recv_msg(value val_fd, value val_n_iovs, value val_iovs)
 {
-  int n_iovs = Int_val(val_n_iovs);
-  struct iovec iovs[n_iovs];
-  store_iovs(iovs, val_iovs);
-  return wrapper_recv_msg(Int_val(val_fd), n_iovs, iovs);
+    int n_iovs = Int_val(val_n_iovs);
+    struct iovec iovs[n_iovs];
+    store_iovs(iovs, val_iovs);
+    return wrapper_recv_msg(Int_val(val_fd), n_iovs, iovs);
 }
 
-CAMLprim value lwt_unix_bytes_recv_msg(value val_fd, value val_n_iovs, value val_iovs)
+CAMLprim value lwt_unix_bytes_recv_msg(value val_fd, value val_n_iovs,
+                                       value val_iovs)
 {
-  int n_iovs = Int_val(val_n_iovs);
-  struct iovec iovs[n_iovs];
-  bytes_store_iovs(iovs, val_iovs);
-  return wrapper_recv_msg(Int_val(val_fd), n_iovs, iovs);
+    int n_iovs = Int_val(val_n_iovs);
+    struct iovec iovs[n_iovs];
+    bytes_store_iovs(iovs, val_iovs);
+    return wrapper_recv_msg(Int_val(val_fd), n_iovs, iovs);
 }
 
-static value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs, value val_n_fds, value val_fds)
+static value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
+                              value val_n_fds, value val_fds)
 {
-  CAMLparam2(val_n_fds, val_fds);
+    CAMLparam2(val_n_fds, val_fds);
 
-  struct msghdr msg;
-  memset(&msg, 0, sizeof(msg));
-  msg.msg_iov = iovs;
-  msg.msg_iovlen = n_iovs;
+    struct msghdr msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = iovs;
+    msg.msg_iovlen = n_iovs;
 
-  int n_fds = Int_val(val_n_fds);
+    int n_fds = Int_val(val_n_fds);
 #if defined(HAVE_FD_PASSING)
-  if (n_fds > 0) {
-    msg.msg_controllen = CMSG_SPACE(n_fds * sizeof(int));
-    msg.msg_control = alloca(msg.msg_controllen);
-    memset(msg.msg_control, 0, msg.msg_controllen);
+    if (n_fds > 0) {
+        msg.msg_controllen = CMSG_SPACE(n_fds * sizeof(int));
+        msg.msg_control = alloca(msg.msg_controllen);
+        memset(msg.msg_control, 0, msg.msg_controllen);
 
-    struct cmsghdr *cm;
-    cm = CMSG_FIRSTHDR(&msg);
-    cm->cmsg_level = SOL_SOCKET;
-    cm->cmsg_type = SCM_RIGHTS;
-    cm->cmsg_len = CMSG_LEN(n_fds * sizeof(int));
+        struct cmsghdr *cm;
+        cm = CMSG_FIRSTHDR(&msg);
+        cm->cmsg_level = SOL_SOCKET;
+        cm->cmsg_type = SCM_RIGHTS;
+        cm->cmsg_len = CMSG_LEN(n_fds * sizeof(int));
 
-    int *fds = (int*)CMSG_DATA(cm);
-    for(; Is_block(val_fds); val_fds = Field(val_fds, 1), fds++)
-      *fds = Int_val(Field(val_fds, 0));
-  };
+        int *fds = (int *)CMSG_DATA(cm);
+        for (; Is_block(val_fds); val_fds = Field(val_fds, 1), fds++)
+            *fds = Int_val(Field(val_fds, 0));
+    };
 #else
-  if (n_fds > 0) lwt_unix_not_available("fd_passing");
+    if (n_fds > 0) lwt_unix_not_available("fd_passing");
 #endif
 
-  int ret = sendmsg(fd, &msg, 0);
-  if (ret == -1) uerror("send_msg", Nothing);
-  CAMLreturn(Val_int(ret));
+    int ret = sendmsg(fd, &msg, 0);
+    if (ret == -1) uerror("send_msg", Nothing);
+    CAMLreturn(Val_int(ret));
 }
 
-CAMLprim value lwt_unix_send_msg(value val_fd, value val_n_iovs, value val_iovs, value val_n_fds, value val_fds)
+CAMLprim value lwt_unix_send_msg(value val_fd, value val_n_iovs, value val_iovs,
+                                 value val_n_fds, value val_fds)
 {
-  int n_iovs = Int_val(val_n_iovs);
-  struct iovec iovs[n_iovs];
-  store_iovs(iovs, val_iovs);
-  return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds);
+    int n_iovs = Int_val(val_n_iovs);
+    struct iovec iovs[n_iovs];
+    store_iovs(iovs, val_iovs);
+    return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds);
 }
 
-CAMLprim value lwt_unix_bytes_send_msg(value val_fd, value val_n_iovs, value val_iovs, value val_n_fds, value val_fds)
+CAMLprim value lwt_unix_bytes_send_msg(value val_fd, value val_n_iovs,
+                                       value val_iovs, value val_n_fds,
+                                       value val_fds)
 {
-  int n_iovs = Int_val(val_n_iovs);
-  struct iovec iovs[n_iovs];
-  bytes_store_iovs(iovs, val_iovs);
-  return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds);
+    int n_iovs = Int_val(val_n_iovs);
+    struct iovec iovs[n_iovs];
+    bytes_store_iovs(iovs, val_iovs);
+    return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds);
 }
 
 /* +-----------------------------------------------------------------+
@@ -703,17 +700,17 @@ CAMLprim value lwt_unix_bytes_send_msg(value val_fd, value val_n_iovs, value val
    +-----------------------------------------------------------------+ */
 
 #if defined(HAVE_GET_CREDENTIALS_LINUX)
-#  define CREDENTIALS_TYPE struct ucred
-#  define CREDENTIALS_FIELD(id) id
+#define CREDENTIALS_TYPE struct ucred
+#define CREDENTIALS_FIELD(id) id
 #elif defined(HAVE_GET_CREDENTIALS_NETBSD)
-#  define CREDENTIALS_TYPE struct sockcred
-#  define CREDENTIALS_FIELD(id) sc_ ## id
+#define CREDENTIALS_TYPE struct sockcred
+#define CREDENTIALS_FIELD(id) sc_##id
 #elif defined(HAVE_GET_CREDENTIALS_OPENBSD)
-#  define CREDENTIALS_TYPE struct sockpeercred
-#  define CREDENTIALS_FIELD(id) id
+#define CREDENTIALS_TYPE struct sockpeercred
+#define CREDENTIALS_FIELD(id) id
 #elif defined(HAVE_GET_CREDENTIALS_FREEBSD)
-#  define CREDENTIALS_TYPE struct cmsgcred
-#  define CREDENTIALS_FIELD(id) cmsgcred_ ## id
+#define CREDENTIALS_TYPE struct cmsgcred
+#define CREDENTIALS_FIELD(id) cmsgcred_##id
 #endif
 
 #if defined(CREDENTIALS_TYPE)
@@ -725,8 +722,9 @@ CAMLprim value lwt_unix_get_credentials(value fd)
     CREDENTIALS_TYPE cred;
     socklen_t cred_len = sizeof(cred);
 
-    if (getsockopt(Int_val(fd), SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) == -1)
-      uerror("get_credentials", Nothing);
+    if (getsockopt(Int_val(fd), SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) ==
+        -1)
+        uerror("get_credentials", Nothing);
 
     res = caml_alloc_tuple(3);
     Store_field(res, 0, Val_int(cred.CREDENTIALS_FIELD(pid)));
@@ -745,7 +743,7 @@ CAMLprim value lwt_unix_get_credentials(value fd)
     gid_t egid;
 
     if (getpeereid(Int_val(fd), &euid, &egid) == -1)
-      uerror("get_credentials", Nothing);
+        uerror("get_credentials", Nothing);
 
     res = caml_alloc_tuple(3);
     Store_field(res, 0, Val_int(-1));
@@ -764,7 +762,7 @@ LWT_NOT_AVAILABLE1(unix_get_credentials)
    | Multicast functions                                             |
    +-----------------------------------------------------------------+ */
 
-static int socket_domain (int fd)
+static int socket_domain(int fd)
 {
     /* Return the socket domain, PF_INET or PF_INET6. Fails for non-IP
        protos.
@@ -774,23 +772,21 @@ static int socket_domain (int fd)
     socklen_t l;
 
     l = sizeof(addr);
-    if (getsockname(fd, &addr.s_gen, &l) == -1)
-        uerror("getsockname", Nothing);
+    if (getsockname(fd, &addr.s_gen, &l) == -1) uerror("getsockname", Nothing);
 
     switch (addr.s_gen.sa_family) {
-    case AF_INET:
-        return PF_INET;
-    case AF_INET6:
-        return PF_INET6;
-    default:
-        caml_invalid_argument("Not an Internet socket");
+        case AF_INET:
+            return PF_INET;
+        case AF_INET6:
+            return PF_INET6;
+        default:
+            caml_invalid_argument("Not an Internet socket");
     }
 
     return 0;
 }
 
-
-CAMLprim value lwt_unix_mcast_set_loop (value fd, value flag)
+CAMLprim value lwt_unix_mcast_set_loop(value fd, value flag)
 {
     int t, r, f;
 
@@ -799,21 +795,20 @@ CAMLprim value lwt_unix_mcast_set_loop (value fd, value flag)
     r = 0;
 
     switch (t) {
-    case PF_INET:
-        r = setsockopt (Int_val(fd), IPPROTO_IP, IP_MULTICAST_LOOP, (void *) &f, sizeof(f));
-        break;
-    default:
-        caml_invalid_argument("lwt_unix_mcast_set_loop");
+        case PF_INET:
+            r = setsockopt(Int_val(fd), IPPROTO_IP, IP_MULTICAST_LOOP,
+                           (void *)&f, sizeof(f));
+            break;
+        default:
+            caml_invalid_argument("lwt_unix_mcast_set_loop");
     };
 
-    if (r == -1)
-        uerror("setsockopt",Nothing);
+    if (r == -1) uerror("setsockopt", Nothing);
 
     return Val_unit;
 }
 
-
-CAMLprim value lwt_unix_mcast_set_ttl (value fd, value ttl)
+CAMLprim value lwt_unix_mcast_set_ttl(value fd, value ttl)
 {
     int t, r, v;
     int fd_sock;
@@ -824,26 +819,27 @@ CAMLprim value lwt_unix_mcast_set_ttl (value fd, value ttl)
     r = 0;
 
     switch (t) {
-    case PF_INET:
-        r = setsockopt(fd_sock, IPPROTO_IP, IP_MULTICAST_TTL, (void *) &v, sizeof(v));
-        break;
-    default:
-        caml_invalid_argument("lwt_unix_mcast_set_ttl");
+        case PF_INET:
+            r = setsockopt(fd_sock, IPPROTO_IP, IP_MULTICAST_TTL, (void *)&v,
+                           sizeof(v));
+            break;
+        default:
+            caml_invalid_argument("lwt_unix_mcast_set_ttl");
     };
 
-    if (r == -1)
-        uerror("setsockopt",Nothing);
+    if (r == -1) uerror("setsockopt", Nothing);
 
     return Val_unit;
 }
 
 /* Keep this in sync with the type Lwt_unix.mcast_action */
-#define VAL_MCAST_ACTION_ADD  (Val_int(0))
+#define VAL_MCAST_ACTION_ADD (Val_int(0))
 #define VAL_MCAST_ACTION_DROP (Val_int(1))
 
-#define GET_INET_ADDR(v)      (*((struct in_addr *) (v)))
+#define GET_INET_ADDR(v) (*((struct in_addr *)(v)))
 
-CAMLprim value lwt_unix_mcast_modify_membership (value fd, value v_action, value if_addr, value group_addr)
+CAMLprim value lwt_unix_mcast_modify_membership(value fd, value v_action,
+                                                value if_addr, value group_addr)
 {
     int t, r;
     int fd_sock;
@@ -854,41 +850,40 @@ CAMLprim value lwt_unix_mcast_modify_membership (value fd, value v_action, value
     r = 0;
 
     switch (t) {
-    case PF_INET: {
-        struct ip_mreq mreq;
+        case PF_INET: {
+            struct ip_mreq mreq;
 
-        if (caml_string_length(group_addr) != 4 ||
-            caml_string_length(if_addr) != 4) {
+            if (caml_string_length(group_addr) != 4 ||
+                caml_string_length(if_addr) != 4) {
+                caml_invalid_argument(
+                    "lwt_unix_mcast_modify: Not an IPV4 address");
+            }
 
-            caml_invalid_argument("lwt_unix_mcast_modify: Not an IPV4 address");
-        }
+            memcpy(&mreq.imr_multiaddr, &GET_INET_ADDR(group_addr), 4);
+            memcpy(&mreq.imr_interface, &GET_INET_ADDR(if_addr), 4);
 
-        memcpy(&mreq.imr_multiaddr, &GET_INET_ADDR(group_addr), 4);
-        memcpy(&mreq.imr_interface, &GET_INET_ADDR(if_addr), 4);
+            switch (v_action) {
+                case VAL_MCAST_ACTION_ADD:
+                    optname = IP_ADD_MEMBERSHIP;
+                    break;
 
-        switch (v_action) {
-        case VAL_MCAST_ACTION_ADD:
-            optname = IP_ADD_MEMBERSHIP;
+                default:
+                    optname = IP_DROP_MEMBERSHIP;
+                    break;
+            }
+
+            r = setsockopt(fd_sock, IPPROTO_IP, optname, (void *)&mreq,
+                           sizeof(mreq));
             break;
-
+        }
         default:
-            optname = IP_DROP_MEMBERSHIP;
-            break;
-        }
-
-        r = setsockopt(fd_sock, IPPROTO_IP, optname, (void *) &mreq, sizeof(mreq));
-        break;
-    }
-    default:
-        caml_invalid_argument("lwt_unix_mcast_modify_membership");
+            caml_invalid_argument("lwt_unix_mcast_modify_membership");
     };
 
-    if (r == -1)
-        uerror("setsockopt", Nothing);
+    if (r == -1) uerror("setsockopt", Nothing);
 
     return Val_unit;
 }
-
 
 /* +-----------------------------------------------------------------+
    | wait4                                                           |
@@ -896,19 +891,19 @@ CAMLprim value lwt_unix_mcast_modify_membership (value fd, value v_action, value
 
 /* Some code duplicated from OCaml's otherlibs/unix/wait.c */
 
-CAMLextern int caml_convert_signal_number (int);
-CAMLextern int caml_rev_convert_signal_number (int);
+CAMLextern int caml_convert_signal_number(int);
+CAMLextern int caml_rev_convert_signal_number(int);
 
 #if !defined(__ANDROID__)
 
 #if !(defined(WIFEXITED) && defined(WEXITSTATUS) && defined(WIFSTOPPED) && \
       defined(WSTOPSIG) && defined(WTERMSIG))
 /* Assume old-style V7 status word */
-#define WIFEXITED(status) (((status) & 0xFF) == 0)
+#define WIFEXITED(status) (((status)&0xFF) == 0)
 #define WEXITSTATUS(status) (((status) >> 8) & 0xFF)
-#define WIFSTOPPED(status) (((status) & 0xFF) == 0xFF)
+#define WIFSTOPPED(status) (((status)&0xFF) == 0xFF)
 #define WSTOPSIG(status) (((status) >> 8) & 0xFF)
-#define WTERMSIG(status) ((status) & 0x3F)
+#define WTERMSIG(status) ((status)&0x3F)
 #endif
 
 #define TAG_WEXITED 0
@@ -917,51 +912,51 @@ CAMLextern int caml_rev_convert_signal_number (int);
 
 static value alloc_process_status(int status)
 {
-  value st;
+    value st;
 
-  if (WIFEXITED(status)) {
-    st = caml_alloc_small(1, TAG_WEXITED);
-    Field(st, 0) = Val_int(WEXITSTATUS(status));
-  }
-  else if (WIFSTOPPED(status)) {
-    st = caml_alloc_small(1, TAG_WSTOPPED);
-    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WSTOPSIG(status)));
-  }
-  else {
-    st = caml_alloc_small(1, TAG_WSIGNALED);
-    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WTERMSIG(status)));
-  }
-  return st;
+    if (WIFEXITED(status)) {
+        st = caml_alloc_small(1, TAG_WEXITED);
+        Field(st, 0) = Val_int(WEXITSTATUS(status));
+    } else if (WIFSTOPPED(status)) {
+        st = caml_alloc_small(1, TAG_WSTOPPED);
+        Field(st, 0) =
+            Val_int(caml_rev_convert_signal_number(WSTOPSIG(status)));
+    } else {
+        st = caml_alloc_small(1, TAG_WSIGNALED);
+        Field(st, 0) =
+            Val_int(caml_rev_convert_signal_number(WTERMSIG(status)));
+    }
+    return st;
 }
 
-static int wait_flag_table[] = {
-  WNOHANG, WUNTRACED
-};
+static int wait_flag_table[] = {WNOHANG, WUNTRACED};
 
 value lwt_unix_wait4(value flags, value pid_req)
 {
-  CAMLparam1(flags);
-  CAMLlocal2(times, res);
+    CAMLparam1(flags);
+    CAMLlocal2(times, res);
 
-  int pid, status, cv_flags;
-  cv_flags = caml_convert_flag_list(flags, wait_flag_table);
+    int pid, status, cv_flags;
+    cv_flags = caml_convert_flag_list(flags, wait_flag_table);
 
-  struct rusage ru;
+    struct rusage ru;
 
-  caml_enter_blocking_section();
-  pid = wait4(Int_val(pid_req), &status, cv_flags, &ru);
-  caml_leave_blocking_section();
-  if (pid == -1) uerror("wait4", Nothing);
+    caml_enter_blocking_section();
+    pid = wait4(Int_val(pid_req), &status, cv_flags, &ru);
+    caml_leave_blocking_section();
+    if (pid == -1) uerror("wait4", Nothing);
 
-  times = caml_alloc_small(2 * Double_wosize, Double_array_tag);
-  Store_double_field(times, 0, ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
-  Store_double_field(times, 1, ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
+    times = caml_alloc_small(2 * Double_wosize, Double_array_tag);
+    Store_double_field(times, 0,
+                       ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
+    Store_double_field(times, 1,
+                       ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
 
-  res = caml_alloc_tuple(3);
-  Store_field(res, 0, Val_int(pid));
-  Store_field(res, 1, alloc_process_status(status));
-  Store_field(res, 2, times);
-  CAMLreturn(res);
+    res = caml_alloc_tuple(3);
+    Store_field(res, 0, Val_int(pid));
+    Store_field(res, 1, alloc_process_status(status));
+    Store_field(res, 2, times);
+    CAMLreturn(res);
 }
 
 #else
@@ -978,9 +973,9 @@ LWT_NOT_AVAILABLE2(unix_wait4)
 
 CAMLprim value lwt_unix_get_cpu(value Unit)
 {
-  int cpu = sched_getcpu();
-  if (cpu < 0) uerror("sched_getcpu", Nothing);
-  return Val_int(cpu);
+    int cpu = sched_getcpu();
+    if (cpu < 0) uerror("sched_getcpu", Nothing);
+    return Val_int(cpu);
 }
 
 #else
@@ -993,33 +988,33 @@ LWT_NOT_AVAILABLE1(unix_get_cpu)
 
 CAMLprim value lwt_unix_get_affinity(value val_pid)
 {
-  CAMLparam1(val_pid);
-  CAMLlocal2(list, node);
-  cpu_set_t cpus;
-  if (sched_getaffinity(Int_val(val_pid), sizeof(cpu_set_t), &cpus) < 0)
-    uerror("sched_getaffinity", Nothing);
-  int i;
-  list = Val_int(0);
-  for (i = sizeof(cpu_set_t) * 8 - 1; i >= 0; i--) {
-    if (CPU_ISSET(i, &cpus)) {
-      node = caml_alloc_tuple(2);
-      Field(node, 0) = Val_int(i);
-      Field(node, 1) = list;
-      list = node;
+    CAMLparam1(val_pid);
+    CAMLlocal2(list, node);
+    cpu_set_t cpus;
+    if (sched_getaffinity(Int_val(val_pid), sizeof(cpu_set_t), &cpus) < 0)
+        uerror("sched_getaffinity", Nothing);
+    int i;
+    list = Val_int(0);
+    for (i = sizeof(cpu_set_t) * 8 - 1; i >= 0; i--) {
+        if (CPU_ISSET(i, &cpus)) {
+            node = caml_alloc_tuple(2);
+            Field(node, 0) = Val_int(i);
+            Field(node, 1) = list;
+            list = node;
+        }
     }
-  }
-  CAMLreturn(list);
+    CAMLreturn(list);
 }
 
 CAMLprim value lwt_unix_set_affinity(value val_pid, value val_cpus)
 {
-  cpu_set_t cpus;
-  CPU_ZERO(&cpus);
-  for (; Is_block(val_cpus); val_cpus = Field(val_cpus, 1))
-    CPU_SET(Int_val(Field(val_cpus, 0)), &cpus);
-  if (sched_setaffinity(Int_val(val_pid), sizeof(cpu_set_t), &cpus) < 0)
-    uerror("sched_setaffinity", Nothing);
-  return Val_unit;
+    cpu_set_t cpus;
+    CPU_ZERO(&cpus);
+    for (; Is_block(val_cpus); val_cpus = Field(val_cpus, 1))
+        CPU_SET(Int_val(Field(val_cpus, 0)), &cpus);
+    if (sched_setaffinity(Int_val(val_pid), sizeof(cpu_set_t), &cpus) < 0)
+        uerror("sched_setaffinity", Nothing);
+    return Val_unit;
 }
 
 #else
@@ -1034,32 +1029,32 @@ LWT_NOT_AVAILABLE2(unix_set_affinity)
    +-----------------------------------------------------------------+ */
 
 struct job_guess_blocking {
-  struct lwt_unix_job job;
-  int fd;
-  int result;
+    struct lwt_unix_job job;
+    int fd;
+    int result;
 };
 
 static void worker_guess_blocking(struct job_guess_blocking *job)
 {
-  struct stat stat;
-  if (fstat(job->fd, &stat) == 0)
-    job->result = !(S_ISFIFO(stat.st_mode) || S_ISSOCK(stat.st_mode));
-  else
-    job->result = 1;
+    struct stat stat;
+    if (fstat(job->fd, &stat) == 0)
+        job->result = !(S_ISFIFO(stat.st_mode) || S_ISSOCK(stat.st_mode));
+    else
+        job->result = 1;
 }
 
 static value result_guess_blocking(struct job_guess_blocking *job)
 {
-  value result = Val_bool(job->result);
-  lwt_unix_free_job(&job->job);
-  return result;
+    value result = Val_bool(job->result);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_guess_blocking_job(value val_fd)
 {
-  LWT_UNIX_INIT_JOB(job, guess_blocking, 0);
-  job->fd = Int_val(val_fd);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, guess_blocking, 0);
+    job->fd = Int_val(val_fd);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1070,28 +1065,28 @@ CAMLprim value lwt_unix_guess_blocking_job(value val_fd)
 LWT_NOT_AVAILABLE2(unix_wait_mincore_job)
 #else
 struct job_wait_mincore {
-  struct lwt_unix_job job;
-  char *ptr;
+    struct lwt_unix_job job;
+    char *ptr;
 };
 
 static void worker_wait_mincore(struct job_wait_mincore *job)
 {
-  /* Read the byte to force the kernel to fetch the page: */
-  char dummy;
-  memcpy(&dummy, job->ptr, 1);
+    /* Read the byte to force the kernel to fetch the page: */
+    char dummy;
+    memcpy(&dummy, job->ptr, 1);
 }
 
 static value result_wait_mincore(struct job_wait_mincore *job)
 {
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    lwt_unix_free_job(&job->job);
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_wait_mincore_job(value val_buffer, value val_offset)
 {
-  LWT_UNIX_INIT_JOB(job, wait_mincore, 0);
-  job->ptr = (char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, wait_mincore, 0);
+    job->ptr = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
+    return lwt_unix_alloc_job(&(job->job));
 }
 #endif
 
@@ -1113,106 +1108,91 @@ CAMLprim value lwt_unix_wait_mincore_job(value val_buffer, value val_offset)
 #endif
 
 static int open_flag_table[] = {
-  O_RDONLY,
-  O_WRONLY,
-  O_RDWR,
-  O_NONBLOCK,
-  O_APPEND,
-  O_CREAT,
-  O_TRUNC,
-  O_EXCL,
-  O_NOCTTY,
-  O_DSYNC,
-  O_SYNC,
-  O_RSYNC,
-  0, /* O_SHARE_DELETE, Windows-only */
-  0, /* O_CLOEXEC, treated specially */
-  0  /* O_KEEPEXEC, treated specially */
+    O_RDONLY, O_WRONLY, O_RDWR,  O_NONBLOCK, O_APPEND, O_CREAT, O_TRUNC,
+    O_EXCL,   O_NOCTTY, O_DSYNC, O_SYNC,     O_RSYNC,  0, /* O_SHARE_DELETE,
+                                                             Windows-only */
+    0, /* O_CLOEXEC, treated specially */
+    0  /* O_KEEPEXEC, treated specially */
 };
 
 enum { CLOEXEC = 1, KEEPEXEC = 2 };
 
-static int open_cloexec_table[15] = {
-  0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0,
-  0,
-  CLOEXEC, KEEPEXEC
-};
+static int open_cloexec_table[15] = {0, 0, 0, 0, 0, 0,       0,       0,
+                                     0, 0, 0, 0, 0, CLOEXEC, KEEPEXEC};
 
 struct job_open {
-  struct lwt_unix_job job;
-  int flags;
-  int perms;
-  int fd; /* will have value CLOEXEC or KEEPEXEC on entry to worker_open */
-  int blocking;
-  int error_code;
-  char *name;
-  char data[];
+    struct lwt_unix_job job;
+    int flags;
+    int perms;
+    int fd; /* will have value CLOEXEC or KEEPEXEC on entry to worker_open */
+    int blocking;
+    int error_code;
+    char *name;
+    char data[];
 };
 
 static void worker_open(struct job_open *job)
 {
-  int fd;
-  int cloexec;
+    int fd;
+    int cloexec;
 
-  if (job->fd & CLOEXEC)
-    cloexec = 1;
-  else if (job->fd & KEEPEXEC)
-    cloexec = 0;
-  else
+    if (job->fd & CLOEXEC)
+        cloexec = 1;
+    else if (job->fd & KEEPEXEC)
+        cloexec = 0;
+    else
 #if OCAML_VERSION_MAJOR >= 4 && OCAML_VERSION_MINOR >= 5
-    cloexec = unix_cloexec_default;
+        cloexec = unix_cloexec_default;
 #else
-    cloexec = 0;
+        cloexec = 0;
 #endif
 
 #if defined(O_CLOEXEC)
-  if (cloexec) job->flags |= O_CLOEXEC;
+    if (cloexec) job->flags |= O_CLOEXEC;
 #endif
 
-  fd = open(job->name, job->flags, job->perms);
+    fd = open(job->name, job->flags, job->perms);
 #if !defined(O_CLOEXEC) && defined(FD_CLOEXEC)
-  if (fd >= 0 && cloexec) {
-    int flags = fcntl(fd, F_GETFD, 0);
+    if (fd >= 0 && cloexec) {
+        int flags = fcntl(fd, F_GETFD, 0);
 
-    if (flags == -1 ||
-        fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
-      int serrno = errno;
-      close(fd);
-      errno = serrno;
-      fd = -1;
+        if (flags == -1 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
+            int serrno = errno;
+            close(fd);
+            errno = serrno;
+            fd = -1;
+        }
     }
-  }
 #endif
-  job->fd = fd;
-  job->error_code = errno;
-  if (fd >= 0) {
-    struct stat stat;
-    if (fstat(fd, &stat) < 0)
-      job->blocking = 1;
-    else
-      job->blocking = !(S_ISFIFO(stat.st_mode) || S_ISSOCK(stat.st_mode));
-  }
+    job->fd = fd;
+    job->error_code = errno;
+    if (fd >= 0) {
+        struct stat stat;
+        if (fstat(fd, &stat) < 0)
+            job->blocking = 1;
+        else
+            job->blocking = !(S_ISFIFO(stat.st_mode) || S_ISSOCK(stat.st_mode));
+    }
 }
 
 static value result_open(struct job_open *job)
 {
-  int fd = job->fd;
-  LWT_UNIX_CHECK_JOB_ARG(job, fd < 0, "open", job->name);
-  value result = caml_alloc_tuple(2);
-  Field(result, 0) = Val_int(fd);
-  Field(result, 1) = Val_bool(job->blocking);
-  lwt_unix_free_job(&job->job);
-  return result;
+    int fd = job->fd;
+    LWT_UNIX_CHECK_JOB_ARG(job, fd < 0, "open", job->name);
+    value result = caml_alloc_tuple(2);
+    Field(result, 0) = Val_int(fd);
+    Field(result, 1) = Val_bool(job->blocking);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_open_job(value name, value flags, value perms)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, open, 0, name);
-  job->fd = caml_convert_flag_list(flags, open_cloexec_table);
-  job->flags = caml_convert_flag_list(flags, open_flag_table);
-  job->perms = Int_val(perms);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, open, 0, name);
+    job->fd = caml_convert_flag_list(flags, open_cloexec_table);
+    job->flags = caml_convert_flag_list(flags, open_flag_table);
+    job->perms = Int_val(perms);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1220,55 +1200,56 @@ CAMLprim value lwt_unix_open_job(value name, value flags, value perms)
    +-----------------------------------------------------------------+ */
 
 struct job_read {
-  struct lwt_unix_job job;
-  /* The file descriptor. */
-  int fd;
-  /* The amount of data to read. */
-  long length;
-  /* The OCaml string. */
-  value string;
-  /* The offset in the string. */
-  long offset;
-  /* The result of the read syscall. */
-  long result;
-  /* The value of errno. */
-  int error_code;
-  /* The temporary buffer. */
-  char buffer[];
+    struct lwt_unix_job job;
+    /* The file descriptor. */
+    int fd;
+    /* The amount of data to read. */
+    long length;
+    /* The OCaml string. */
+    value string;
+    /* The offset in the string. */
+    long offset;
+    /* The result of the read syscall. */
+    long result;
+    /* The value of errno. */
+    int error_code;
+    /* The temporary buffer. */
+    char buffer[];
 };
 
 static void worker_read(struct job_read *job)
 {
-  job->result = read(job->fd, job->buffer, job->length);
-  job->error_code = errno;
+    job->result = read(job->fd, job->buffer, job->length);
+    job->error_code = errno;
 }
 
 static value result_read(struct job_read *job)
 {
-  long result = job->result;
-  if (result < 0) {
-    int error_code = job->error_code;
-    caml_remove_generational_global_root(&(job->string));
-    lwt_unix_free_job(&job->job);
-    unix_error(error_code, "read", Nothing);
-  } else {
-    memcpy(String_val(job->string) + job->offset, job->buffer, result);
-    caml_remove_generational_global_root(&(job->string));
-    lwt_unix_free_job(&job->job);
-    return Val_long(result);
-  }
+    long result = job->result;
+    if (result < 0) {
+        int error_code = job->error_code;
+        caml_remove_generational_global_root(&(job->string));
+        lwt_unix_free_job(&job->job);
+        unix_error(error_code, "read", Nothing);
+    } else {
+        memcpy(String_val(job->string) + job->offset, job->buffer, result);
+        caml_remove_generational_global_root(&(job->string));
+        lwt_unix_free_job(&job->job);
+        return Val_long(result);
+    }
 }
 
-CAMLprim value lwt_unix_read_job(value val_fd, value val_buffer, value val_offset, value val_length)
+CAMLprim value lwt_unix_read_job(value val_fd, value val_buffer,
+                                 value val_offset, value val_length)
 {
-  long length = Long_val(val_length);
-  LWT_UNIX_INIT_JOB(job, read, length);
-  job->fd = Int_val(val_fd);
-  job->length = length;
-  job->string = val_buffer;
-  job->offset = Long_val(val_offset);
-  caml_register_generational_global_root(&(job->string));
-  return lwt_unix_alloc_job(&(job->job));
+    long length = Long_val(val_length);
+    LWT_UNIX_INIT_JOB(job, read, length);
+    job->fd = Int_val(val_fd);
+    job->length = length;
+    job->string = val_buffer;
+    job->offset = Long_val(val_offset);
+    caml_register_generational_global_root(&(job->string));
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1276,42 +1257,43 @@ CAMLprim value lwt_unix_read_job(value val_fd, value val_buffer, value val_offse
    +-----------------------------------------------------------------+ */
 
 struct job_bytes_read {
-  struct lwt_unix_job job;
-  /* The file descriptor. */
-  int fd;
-  /* The destination buffer. */
-  char *buffer;
-  /* The offset in the string. */
-  long offset;
-  /* The amount of data to read. */
-  long length;
-  /* The result of the read syscall. */
-  long result;
-  /* The value of errno. */
-  int error_code;
+    struct lwt_unix_job job;
+    /* The file descriptor. */
+    int fd;
+    /* The destination buffer. */
+    char *buffer;
+    /* The offset in the string. */
+    long offset;
+    /* The amount of data to read. */
+    long length;
+    /* The result of the read syscall. */
+    long result;
+    /* The value of errno. */
+    int error_code;
 };
 
 static void worker_bytes_read(struct job_bytes_read *job)
 {
-  job->result = read(job->fd, job->buffer, job->length);
-  job->error_code = errno;
+    job->result = read(job->fd, job->buffer, job->length);
+    job->error_code = errno;
 }
 
 static value result_bytes_read(struct job_bytes_read *job)
 {
-  long result = job->result;
-  LWT_UNIX_CHECK_JOB(job, result < 0, "read");
-  lwt_unix_free_job(&job->job);
-  return Val_long(result);
+    long result = job->result;
+    LWT_UNIX_CHECK_JOB(job, result < 0, "read");
+    lwt_unix_free_job(&job->job);
+    return Val_long(result);
 }
 
-CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buf, value val_ofs, value val_len)
+CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buf,
+                                       value val_ofs, value val_len)
 {
-  LWT_UNIX_INIT_JOB(job, bytes_read, 0);
-  job->fd = Int_val(val_fd);
-  job->buffer = (char*)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
-  job->length = Long_val(val_len);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, bytes_read, 0);
+    job->fd = Int_val(val_fd);
+    job->buffer = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+    job->length = Long_val(val_len);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1319,36 +1301,37 @@ CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buf, value val_of
    +-----------------------------------------------------------------+ */
 
 struct job_write {
-  struct lwt_unix_job job;
-  int fd;
-  long length;
-  long result;
-  int error_code;
-  char buffer[];
+    struct lwt_unix_job job;
+    int fd;
+    long length;
+    long result;
+    int error_code;
+    char buffer[];
 };
 
 static void worker_write(struct job_write *job)
 {
-  job->result = write(job->fd, job->buffer, job->length);
-  job->error_code = errno;
+    job->result = write(job->fd, job->buffer, job->length);
+    job->error_code = errno;
 }
 
 static value result_write(struct job_write *job)
 {
-  long result = job->result;
-  LWT_UNIX_CHECK_JOB(job, result < 0, "write");
-  lwt_unix_free_job(&job->job);
-  return Val_long(result);
+    long result = job->result;
+    LWT_UNIX_CHECK_JOB(job, result < 0, "write");
+    lwt_unix_free_job(&job->job);
+    return Val_long(result);
 }
 
-CAMLprim value lwt_unix_write_job(value val_fd, value val_string, value val_offset, value val_length)
+CAMLprim value lwt_unix_write_job(value val_fd, value val_string,
+                                  value val_offset, value val_length)
 {
-  long length = Long_val(val_length);
-  LWT_UNIX_INIT_JOB(job, write, length);
-  job->fd = Int_val(val_fd);
-  job->length = length;
-  memcpy(job->buffer, String_val(val_string) + Long_val(val_offset), length);
-  return lwt_unix_alloc_job(&(job->job));
+    long length = Long_val(val_length);
+    LWT_UNIX_INIT_JOB(job, write, length);
+    job->fd = Int_val(val_fd);
+    job->length = length;
+    memcpy(job->buffer, String_val(val_string) + Long_val(val_offset), length);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1356,35 +1339,36 @@ CAMLprim value lwt_unix_write_job(value val_fd, value val_string, value val_offs
    +-----------------------------------------------------------------+ */
 
 struct job_bytes_write {
-  struct lwt_unix_job job;
-  int fd;
-  char *buffer;
-  long length;
-  long result;
-  int error_code;
+    struct lwt_unix_job job;
+    int fd;
+    char *buffer;
+    long length;
+    long result;
+    int error_code;
 };
 
 static void worker_bytes_write(struct job_bytes_write *job)
 {
-  job->result = write(job->fd, job->buffer, job->length);
-  job->error_code = errno;
+    job->result = write(job->fd, job->buffer, job->length);
+    job->error_code = errno;
 }
 
 static value result_bytes_write(struct job_bytes_write *job)
 {
-  long result = job->result;
-  LWT_UNIX_CHECK_JOB(job, result < 0, "write");
-  lwt_unix_free_job(&job->job);
-  return Val_long(result);
+    long result = job->result;
+    LWT_UNIX_CHECK_JOB(job, result < 0, "write");
+    lwt_unix_free_job(&job->job);
+    return Val_long(result);
 }
 
-CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer, value val_offset, value val_length)
+CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer,
+                                        value val_offset, value val_length)
 {
-  LWT_UNIX_INIT_JOB(job, bytes_write, 0);
-  job->fd = Int_val(val_fd);
-  job->buffer = (char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
-  job->length = Long_val(val_length);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, bytes_write, 0);
+    job->fd = Int_val(val_fd);
+    job->buffer = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
+    job->length = Long_val(val_length);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1392,100 +1376,100 @@ CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer, value va
    +-----------------------------------------------------------------+ */
 
 struct job_stat {
-  struct lwt_unix_job job;
-  struct stat stat;
-  int result;
-  int error_code;
-  char *name;
-  char data[];
+    struct lwt_unix_job job;
+    struct stat stat;
+    int result;
+    int error_code;
+    char *name;
+    char data[];
 };
 
 static value copy_stat(int use_64, struct stat *buf)
 {
-  CAMLparam0();
-  CAMLlocal5(atime, mtime, ctime, offset, v);
+    CAMLparam0();
+    CAMLlocal5(atime, mtime, ctime, offset, v);
 
-  atime =
-    caml_copy_double((double) buf->st_atime + (NANOSEC(buf, a) / 1000000000.0));
-  mtime =
-    caml_copy_double((double) buf->st_mtime + (NANOSEC(buf, m) / 1000000000.0));
-  ctime =
-    caml_copy_double((double) buf->st_ctime + (NANOSEC(buf, c) / 1000000000.0));
-  offset = use_64 ? caml_copy_int64(buf->st_size) : Val_int(buf->st_size);
-  v = caml_alloc_small(12, 0);
-  Field(v, 0) = Val_int (buf->st_dev);
-  Field(v, 1) = Val_int (buf->st_ino);
-  switch (buf->st_mode & S_IFMT) {
-  case S_IFREG:
-    Field(v, 2) = Val_int(0);
-    break;
-  case S_IFDIR:
-    Field(v, 2) = Val_int(1);
-    break;
-  case S_IFCHR:
-    Field(v, 2) = Val_int(2);
-    break;
-  case S_IFBLK:
-    Field(v, 2) = Val_int(3);
-    break;
-  case S_IFLNK:
-    Field(v, 2) = Val_int(4);
-    break;
-  case S_IFIFO:
-    Field(v, 2) = Val_int(5);
-    break;
-  case S_IFSOCK:
-    Field(v, 2) = Val_int(6);
-    break;
-  default:
-    Field(v, 2) = Val_int(0);
-    break;
-  }
-  Field(v, 3) = Val_int(buf->st_mode & 07777);
-  Field(v, 4) = Val_int(buf->st_nlink);
-  Field(v, 5) = Val_int(buf->st_uid);
-  Field(v, 6) = Val_int(buf->st_gid);
-  Field(v, 7) = Val_int(buf->st_rdev);
-  Field(v, 8) = offset;
-  Field(v, 9) = atime;
-  Field(v, 10) = mtime;
-  Field(v, 11) = ctime;
-  CAMLreturn(v);
+    atime = caml_copy_double((double)buf->st_atime +
+                             (NANOSEC(buf, a) / 1000000000.0));
+    mtime = caml_copy_double((double)buf->st_mtime +
+                             (NANOSEC(buf, m) / 1000000000.0));
+    ctime = caml_copy_double((double)buf->st_ctime +
+                             (NANOSEC(buf, c) / 1000000000.0));
+    offset = use_64 ? caml_copy_int64(buf->st_size) : Val_int(buf->st_size);
+    v = caml_alloc_small(12, 0);
+    Field(v, 0) = Val_int(buf->st_dev);
+    Field(v, 1) = Val_int(buf->st_ino);
+    switch (buf->st_mode & S_IFMT) {
+        case S_IFREG:
+            Field(v, 2) = Val_int(0);
+            break;
+        case S_IFDIR:
+            Field(v, 2) = Val_int(1);
+            break;
+        case S_IFCHR:
+            Field(v, 2) = Val_int(2);
+            break;
+        case S_IFBLK:
+            Field(v, 2) = Val_int(3);
+            break;
+        case S_IFLNK:
+            Field(v, 2) = Val_int(4);
+            break;
+        case S_IFIFO:
+            Field(v, 2) = Val_int(5);
+            break;
+        case S_IFSOCK:
+            Field(v, 2) = Val_int(6);
+            break;
+        default:
+            Field(v, 2) = Val_int(0);
+            break;
+    }
+    Field(v, 3) = Val_int(buf->st_mode & 07777);
+    Field(v, 4) = Val_int(buf->st_nlink);
+    Field(v, 5) = Val_int(buf->st_uid);
+    Field(v, 6) = Val_int(buf->st_gid);
+    Field(v, 7) = Val_int(buf->st_rdev);
+    Field(v, 8) = offset;
+    Field(v, 9) = atime;
+    Field(v, 10) = mtime;
+    Field(v, 11) = ctime;
+    CAMLreturn(v);
 }
 
 static void worker_stat(struct job_stat *job)
 {
-  job->result = stat(job->name, &job->stat);
-  job->error_code = errno;
+    job->result = stat(job->name, &job->stat);
+    job->error_code = errno;
 }
 
 static value result_stat(struct job_stat *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "stat", job->name);
-  value result = copy_stat(0, &job->stat);
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "stat", job->name);
+    value result = copy_stat(0, &job->stat);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_stat_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, stat, 0, name);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, stat, 0, name);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 static value result_stat_64(struct job_stat *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "stat", job->name);
-  value result = copy_stat(1, &job->stat);
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "stat", job->name);
+    value result = copy_stat(1, &job->stat);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_stat_64_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, stat, 0, name);
-  job->job.result = (lwt_unix_job_result)result_stat_64;
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, stat, 0, name);
+    job->job.result = (lwt_unix_job_result)result_stat_64;
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1493,47 +1477,47 @@ CAMLprim value lwt_unix_stat_64_job(value name)
    +-----------------------------------------------------------------+ */
 
 struct job_lstat {
-  struct lwt_unix_job job;
-  struct stat lstat;
-  int result;
-  int error_code;
-  char *name;
-  char data[];
+    struct lwt_unix_job job;
+    struct stat lstat;
+    int result;
+    int error_code;
+    char *name;
+    char data[];
 };
 
 static void worker_lstat(struct job_lstat *job)
 {
-  job->result = lstat(job->name, &job->lstat);
-  job->error_code = errno;
+    job->result = lstat(job->name, &job->lstat);
+    job->error_code = errno;
 }
 
 static value result_lstat(struct job_lstat *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "lstat", job->name);
-  value result = copy_stat(0, &(job->lstat));
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "lstat", job->name);
+    value result = copy_stat(0, &(job->lstat));
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_lstat_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, lstat, 0, name);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, lstat, 0, name);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 static value result_lstat_64(struct job_lstat *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "lstat", job->name);
-  value result = copy_stat(1, &(job->lstat));
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "lstat", job->name);
+    value result = copy_stat(1, &(job->lstat));
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_lstat_64_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, lstat, 0, name);
-  job->job.result = (lwt_unix_job_result)result_lstat_64;
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, lstat, 0, name);
+    job->job.result = (lwt_unix_job_result)result_lstat_64;
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1541,48 +1525,48 @@ CAMLprim value lwt_unix_lstat_64_job(value name)
    +-----------------------------------------------------------------+ */
 
 struct job_fstat {
-  struct lwt_unix_job job;
-  int fd;
-  struct stat fstat;
-  int result;
-  int error_code;
+    struct lwt_unix_job job;
+    int fd;
+    struct stat fstat;
+    int result;
+    int error_code;
 };
 
 static void worker_fstat(struct job_fstat *job)
 {
-  job->result = fstat(job->fd, &(job->fstat));
-  job->error_code = errno;
+    job->result = fstat(job->fd, &(job->fstat));
+    job->error_code = errno;
 }
 
 static value result_fstat(struct job_fstat *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "fstat");
-  value result = copy_stat(0, &(job->fstat));
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "fstat");
+    value result = copy_stat(0, &(job->fstat));
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_fstat_job(value val_fd)
 {
-  LWT_UNIX_INIT_JOB(job, fstat, 0);
-  job->fd = Int_val(val_fd);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, fstat, 0);
+    job->fd = Int_val(val_fd);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 static value result_fstat_64(struct job_fstat *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "fstat");
-  value result = copy_stat(1, &(job->fstat));
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "fstat");
+    value result = copy_stat(1, &(job->fstat));
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_fstat_64_job(value val_fd)
 {
-  LWT_UNIX_INIT_JOB(job, fstat, 0);
-  job->job.result = (lwt_unix_job_result)result_fstat_64;
-  job->fd = Int_val(val_fd);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, fstat, 0);
+    job->job.result = (lwt_unix_job_result)result_fstat_64;
+    job->fd = Int_val(val_fd);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1616,8 +1600,8 @@ CAMLprim value lwt_unix_utimes_job(value path, value val_atime, value val_mtime)
 {
     LWT_UNIX_INIT_JOB_STRING(job, utimes, 0, path);
 
-    double  atime = Double_val(val_atime);
-    double  mtime = Double_val(val_mtime);
+    double atime = Double_val(val_atime);
+    double mtime = Double_val(val_mtime);
 
     if (atime == 0.0 && mtime == 0.0)
         job->times_pointer = NULL;
@@ -1639,28 +1623,28 @@ CAMLprim value lwt_unix_utimes_job(value path, value val_atime, value val_mtime)
    +-----------------------------------------------------------------+ */
 
 struct job_isatty {
-  struct lwt_unix_job job;
-  int fd;
-  int result;
+    struct lwt_unix_job job;
+    int fd;
+    int result;
 };
 
 static void worker_isatty(struct job_isatty *job)
 {
-  job->result = isatty(job->fd);
+    job->result = isatty(job->fd);
 }
 
 static value result_isatty(struct job_isatty *job)
 {
-  value result = Val_bool(job->result);
-  lwt_unix_free_job(&job->job);
-  return result;
+    value result = Val_bool(job->result);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_isatty_job(value val_fd)
 {
-  LWT_UNIX_INIT_JOB(job, isatty, 0);
-  job->fd = Int_val(val_fd);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, isatty, 0);
+    job->fd = Int_val(val_fd);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1668,32 +1652,32 @@ CAMLprim value lwt_unix_isatty_job(value val_fd)
    +-----------------------------------------------------------------+ */
 
 struct job_opendir {
-  struct lwt_unix_job job;
-  DIR* result;
-  int error_code;
-  char* path;
-  char data[];
+    struct lwt_unix_job job;
+    DIR *result;
+    int error_code;
+    char *path;
+    char data[];
 };
 
-static void worker_opendir(struct job_opendir* job)
+static void worker_opendir(struct job_opendir *job)
 {
-  job->result = opendir(job->path);
-  job->error_code = errno;
+    job->result = opendir(job->path);
+    job->error_code = errno;
 }
 
-static value result_opendir(struct job_opendir* job)
+static value result_opendir(struct job_opendir *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result == NULL, "opendir", job->path);
-  value result = caml_alloc_small(1, Abstract_tag);
-  DIR_Val(result) = job->result;
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result == NULL, "opendir", job->path);
+    value result = caml_alloc_small(1, Abstract_tag);
+    DIR_Val(result) = job->result;
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_opendir_job(value path)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, opendir, 0, path);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB_STRING(job, opendir, 0, path);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -1701,30 +1685,30 @@ CAMLprim value lwt_unix_opendir_job(value path)
    +-----------------------------------------------------------------+ */
 
 struct job_closedir {
-  struct lwt_unix_job job;
-  int result;
-  int error_code;
-  DIR* dir;
+    struct lwt_unix_job job;
+    int result;
+    int error_code;
+    DIR *dir;
 };
 
-static void worker_closedir(struct job_closedir* job)
+static void worker_closedir(struct job_closedir *job)
 {
-  job->result = closedir(job->dir);
-  job->error_code = errno;
+    job->result = closedir(job->dir);
+    job->error_code = errno;
 }
 
-static value result_closedir(struct job_closedir* job)
+static value result_closedir(struct job_closedir *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->dir < 0, "closedir");
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    LWT_UNIX_CHECK_JOB(job, job->dir < 0, "closedir");
+    lwt_unix_free_job(&job->job);
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_closedir_job(value dir)
 {
-  LWT_UNIX_INIT_JOB(job, closedir, 0);
-  job->dir = DIR_Val(dir);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, closedir, 0);
+    job->dir = DIR_Val(dir);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* Directory handle validity. */
@@ -1748,26 +1732,22 @@ CAMLprim value lwt_unix_invalidate_dir(value dir)
    +-----------------------------------------------------------------+ */
 
 struct job_rewinddir {
-  struct lwt_unix_job job;
-  DIR* dir;
+    struct lwt_unix_job job;
+    DIR *dir;
 };
 
-static void worker_rewinddir(struct job_rewinddir *job)
-{
-  rewinddir(job->dir);
-}
-
+static void worker_rewinddir(struct job_rewinddir *job) { rewinddir(job->dir); }
 static value result_rewinddir(struct job_rewinddir *job)
 {
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    lwt_unix_free_job(&job->job);
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_rewinddir_job(value dir)
 {
-  LWT_UNIX_INIT_JOB(job, rewinddir, 0);
-  job->dir = DIR_Val(dir);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, rewinddir, 0);
+    job->dir = DIR_Val(dir);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* struct dirent size */
@@ -1778,12 +1758,10 @@ CAMLprim value lwt_unix_rewinddir_job(value dir)
    guess the size in this way. */
 static size_t dirent_size(DIR *dir)
 {
-    size_t size =
-        offsetof(struct dirent, d_name) +
-        fpathconf(dirfd(dir), _PC_NAME_MAX) + 1;
+    size_t size = offsetof(struct dirent, d_name) +
+                  fpathconf(dirfd(dir), _PC_NAME_MAX) + 1;
 
-    if (size < sizeof(struct dirent))
-        size = sizeof(struct dirent);
+    if (size < sizeof(struct dirent)) size = sizeof(struct dirent);
 
     return size;
 }
@@ -1793,43 +1771,43 @@ static size_t dirent_size(DIR *dir)
    +-----------------------------------------------------------------+ */
 
 struct job_readdir {
-  struct lwt_unix_job job;
-  DIR *dir;
-  struct dirent *entry;
-  struct dirent *ptr;
-  int result;
+    struct lwt_unix_job job;
+    DIR *dir;
+    struct dirent *entry;
+    struct dirent *ptr;
+    int result;
 };
 
 static void worker_readdir(struct job_readdir *job)
 {
-  job->entry = lwt_unix_malloc(dirent_size(job->dir));
-  job->result = readdir_r(job->dir, job->entry, &job->ptr);
+    job->entry = lwt_unix_malloc(dirent_size(job->dir));
+    job->result = readdir_r(job->dir, job->entry, &job->ptr);
 }
 
 static value result_readdir(struct job_readdir *job)
 {
-  int result = job->result;
-  if (result) {
-    free(job->entry);
-    lwt_unix_free_job(&job->job);
-    unix_error(result, "readdir", Nothing);
-  } else if (job->ptr == NULL) {
-    free(job->entry);
-    lwt_unix_free_job(&job->job);
-    caml_raise_end_of_file();
-  } else {
-    value name = caml_copy_string(job->entry->d_name);
-    free(job->entry);
-    lwt_unix_free_job(&job->job);
-    return name;
-  }
+    int result = job->result;
+    if (result) {
+        free(job->entry);
+        lwt_unix_free_job(&job->job);
+        unix_error(result, "readdir", Nothing);
+    } else if (job->ptr == NULL) {
+        free(job->entry);
+        lwt_unix_free_job(&job->job);
+        caml_raise_end_of_file();
+    } else {
+        value name = caml_copy_string(job->entry->d_name);
+        free(job->entry);
+        lwt_unix_free_job(&job->job);
+        return name;
+    }
 }
 
 CAMLprim value lwt_unix_readdir_job(value val_dir)
 {
-  LWT_UNIX_INIT_JOB(job, readdir, 0);
-  job->dir = DIR_Val(val_dir);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, readdir, 0);
+    job->dir = DIR_Val(val_dir);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -1837,64 +1815,63 @@ CAMLprim value lwt_unix_readdir_job(value val_dir)
    +-----------------------------------------------------------------+ */
 
 struct job_readdir_n {
-  struct lwt_unix_job job;
-  DIR *dir;
-  long count;
-  int error_code;
-  struct dirent entries[];
+    struct lwt_unix_job job;
+    DIR *dir;
+    long count;
+    int error_code;
+    struct dirent entries[];
 };
 
 static void worker_readdir_n(struct job_readdir_n *job)
 {
-  long i;
-  for(i = 0; i < job->count; i++) {
-    struct dirent *ptr;
-    int result = readdir_r(job->dir, &job->entries[i], &ptr);
+    long i;
+    for (i = 0; i < job->count; i++) {
+        struct dirent *ptr;
+        int result = readdir_r(job->dir, &job->entries[i], &ptr);
 
-    /* An error happened. */
-    if (result != 0) {
-      job->error_code = result;
-      return;
+        /* An error happened. */
+        if (result != 0) {
+            job->error_code = result;
+            return;
+        }
+
+        /* End of directory reached */
+        if (ptr == NULL) break;
     }
 
-    /* End of directory reached */
-    if (ptr == NULL)
-      break;
-  }
-
-  job->count = i;
-  job->error_code = 0;
+    job->count = i;
+    job->error_code = 0;
 }
 
 static value result_readdir_n(struct job_readdir_n *job)
 {
-  CAMLparam0();
-  CAMLlocal1(result);
-  int error_code = job->error_code;
-  if (error_code) {
-    lwt_unix_free_job(&job->job);
-    unix_error(error_code, "readdir", Nothing);
-  } else {
-    result = caml_alloc(job->count, 0);
-    long i;
-    for(i = 0; i < job->count; i++) {
-      Store_field(result, i, caml_copy_string(job->entries[i].d_name));
+    CAMLparam0();
+    CAMLlocal1(result);
+    int error_code = job->error_code;
+    if (error_code) {
+        lwt_unix_free_job(&job->job);
+        unix_error(error_code, "readdir", Nothing);
+    } else {
+        result = caml_alloc(job->count, 0);
+        long i;
+        for (i = 0; i < job->count; i++) {
+            Store_field(result, i, caml_copy_string(job->entries[i].d_name));
+        }
+        lwt_unix_free_job(&job->job);
+        CAMLreturn(result);
     }
-    lwt_unix_free_job(&job->job);
-    CAMLreturn(result);
-  }
 }
 
 CAMLprim value lwt_unix_readdir_n_job(value val_dir, value val_count)
 {
-  long count = Long_val(val_count);
-  DIR *dir = DIR_Val(val_dir);
+    long count = Long_val(val_count);
+    DIR *dir = DIR_Val(val_dir);
 
-  LWT_UNIX_INIT_JOB(job, readdir_n, dirent_size(dir) * count);
-  job->dir = dir;
-  job->count = count;
+    LWT_UNIX_INIT_JOB(job, readdir_n, dirent_size(dir) * count);
+    job->dir = dir;
+    job->count = count;
 
-  return lwt_unix_alloc_job(&job->job);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -1902,52 +1879,53 @@ CAMLprim value lwt_unix_readdir_n_job(value val_dir, value val_count)
    +-----------------------------------------------------------------+ */
 
 struct job_readlink {
-  struct lwt_unix_job job;
-  char *buffer;
-  ssize_t result;
-  int error_code;
-  char *name;
-  char data[];
+    struct lwt_unix_job job;
+    char *buffer;
+    ssize_t result;
+    int error_code;
+    char *name;
+    char data[];
 };
 
 static void worker_readlink(struct job_readlink *job)
 {
-  ssize_t buffer_size = 1024;
-  ssize_t link_length;
+    ssize_t buffer_size = 1024;
+    ssize_t link_length;
 
-  for (;;) {
-    job->buffer = lwt_unix_malloc(buffer_size + 1);
-    link_length = readlink(job->name, job->buffer, buffer_size);
+    for (;;) {
+        job->buffer = lwt_unix_malloc(buffer_size + 1);
+        link_length = readlink(job->name, job->buffer, buffer_size);
 
-    if (link_length < 0) {
-      free(job->buffer);
-      job->result = -1;
-      job->error_code = errno;
-      return;
-    } if (link_length < buffer_size) {
-      job->buffer[link_length] = 0;
-      job->result = link_length;
-      return;
-    } else {
-      free(job->buffer);
-      buffer_size *= 2;
+        if (link_length < 0) {
+            free(job->buffer);
+            job->result = -1;
+            job->error_code = errno;
+            return;
+        }
+        if (link_length < buffer_size) {
+            job->buffer[link_length] = 0;
+            job->result = link_length;
+            return;
+        } else {
+            free(job->buffer);
+            buffer_size *= 2;
+        }
     }
-  }
 }
 
 static value result_readlink(struct job_readlink *job)
 {
-  LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "readlink", job->name);
-  value result = caml_copy_string(job->buffer);
-  free(job->buffer);
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB_ARG(job, job->result < 0, "readlink", job->name);
+    value result = caml_copy_string(job->buffer);
+    free(job->buffer);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_readlink_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, readlink, 0, name);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, readlink, 0, name);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -1955,100 +1933,100 @@ CAMLprim value lwt_unix_readlink_job(value name)
    +-----------------------------------------------------------------+ */
 
 struct job_lockf {
-  struct lwt_unix_job job;
-  int fd;
-  int command;
-  long length;
-  int result;
-  int error_code;
+    struct lwt_unix_job job;
+    int fd;
+    int command;
+    long length;
+    int result;
+    int error_code;
 };
 
 #if defined(F_GETLK) && defined(F_SETLK) && defined(F_SETLKW)
 
 static void worker_lockf(struct job_lockf *job)
 {
-  struct flock l;
+    struct flock l;
 
-  l.l_whence = 1;
-  if (job->length < 0) {
-    l.l_start = job->length;
-    l.l_len = -job->length;
-  } else {
-    l.l_start = 0L;
-    l.l_len = job->length;
-  }
-  switch (job->command) {
-  case 0: /* F_ULOCK */
-    l.l_type = F_UNLCK;
-    job->result = fcntl(job->fd, F_SETLK, &l);
-    job->error_code = errno;
-    break;
-  case 1: /* F_LOCK */
-    l.l_type = F_WRLCK;
-    job->result = fcntl(job->fd, F_SETLKW, &l);
-    job->error_code = errno;
-    break;
-  case 2: /* F_TLOCK */
-    l.l_type = F_WRLCK;
-    job->result = fcntl(job->fd, F_SETLK, &l);
-    job->error_code = errno;
-    break;
-  case 3: /* F_TEST */
-    l.l_type = F_WRLCK;
-    job->result = fcntl(job->fd, F_GETLK, &l);
-    if (job->result != -1) {
-      if (l.l_type == F_UNLCK) {
-        job->result = 0;
-      } else {
-        job->result = -1;
-        job->error_code = EACCES;
-      }
+    l.l_whence = 1;
+    if (job->length < 0) {
+        l.l_start = job->length;
+        l.l_len = -job->length;
+    } else {
+        l.l_start = 0L;
+        l.l_len = job->length;
     }
-    break;
-  case 4: /* F_RLOCK */
-    l.l_type = F_RDLCK;
-    job->result = fcntl(job->fd, F_SETLKW, &l);
-    job->error_code = errno;
-    break;
-  case 5: /* F_TRLOCK */
-    l.l_type = F_RDLCK;
-    job->result = fcntl(job->fd, F_SETLK, &l);
-    job->error_code = errno;
-    break;
-  default:
-    job->result = -1;
-    job->error_code = EINVAL;
-  }
+    switch (job->command) {
+        case 0: /* F_ULOCK */
+            l.l_type = F_UNLCK;
+            job->result = fcntl(job->fd, F_SETLK, &l);
+            job->error_code = errno;
+            break;
+        case 1: /* F_LOCK */
+            l.l_type = F_WRLCK;
+            job->result = fcntl(job->fd, F_SETLKW, &l);
+            job->error_code = errno;
+            break;
+        case 2: /* F_TLOCK */
+            l.l_type = F_WRLCK;
+            job->result = fcntl(job->fd, F_SETLK, &l);
+            job->error_code = errno;
+            break;
+        case 3: /* F_TEST */
+            l.l_type = F_WRLCK;
+            job->result = fcntl(job->fd, F_GETLK, &l);
+            if (job->result != -1) {
+                if (l.l_type == F_UNLCK) {
+                    job->result = 0;
+                } else {
+                    job->result = -1;
+                    job->error_code = EACCES;
+                }
+            }
+            break;
+        case 4: /* F_RLOCK */
+            l.l_type = F_RDLCK;
+            job->result = fcntl(job->fd, F_SETLKW, &l);
+            job->error_code = errno;
+            break;
+        case 5: /* F_TRLOCK */
+            l.l_type = F_RDLCK;
+            job->result = fcntl(job->fd, F_SETLK, &l);
+            job->error_code = errno;
+            break;
+        default:
+            job->result = -1;
+            job->error_code = EINVAL;
+    }
 }
 
 #else
 
-static int lock_command_table[] = {
-  F_ULOCK, F_LOCK, F_TLOCK, F_TEST, F_LOCK, F_TLOCK
-};
+static int lock_command_table[] = {F_ULOCK, F_LOCK, F_TLOCK,
+                                   F_TEST,  F_LOCK, F_TLOCK};
 
 static void worker_lockf(struct job_lockf *job)
 {
-  job->result = lockf(job->fd, lock_command_table[job->command], job->length);
-  job->error_code = errno;
+    job->result = lockf(job->fd, lock_command_table[job->command], job->length);
+    job->error_code = errno;
 }
 
 #endif
 
 static value result_lockf(struct job_lockf *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "lockf");
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "lockf");
+    lwt_unix_free_job(&job->job);
+    return Val_unit;
 }
 
-CAMLprim value lwt_unix_lockf_job(value val_fd, value val_command, value val_length)
+CAMLprim value lwt_unix_lockf_job(value val_fd, value val_command,
+                                  value val_length)
 {
-  LWT_UNIX_INIT_JOB(job, lockf, 0);
-  job->fd = Int_val(val_fd);
-  job->command = Int_val(val_command);
-  job->length = Long_val(val_length);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, lockf, 0);
+    job->fd = Int_val(val_fd);
+    job->command = Int_val(val_command);
+    job->length = Long_val(val_length);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -2058,33 +2036,33 @@ CAMLprim value lwt_unix_lockf_job(value val_fd, value val_command, value val_len
 #if !defined(__ANDROID__)
 
 struct job_getlogin {
-  struct lwt_unix_job job;
-  char buffer[1024];
-  int result;
+    struct lwt_unix_job job;
+    char buffer[1024];
+    int result;
 };
 
 static void worker_getlogin(struct job_getlogin *job)
 {
-  job->result = getlogin_r(job->buffer, 1024);
+    job->result = getlogin_r(job->buffer, 1024);
 }
 
 static value result_getlogin(struct job_getlogin *job)
 {
-  int result = job->result;
-  if (result) {
-    lwt_unix_free_job(&job->job);
-    unix_error(result, "getlogin", Nothing);
-  } else {
-    value v = caml_copy_string(job->buffer);
-    lwt_unix_free_job(&job->job);
-    return v;
-  }
+    int result = job->result;
+    if (result) {
+        lwt_unix_free_job(&job->job);
+        unix_error(result, "getlogin", Nothing);
+    } else {
+        value v = caml_copy_string(job->buffer);
+        lwt_unix_free_job(&job->job);
+        return v;
+    }
 }
 
 CAMLprim value lwt_unix_getlogin_job(value Unit)
 {
-  LWT_UNIX_INIT_JOB(job, getlogin, 0);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, getlogin, 0);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 #else
@@ -2101,11 +2079,11 @@ LWT_NOT_AVAILABLE1(unix_getlogin_job)
 
 static value alloc_passwd_entry(struct passwd *entry)
 {
-  value res;
-  value name = Val_unit, passwd = Val_unit, gecos = Val_unit;
-  value dir = Val_unit, shell = Val_unit;
+    value res;
+    value name = Val_unit, passwd = Val_unit, gecos = Val_unit;
+    value dir = Val_unit, shell = Val_unit;
 
-  Begin_roots5 (name, passwd, gecos, dir, shell);
+    Begin_roots5(name, passwd, gecos, dir, shell);
     name = caml_copy_string(entry->pw_name);
     passwd = caml_copy_string(entry->pw_passwd);
 #if !defined(__BEOS__)
@@ -2123,76 +2101,85 @@ static value alloc_passwd_entry(struct passwd *entry)
     Field(res, 4) = gecos;
     Field(res, 5) = dir;
     Field(res, 6) = shell;
-  End_roots();
-  return res;
+    End_roots();
+    return res;
 }
 
 static value alloc_group_entry(struct group *entry)
 {
-  value res;
-  value name = Val_unit, pass = Val_unit, mem = Val_unit;
+    value res;
+    value name = Val_unit, pass = Val_unit, mem = Val_unit;
 
-  Begin_roots3 (name, pass, mem);
+    Begin_roots3(name, pass, mem);
     name = caml_copy_string(entry->gr_name);
     pass = caml_copy_string(entry->gr_passwd);
-    mem = caml_copy_string_array((const char**)entry->gr_mem);
+    mem = caml_copy_string_array((const char **)entry->gr_mem);
     res = caml_alloc_small(4, 0);
     Field(res, 0) = name;
     Field(res, 1) = pass;
     Field(res, 2) = Val_int(entry->gr_gid);
     Field(res, 3) = mem;
-  End_roots();
-  return res;
+    End_roots();
+    return res;
 }
 
-#define JOB_GET_ENTRY(INIT, FUNC, CONF, TYPE, ARG, ARG_DECL, FAIL_ARG)  \
-  struct job_##FUNC {                                                   \
-    struct lwt_unix_job job;                                            \
-    struct TYPE entry;                                                  \
-    struct TYPE *ptr;                                                   \
-    char *buffer;                                                       \
-    int result;                                                         \
-    ARG_DECL;                                                           \
-  };                                                                    \
-                                                                        \
-  static void worker_##FUNC(struct job_##FUNC *job)                     \
-  {                                                                     \
-    size_t buffer_size = sysconf(_SC_##CONF##_R_SIZE_MAX);              \
-    if (buffer_size == (size_t) -1) buffer_size = 16384;                \
-    job->buffer = (char*)lwt_unix_malloc(buffer_size);                  \
-    job->result = FUNC##_r(job->ARG, &job->entry, job->buffer, buffer_size, &job->ptr); \
-  }                                                                     \
-                                                                        \
-  static value result_##FUNC(struct job_##FUNC *job)                    \
-  {                                                                     \
-    int result = job->result;                                           \
-    if (result) {                                                       \
-      value arg = FAIL_ARG;                                             \
-      free(job->buffer);                                                \
-      lwt_unix_free_job(&job->job);                                     \
-      unix_error(result, #FUNC, arg);                                   \
-    } else if (job->ptr == NULL) {                                      \
-      free(job->buffer);                                                \
-      lwt_unix_free_job(&job->job);                                     \
-      caml_raise_not_found();                                           \
-    } else {                                                            \
-      value entry = alloc_##TYPE##_entry(&job->entry);                  \
-      free(job->buffer);                                                \
-      lwt_unix_free_job(&job->job);                                     \
-      return entry;                                                     \
-    }                                                                   \
-  }                                                                     \
-                                                                        \
-  CAMLprim value lwt_unix_##FUNC##_job(value ARG)                       \
-  {                                                                     \
-    INIT;                                                               \
-    return lwt_unix_alloc_job(&job->job);                               \
-  }
+#define JOB_GET_ENTRY(INIT, FUNC, CONF, TYPE, ARG, ARG_DECL, FAIL_ARG) \
+    struct job_##FUNC {                                                \
+        struct lwt_unix_job job;                                       \
+        struct TYPE entry;                                             \
+        struct TYPE *ptr;                                              \
+        char *buffer;                                                  \
+        int result;                                                    \
+        ARG_DECL;                                                      \
+    };                                                                 \
+                                                                       \
+    static void worker_##FUNC(struct job_##FUNC *job)                  \
+    {                                                                  \
+        size_t buffer_size = sysconf(_SC_##CONF##_R_SIZE_MAX);         \
+        if (buffer_size == (size_t)-1) buffer_size = 16384;            \
+        job->buffer = (char *)lwt_unix_malloc(buffer_size);            \
+        job->result = FUNC##_r(job->ARG, &job->entry, job->buffer,     \
+                               buffer_size, &job->ptr);                \
+    }                                                                  \
+                                                                       \
+    static value result_##FUNC(struct job_##FUNC *job)                 \
+    {                                                                  \
+        int result = job->result;                                      \
+        if (result) {                                                  \
+            value arg = FAIL_ARG;                                      \
+            free(job->buffer);                                         \
+            lwt_unix_free_job(&job->job);                              \
+            unix_error(result, #FUNC, arg);                            \
+        } else if (job->ptr == NULL) {                                 \
+            free(job->buffer);                                         \
+            lwt_unix_free_job(&job->job);                              \
+            caml_raise_not_found();                                    \
+        } else {                                                       \
+            value entry = alloc_##TYPE##_entry(&job->entry);           \
+            free(job->buffer);                                         \
+            lwt_unix_free_job(&job->job);                              \
+            return entry;                                              \
+        }                                                              \
+    }                                                                  \
+                                                                       \
+    CAMLprim value lwt_unix_##FUNC##_job(value ARG)                    \
+    {                                                                  \
+        INIT;                                                          \
+        return lwt_unix_alloc_job(&job->job);                          \
+    }
 
-JOB_GET_ENTRY(LWT_UNIX_INIT_JOB_STRING(job, getpwnam, 0, name), getpwnam, GETPW, passwd, name, char *name; char data[], caml_copy_string(job->name))
-JOB_GET_ENTRY(LWT_UNIX_INIT_JOB_STRING(job, getgrnam, 0, name), getgrnam, GETGR, group, name, char *name; char data[], caml_copy_string(job->name))
-JOB_GET_ENTRY(LWT_UNIX_INIT_JOB(job, getpwuid, 0); job->uid = Int_val(uid), getpwuid, GETPW, passwd, uid, int uid, Nothing)
-JOB_GET_ENTRY(LWT_UNIX_INIT_JOB(job, getgrgid, 0); job->gid = Int_val(gid), getgrgid, GETGR, group, gid, int gid, Nothing)
+JOB_GET_ENTRY(LWT_UNIX_INIT_JOB_STRING(job, getpwnam, 0, name), getpwnam, GETPW,
+              passwd, name, char *name;
+              char data[], caml_copy_string(job->name))
+JOB_GET_ENTRY(LWT_UNIX_INIT_JOB_STRING(job, getgrnam, 0, name), getgrnam, GETGR,
+              group, name, char *name;
+              char data[], caml_copy_string(job->name))
+JOB_GET_ENTRY(LWT_UNIX_INIT_JOB(job, getpwuid, 0); job->uid = Int_val(uid),
+                                                   getpwuid, GETPW, passwd, uid,
+                                                   int uid, Nothing)
+JOB_GET_ENTRY(LWT_UNIX_INIT_JOB(job, getgrgid, 0); job->gid = Int_val(gid),
+                                                   getgrgid, GETGR, group, gid,
+                                                   int gid, Nothing)
 
 #else
 
@@ -2206,97 +2193,99 @@ LWT_NOT_AVAILABLE1(unix_getgrgid_job)
 /* Helper functions for not re-entrant functions */
 
 /* keep test in sync with discover.ml */
-#if !defined(HAS_GETHOSTBYADDR_R) || (HAS_GETHOSTBYADDR_R != 7 && HAS_GETHOSTBYADDR_R != 8)
+#if !defined(HAS_GETHOSTBYADDR_R) || \
+    (HAS_GETHOSTBYADDR_R != 7 && HAS_GETHOSTBYADDR_R != 8)
 #define NON_R_GETHOSTBYADDR 1
 #endif
 
 /* keep test in sync with discover.ml */
-#if !defined(HAS_GETHOSTBYNAME_R) || (HAS_GETHOSTBYNAME_R != 5 && HAS_GETHOSTBYNAME_R != 6)
+#if !defined(HAS_GETHOSTBYNAME_R) || \
+    (HAS_GETHOSTBYNAME_R != 5 && HAS_GETHOSTBYNAME_R != 6)
 #define NON_R_GETHOSTBYNAME 1
 #endif
 
 #if defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
-static char **
-c_copy_addr_array(char ** src, int addr_len)
+static char **c_copy_addr_array(char **src, int addr_len)
 {
-  if ( src == NULL ){
-    return NULL;
-  }
-  char ** p = src;
-  size_t i = 0 ;
-  while ( *p ){
-    i++;
-    p++;
-  }
-  const size_t ar_len = i;
-  p = malloc((ar_len+1) * sizeof(char*));
-  if ( p == NULL ){
-    return NULL;
-  }
-  for ( i = 0 ; i < ar_len ; ++i ){
-    p[i] = malloc(addr_len);
-    if ( p[i] == NULL ){
-      size_t j;
-      for ( j = 0 ; j < i ; j++ ){
-        free(p[j]);
-      }
-      free(p);
-      return NULL;
+    if (src == NULL) {
+        return NULL;
     }
-    memcpy(p[i],src[i],addr_len);
-  }
-  p[ar_len] = NULL;
-  return p;
+    char **p = src;
+    size_t i = 0;
+    while (*p) {
+        i++;
+        p++;
+    }
+    const size_t ar_len = i;
+    p = malloc((ar_len + 1) * sizeof(char *));
+    if (p == NULL) {
+        return NULL;
+    }
+    for (i = 0; i < ar_len; ++i) {
+        p[i] = malloc(addr_len);
+        if (p[i] == NULL) {
+            size_t j;
+            for (j = 0; j < i; j++) {
+                free(p[j]);
+            }
+            free(p);
+            return NULL;
+        }
+        memcpy(p[i], src[i], addr_len);
+    }
+    p[ar_len] = NULL;
+    return p;
 }
 #endif
-#if !defined(HAVE_NETDB_REENTRANT) || defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
-static char **
-c_copy_string_array(char **src)
+#if !defined(HAVE_NETDB_REENTRANT) || defined(NON_R_GETHOSTBYADDR) || \
+    defined(NON_R_GETHOSTBYNAME)
+static char **c_copy_string_array(char **src)
 {
-  char ** p = src;
-  size_t i = 0 ;
-  size_t len ;
-  if ( src == NULL ){
-    return NULL;
-  }
-  while ( *p ){
-    i++;
-    p++;
-  }
-  len = i;
-  p = malloc((len+1) * sizeof(char *));
-  if ( p == NULL ){
-    return NULL;
-  }
-  for ( i = 0 ; i < len ; ++i ){
-    p[i] = strdup(src[i]);
-    if ( p[i] == NULL ){
-      size_t j;
-      for ( j = 0 ; j < i ; j++ ){
-        free(p[j]);
-      }
-      free(p);
-      return NULL;
+    char **p = src;
+    size_t i = 0;
+    size_t len;
+    if (src == NULL) {
+        return NULL;
     }
-  }
-  p[len] = NULL;
-  return p;
+    while (*p) {
+        i++;
+        p++;
+    }
+    len = i;
+    p = malloc((len + 1) * sizeof(char *));
+    if (p == NULL) {
+        return NULL;
+    }
+    for (i = 0; i < len; ++i) {
+        p[i] = strdup(src[i]);
+        if (p[i] == NULL) {
+            size_t j;
+            for (j = 0; j < i; j++) {
+                free(p[j]);
+            }
+            free(p);
+            return NULL;
+        }
+    }
+    p[len] = NULL;
+    return p;
 }
 
-static void c_free_string_array(char ** src)
+static void c_free_string_array(char **src)
 {
-  if ( src ){
-    char ** p = src;
-    while (*p){
-      free(*p);
-      ++p;
+    if (src) {
+        char **p = src;
+        while (*p) {
+            free(*p);
+            ++p;
+        }
+        free(src);
     }
-    free(src);
-  }
 }
 
-static inline char * s_strdup (const char *s){
-  return (strdup( s == NULL ? "" : s ));
+static inline char *s_strdup(const char *s)
+{
+    return (strdup(s == NULL ? "" : s));
 }
 #endif
 
@@ -2305,52 +2294,51 @@ static inline char * s_strdup (const char *s){
    +-----------------------------------------------------------------+ */
 
 struct job_gethostname {
-  struct lwt_unix_job job;
-  char *buffer;
-  int result;
-  int error_code;
+    struct lwt_unix_job job;
+    char *buffer;
+    int result;
+    int error_code;
 };
 
 static void worker_gethostname(struct job_gethostname *job)
 {
-  int buffer_size = 64;
-  int err;
+    int buffer_size = 64;
+    int err;
 
-  for (;;) {
+    for (;;) {
+        job->buffer = lwt_unix_malloc(buffer_size + 1);
 
-    job->buffer = lwt_unix_malloc(buffer_size + 1);
+        err = gethostname(job->buffer, buffer_size);
 
-    err = gethostname(job->buffer, buffer_size);
-
-    if (err == -1 && errno == ENAMETOOLONG) {
-      free(job->buffer);
-      buffer_size *= 2;
-    } else if (err == -1) {
-      free(job->buffer);
-      job->result = -1;
-      job->error_code = errno;
-      return;
-    } else {
-      job->buffer[buffer_size] = 0;
-      job->result = 0;
-      return;
+        if (err == -1 && errno == ENAMETOOLONG) {
+            free(job->buffer);
+            buffer_size *= 2;
+        } else if (err == -1) {
+            free(job->buffer);
+            job->result = -1;
+            job->error_code = errno;
+            return;
+        } else {
+            job->buffer[buffer_size] = 0;
+            job->result = 0;
+            return;
+        }
     }
-  }
 }
 
 static value result_gethostname(struct job_gethostname *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "gethostname");
-  value result = caml_copy_string(job->buffer);
-  free(job->buffer);
-  lwt_unix_free_job(&job->job);
-  return result;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "gethostname");
+    value result = caml_copy_string(job->buffer);
+    free(job->buffer);
+    lwt_unix_free_job(&job->job);
+    return result;
 }
 
 CAMLprim value lwt_unix_gethostname_job(value Unit)
 {
-  LWT_UNIX_INIT_JOB(job, gethostname, 0);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB(job, gethostname, 0);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -2360,165 +2348,169 @@ CAMLprim value lwt_unix_gethostname_job(value Unit)
 #define NETDB_BUFFER_SIZE 10000
 
 struct job_gethostbyname {
-  struct lwt_unix_job job;
-  struct hostent entry;
-  struct hostent *ptr;
+    struct lwt_unix_job job;
+    struct hostent entry;
+    struct hostent *ptr;
 #ifndef NON_R_GETHOSTBYNAME
-  char buffer[NETDB_BUFFER_SIZE];
+    char buffer[NETDB_BUFFER_SIZE];
 #endif
-  char *name;
-  char data[];
+    char *name;
+    char data[];
 };
 
-CAMLexport value alloc_inet_addr (struct in_addr * inaddr);
-#define GET_INET_ADDR(v) (*((struct in_addr *) (v)))
+CAMLexport value alloc_inet_addr(struct in_addr *inaddr);
+#define GET_INET_ADDR(v) (*((struct in_addr *)(v)))
 
-CAMLexport value alloc_inet6_addr (struct in6_addr * inaddr);
-#define GET_INET6_ADDR(v) (*((struct in6_addr *) (v)))
+CAMLexport value alloc_inet6_addr(struct in6_addr *inaddr);
+#define GET_INET6_ADDR(v) (*((struct in6_addr *)(v)))
 
 static value alloc_one_addr(char const *a)
 {
-  struct in_addr addr;
-  memmove (&addr, a, 4);
-  return alloc_inet_addr(&addr);
+    struct in_addr addr;
+    memmove(&addr, a, 4);
+    return alloc_inet_addr(&addr);
 }
 
 static value alloc_one_addr6(char const *a)
 {
-  struct in6_addr addr;
-  memmove(&addr, a, 16);
-  return alloc_inet6_addr(&addr);
+    struct in6_addr addr;
+    memmove(&addr, a, 16);
+    return alloc_inet6_addr(&addr);
 }
 
 static value alloc_host_entry(struct hostent *entry)
 {
-  value res;
-  value name = Val_unit, aliases = Val_unit;
-  value addr_list = Val_unit, adr = Val_unit;
+    value res;
+    value name = Val_unit, aliases = Val_unit;
+    value addr_list = Val_unit, adr = Val_unit;
 
-  Begin_roots4 (name, aliases, addr_list, adr);
+    Begin_roots4(name, aliases, addr_list, adr);
     name = caml_copy_string((char *)(entry->h_name));
     /* PR#4043: protect against buggy implementations of gethostbynamee()
        that return a NULL pointer in h_aliases */
     if (entry->h_aliases)
-      aliases = caml_copy_string_array((const char**)entry->h_aliases);
+        aliases = caml_copy_string_array((const char **)entry->h_aliases);
     else
-      aliases = Atom(0);
+        aliases = Atom(0);
     if (entry->h_length == 16)
-      addr_list =
-        caml_alloc_array(alloc_one_addr6, (const char**)entry->h_addr_list);
+        addr_list = caml_alloc_array(alloc_one_addr6,
+                                     (const char **)entry->h_addr_list);
     else
-      addr_list =
-        caml_alloc_array(alloc_one_addr, (const char**)entry->h_addr_list);
+        addr_list =
+            caml_alloc_array(alloc_one_addr, (const char **)entry->h_addr_list);
     res = caml_alloc_small(4, 0);
     Field(res, 0) = name;
     Field(res, 1) = aliases;
     switch (entry->h_addrtype) {
-    case PF_UNIX:          Field(res, 2) = Val_int(0); break;
-    case PF_INET:          Field(res, 2) = Val_int(1); break;
-    default: /*PF_INET6 */ Field(res, 2) = Val_int(2); break;
+        case PF_UNIX:
+            Field(res, 2) = Val_int(0);
+            break;
+        case PF_INET:
+            Field(res, 2) = Val_int(1);
+            break;
+        default: /*PF_INET6 */
+            Field(res, 2) = Val_int(2);
+            break;
     }
     Field(res, 3) = addr_list;
-  End_roots();
-  return res;
+    End_roots();
+    return res;
 }
 
 #if defined(NON_R_GETHOSTBYADDR) || defined(NON_R_GETHOSTBYNAME)
-static struct hostent *
-hostent_dup(struct hostent *orig)
+static struct hostent *hostent_dup(struct hostent *orig)
 {
-  if ( orig == NULL ){
-    return NULL;
-  }
-  struct hostent *h = malloc(sizeof *h);
-  if ( h == NULL ){
-    return NULL;
-  }
-  h->h_name = s_strdup(orig->h_name);
-  if ( !h->h_name ){
-    goto nomem1;
-  }
-  if ( !orig->h_aliases ){
-    h->h_aliases = NULL;
-  }
-  else {
-    h->h_aliases = c_copy_string_array(orig->h_aliases);
-    if ( !h->h_aliases){
-      goto nomem2;
+    if (orig == NULL) {
+        return NULL;
     }
-  }
-  if ( !orig->h_addr_list ){
-    h->h_addr_list = NULL;
-  }
-  else {
-    h->h_addr_list = c_copy_addr_array(orig->h_addr_list,orig->h_length);
-    if ( !h->h_addr_list ){
-      goto nomem3;
+    struct hostent *h = malloc(sizeof *h);
+    if (h == NULL) {
+        return NULL;
     }
-  }
-  h->h_addrtype = orig->h_addrtype;
-  h->h_length = orig->h_length;
-  return h;
+    h->h_name = s_strdup(orig->h_name);
+    if (!h->h_name) {
+        goto nomem1;
+    }
+    if (!orig->h_aliases) {
+        h->h_aliases = NULL;
+    } else {
+        h->h_aliases = c_copy_string_array(orig->h_aliases);
+        if (!h->h_aliases) {
+            goto nomem2;
+        }
+    }
+    if (!orig->h_addr_list) {
+        h->h_addr_list = NULL;
+    } else {
+        h->h_addr_list = c_copy_addr_array(orig->h_addr_list, orig->h_length);
+        if (!h->h_addr_list) {
+            goto nomem3;
+        }
+    }
+    h->h_addrtype = orig->h_addrtype;
+    h->h_length = orig->h_length;
+    return h;
 nomem3:
-  c_free_string_array(h->h_aliases);
+    c_free_string_array(h->h_aliases);
 nomem2:
-  free((char*)h->h_name);
+    free((char *)h->h_name);
 nomem1:
-  free(h);
-  return NULL;
+    free(h);
+    return NULL;
 }
 
-static void
-hostent_free(struct hostent *h)
+static void hostent_free(struct hostent *h)
 {
-  if ( h ){
-    c_free_string_array(h->h_addr_list);
-    c_free_string_array(h->h_aliases);
-    free((char*)h->h_name);
-    free(h);
-  }
+    if (h) {
+        c_free_string_array(h->h_addr_list);
+        c_free_string_array(h->h_aliases);
+        free((char *)h->h_name);
+        free(h);
+    }
 }
 #endif
 
 static void worker_gethostbyname(struct job_gethostbyname *job)
 {
 #if HAS_GETHOSTBYNAME_R == 5
-  int h_errno;
-  job->ptr = gethostbyname_r(job->name, &job->entry, job->buffer, NETDB_BUFFER_SIZE, &h_errno);
+    int h_errno;
+    job->ptr = gethostbyname_r(job->name, &job->entry, job->buffer,
+                               NETDB_BUFFER_SIZE, &h_errno);
 #elif HAS_GETHOSTBYNAME_R == 6
-  int h_errno;
-  if (gethostbyname_r(job->name, &job->entry, job->buffer, NETDB_BUFFER_SIZE, &(job->ptr), &h_errno) != 0)
-    job->ptr = NULL;
+    int h_errno;
+    if (gethostbyname_r(job->name, &job->entry, job->buffer, NETDB_BUFFER_SIZE,
+                        &(job->ptr), &h_errno) != 0)
+        job->ptr = NULL;
 #else
-  job->ptr = gethostbyname(job->name);
-  if (job->ptr) {
-    job->ptr= hostent_dup(job->ptr);
-    if ( job->ptr ){
-      job->entry = *job->ptr;
+    job->ptr = gethostbyname(job->name);
+    if (job->ptr) {
+        job->ptr = hostent_dup(job->ptr);
+        if (job->ptr) {
+            job->entry = *job->ptr;
+        }
     }
-  }
 #endif
 }
 
 static value result_gethostbyname(struct job_gethostbyname *job)
 {
-  if (job->ptr == NULL) {
-    lwt_unix_free_job(&job->job);
-    caml_raise_not_found();
-  } else {
-    value entry = alloc_host_entry(&job->entry);
+    if (job->ptr == NULL) {
+        lwt_unix_free_job(&job->job);
+        caml_raise_not_found();
+    } else {
+        value entry = alloc_host_entry(&job->entry);
 #ifdef NON_R_GETHOSTBYNAME
-    hostent_free(job->ptr);
+        hostent_free(job->ptr);
 #endif
-    lwt_unix_free_job(&job->job);
-    return entry;
-  }
+        lwt_unix_free_job(&job->job);
+        return entry;
+    }
 }
 
 CAMLprim value lwt_unix_gethostbyname_job(value name)
 {
-  LWT_UNIX_INIT_JOB_STRING(job, gethostbyname, 0, name);
-  return lwt_unix_alloc_job(&(job->job));
+    LWT_UNIX_INIT_JOB_STRING(job, gethostbyname, 0, name);
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -2526,55 +2518,57 @@ CAMLprim value lwt_unix_gethostbyname_job(value name)
    +-----------------------------------------------------------------+ */
 
 struct job_gethostbyaddr {
-  struct lwt_unix_job job;
-  struct in_addr addr;
-  struct hostent entry;
-  struct hostent *ptr;
+    struct lwt_unix_job job;
+    struct in_addr addr;
+    struct hostent entry;
+    struct hostent *ptr;
 #ifndef NON_R_GETHOSTBYADDR
-  char buffer[NETDB_BUFFER_SIZE];
+    char buffer[NETDB_BUFFER_SIZE];
 #endif
 };
 
 static void worker_gethostbyaddr(struct job_gethostbyaddr *job)
 {
 #if HAS_GETHOSTBYADDR_R == 7
-  int h_errno;
-  job->ptr = gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer, NETDB_BUFFER_SIZE, &h_errno);
+    int h_errno;
+    job->ptr = gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer,
+                               NETDB_BUFFER_SIZE, &h_errno);
 #elif HAS_GETHOSTBYADDR_R == 8
-  int h_errno;
-  if (gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer, NETDB_BUFFER_SIZE, &job->ptr, &h_errno) != 0)
-    job->ptr = NULL;
+    int h_errno;
+    if (gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer,
+                        NETDB_BUFFER_SIZE, &job->ptr, &h_errno) != 0)
+        job->ptr = NULL;
 #else
-  job->ptr = gethostbyaddr(&job->addr, 4, AF_INET);
-  if (job->ptr) {
-    job->ptr = hostent_dup(job->ptr);
-    if ( job->ptr ){
-      job->entry = *job->ptr;
+    job->ptr = gethostbyaddr(&job->addr, 4, AF_INET);
+    if (job->ptr) {
+        job->ptr = hostent_dup(job->ptr);
+        if (job->ptr) {
+            job->entry = *job->ptr;
+        }
     }
-  }
 #endif
 }
 
 static value result_gethostbyaddr(struct job_gethostbyaddr *job)
 {
-  if (job->ptr == NULL) {
-    lwt_unix_free_job(&job->job);
-    caml_raise_not_found();
-  } else {
-    value entry = alloc_host_entry(&job->entry);
+    if (job->ptr == NULL) {
+        lwt_unix_free_job(&job->job);
+        caml_raise_not_found();
+    } else {
+        value entry = alloc_host_entry(&job->entry);
 #ifdef NON_R_GETHOSTBYADDR
-    hostent_free(job->ptr);
+        hostent_free(job->ptr);
 #endif
-    lwt_unix_free_job(&job->job);
-    return entry;
-  }
+        lwt_unix_free_job(&job->job);
+        return entry;
+    }
 }
 
 CAMLprim value lwt_unix_gethostbyaddr_job(value val_addr)
 {
-  LWT_UNIX_INIT_JOB(job, gethostbyaddr, 0);
-  job->addr = GET_INET_ADDR(val_addr);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, gethostbyaddr, 0);
+    job->addr = GET_INET_ADDR(val_addr);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -2583,347 +2577,334 @@ CAMLprim value lwt_unix_gethostbyaddr_job(value val_addr)
 
 static value alloc_protoent(struct protoent *entry)
 {
-  value res;
-  value name = Val_unit, aliases = Val_unit;
+    value res;
+    value name = Val_unit, aliases = Val_unit;
 
-  Begin_roots2 (name, aliases);
+    Begin_roots2(name, aliases);
     name = caml_copy_string(entry->p_name);
-    aliases = caml_copy_string_array((const char**)entry->p_aliases);
+    aliases = caml_copy_string_array((const char **)entry->p_aliases);
     res = caml_alloc_small(3, 0);
-    Field(res,0) = name;
-    Field(res,1) = aliases;
-    Field(res,2) = Val_int(entry->p_proto);
-  End_roots();
-  return res;
+    Field(res, 0) = name;
+    Field(res, 1) = aliases;
+    Field(res, 2) = Val_int(entry->p_proto);
+    End_roots();
+    return res;
 }
 
 static value alloc_servent(struct servent *entry)
 {
-  value res;
-  value name = Val_unit, aliases = Val_unit, proto = Val_unit;
+    value res;
+    value name = Val_unit, aliases = Val_unit, proto = Val_unit;
 
-  Begin_roots3 (name, aliases, proto);
+    Begin_roots3(name, aliases, proto);
     name = caml_copy_string(entry->s_name);
-    aliases = caml_copy_string_array((const char**)entry->s_aliases);
+    aliases = caml_copy_string_array((const char **)entry->s_aliases);
     proto = caml_copy_string(entry->s_proto);
     res = caml_alloc_small(4, 0);
-    Field(res,0) = name;
-    Field(res,1) = aliases;
-    Field(res,2) = Val_int(ntohs(entry->s_port));
-    Field(res,3) = proto;
-  End_roots();
-  return res;
+    Field(res, 0) = name;
+    Field(res, 1) = aliases;
+    Field(res, 2) = Val_int(ntohs(entry->s_port));
+    Field(res, 3) = proto;
+    End_roots();
+    return res;
 }
 
 #if defined(HAVE_NETDB_REENTRANT)
 
-#define JOB_GET_ENTRY2(INIT, FUNC, TYPE, ARGS_VAL, ARGS_DECL, ARGS_CALL) \
-  struct job_##FUNC {                                                   \
-    struct lwt_unix_job job;                                            \
-    struct TYPE entry;                                                  \
-    struct TYPE *ptr;                                                   \
-    char *buffer;                                                       \
-    ARGS_DECL;                                                          \
-  };                                                                    \
-                                                                        \
-  static void worker_##FUNC(struct job_##FUNC *job)                     \
-  {                                                                     \
-    size_t size = 1024;                                                 \
-    for (;;) {                                                          \
-      job->buffer = (char*)lwt_unix_malloc(size);                       \
-                                                                        \
-      int result = FUNC##_r(ARGS_CALL, &job->entry, job->buffer, size, &job->ptr); \
-                                                                        \
-      switch (result) {                                                 \
-      case 0:                                                           \
-        return;                                                         \
-      case ERANGE:                                                      \
-        free(job->buffer);                                              \
-        size += 1024;                                                   \
-        break;                                                          \
-      case ENOENT:                                                      \
-      default:                                                          \
-        job->ptr = NULL;                                                \
-        return;                                                         \
-      }                                                                 \
-    }                                                                   \
-  }                                                                     \
-                                                                        \
-  static value result_##FUNC(struct job_##FUNC *job)                    \
-  {                                                                     \
-    if (job->ptr == NULL) {                                             \
-      free(job->buffer);                                                \
-      lwt_unix_free_job(&job->job);                                     \
-      caml_raise_not_found();                                           \
-    } else {                                                            \
-      value res = alloc_##TYPE(&job->entry);                            \
-      free(job->buffer);                                                \
-      lwt_unix_free_job(&job->job);                                     \
-      return res;                                                       \
-    }                                                                   \
-  }                                                                     \
-                                                                        \
-  CAMLprim value lwt_unix_##FUNC##_job(ARGS_VAL)                        \
-  {                                                                     \
-    INIT;                                                               \
-    return lwt_unix_alloc_job(&(job->job));                             \
-  }
+#define JOB_GET_ENTRY2(INIT, FUNC, TYPE, ARGS_VAL, ARGS_DECL, ARGS_CALL)     \
+    struct job_##FUNC {                                                      \
+        struct lwt_unix_job job;                                             \
+        struct TYPE entry;                                                   \
+        struct TYPE *ptr;                                                    \
+        char *buffer;                                                        \
+        ARGS_DECL;                                                           \
+    };                                                                       \
+                                                                             \
+    static void worker_##FUNC(struct job_##FUNC *job)                        \
+    {                                                                        \
+        size_t size = 1024;                                                  \
+        for (;;) {                                                           \
+            job->buffer = (char *)lwt_unix_malloc(size);                     \
+                                                                             \
+            int result = FUNC##_r(ARGS_CALL, &job->entry, job->buffer, size, \
+                                  &job->ptr);                                \
+                                                                             \
+            switch (result) {                                                \
+                case 0:                                                      \
+                    return;                                                  \
+                case ERANGE:                                                 \
+                    free(job->buffer);                                       \
+                    size += 1024;                                            \
+                    break;                                                   \
+                case ENOENT:                                                 \
+                default:                                                     \
+                    job->ptr = NULL;                                         \
+                    return;                                                  \
+            }                                                                \
+        }                                                                    \
+    }                                                                        \
+                                                                             \
+    static value result_##FUNC(struct job_##FUNC *job)                       \
+    {                                                                        \
+        if (job->ptr == NULL) {                                              \
+            free(job->buffer);                                               \
+            lwt_unix_free_job(&job->job);                                    \
+            caml_raise_not_found();                                          \
+        } else {                                                             \
+            value res = alloc_##TYPE(&job->entry);                           \
+            free(job->buffer);                                               \
+            lwt_unix_free_job(&job->job);                                    \
+            return res;                                                      \
+        }                                                                    \
+    }                                                                        \
+                                                                             \
+    CAMLprim value lwt_unix_##FUNC##_job(ARGS_VAL)                           \
+    {                                                                        \
+        INIT;                                                                \
+        return lwt_unix_alloc_job(&(job->job));                              \
+    }
 
 #else /* defined(HAVE_NETDB_REENTRANT) */
 
-static struct servent * servent_dup(const struct servent * serv)
+static struct servent *servent_dup(const struct servent *serv)
 {
-  struct servent * s;
-  if (!serv){
-    return NULL;
-  }
-  s = malloc(sizeof *s);
-  if ( s == NULL ){
-    goto nomem1;
-  }
-  s->s_name = s_strdup(serv->s_name);
-  if ( s->s_name == NULL ){
-    goto nomem2;
-  }
-  s->s_proto = s_strdup(serv->s_proto);
-  if ( s->s_proto == NULL ){
-    goto nomem3;
-  }
-  s->s_aliases = c_copy_string_array(serv->s_aliases);
-  if ( s->s_aliases == NULL && serv->s_aliases != NULL ){
-    goto nomem4;
-  }
-  s->s_port = serv->s_port;
-  return s;
+    struct servent *s;
+    if (!serv) {
+        return NULL;
+    }
+    s = malloc(sizeof *s);
+    if (s == NULL) {
+        goto nomem1;
+    }
+    s->s_name = s_strdup(serv->s_name);
+    if (s->s_name == NULL) {
+        goto nomem2;
+    }
+    s->s_proto = s_strdup(serv->s_proto);
+    if (s->s_proto == NULL) {
+        goto nomem3;
+    }
+    s->s_aliases = c_copy_string_array(serv->s_aliases);
+    if (s->s_aliases == NULL && serv->s_aliases != NULL) {
+        goto nomem4;
+    }
+    s->s_port = serv->s_port;
+    return s;
 nomem4:
-  free(s->s_proto);
+    free(s->s_proto);
 nomem3:
-  free(s->s_name);
+    free(s->s_name);
 nomem2:
-  free(s);
+    free(s);
 nomem1:
-  return NULL;
+    return NULL;
 }
 
-static void servent_free(struct servent * s)
+static void servent_free(struct servent *s)
 {
-  if ( ! s ){
-    return;
-  }
-  free(s->s_proto);
-  free(s->s_name);
-  c_free_string_array(s->s_aliases);
-  free(s);
+    if (!s) {
+        return;
+    }
+    free(s->s_proto);
+    free(s->s_name);
+    c_free_string_array(s->s_aliases);
+    free(s);
 }
 
-static struct protoent * protoent_dup(const struct protoent * proto)
+static struct protoent *protoent_dup(const struct protoent *proto)
 {
-  if (!proto){
-    return NULL;
-  }
-  struct protoent * p = malloc(sizeof *p);
-  if ( p == NULL ){
-    return NULL;
-  }
-  p->p_name = s_strdup(proto->p_name);
-  if ( p->p_name == NULL ){
-    goto nomem1;
-  }
-  p->p_aliases = c_copy_string_array( proto->p_aliases );
-  if ( p->p_aliases == NULL && proto->p_aliases != NULL ){
-    goto nomem2;
-  }
-  p->p_proto = proto->p_proto;
-  return p;
+    if (!proto) {
+        return NULL;
+    }
+    struct protoent *p = malloc(sizeof *p);
+    if (p == NULL) {
+        return NULL;
+    }
+    p->p_name = s_strdup(proto->p_name);
+    if (p->p_name == NULL) {
+        goto nomem1;
+    }
+    p->p_aliases = c_copy_string_array(proto->p_aliases);
+    if (p->p_aliases == NULL && proto->p_aliases != NULL) {
+        goto nomem2;
+    }
+    p->p_proto = proto->p_proto;
+    return p;
 nomem2:
-  free(p->p_name);
-nomem1:
-  free(p);
-  return NULL;
-}
-
-static void protoent_free(struct protoent * p)
-{
-  if ( p ){
     free(p->p_name);
-    c_free_string_array(p->p_aliases);
+nomem1:
     free(p);
-  }
+    return NULL;
+}
+
+static void protoent_free(struct protoent *p)
+{
+    if (p) {
+        free(p->p_name);
+        c_free_string_array(p->p_aliases);
+        free(p);
+    }
 }
 
 #define JOB_GET_ENTRY2(INIT, FUNC, TYPE, ARGS_VAL, ARGS_DECL, ARGS_CALL) \
-  struct job_##FUNC {                                                   \
-    struct lwt_unix_job job;                                            \
-    struct TYPE *entry;                                                 \
-    ARGS_DECL;                                                          \
-  };                                                                    \
-                                                                        \
-  static void worker_##FUNC(struct job_##FUNC *job)                     \
-  {                                                                     \
-    job->entry = FUNC(ARGS_CALL);                                       \
-    if ( job->entry ){                                                  \
-      job->entry = TYPE ## _dup ( job->entry );                         \
-      if (! job->entry ){                                               \
-      }                                                                 \
-    }                                                                   \
-  }                                                                     \
-                                                                        \
-  static value result_##FUNC(struct job_##FUNC *job)                    \
-  {                                                                     \
-    if (job->entry == NULL) {                                           \
-      lwt_unix_free_job(&job->job);                                     \
-      caml_raise_not_found();                                           \
-    } else {                                                            \
-      value res = alloc_##TYPE(job->entry);                             \
-      TYPE ## _free ( job->entry );                                     \
-      lwt_unix_free_job(&job->job);                                     \
-      return res;                                                       \
-    }                                                                   \
-  }                                                                     \
-                                                                        \
-  CAMLprim value lwt_unix_##FUNC##_job(ARGS_VAL)                        \
-  {                                                                     \
-    INIT;                                                               \
-    return lwt_unix_alloc_job(&(job->job));                             \
-  }
+    struct job_##FUNC {                                                  \
+        struct lwt_unix_job job;                                         \
+        struct TYPE *entry;                                              \
+        ARGS_DECL;                                                       \
+    };                                                                   \
+                                                                         \
+    static void worker_##FUNC(struct job_##FUNC *job)                    \
+    {                                                                    \
+        job->entry = FUNC(ARGS_CALL);                                    \
+        if (job->entry) {                                                \
+            job->entry = TYPE##_dup(job->entry);                         \
+            if (!job->entry) {                                           \
+            }                                                            \
+        }                                                                \
+    }                                                                    \
+                                                                         \
+    static value result_##FUNC(struct job_##FUNC *job)                   \
+    {                                                                    \
+        if (job->entry == NULL) {                                        \
+            lwt_unix_free_job(&job->job);                                \
+            caml_raise_not_found();                                      \
+        } else {                                                         \
+            value res = alloc_##TYPE(job->entry);                        \
+            TYPE##_free(job->entry);                                     \
+            lwt_unix_free_job(&job->job);                                \
+            return res;                                                  \
+        }                                                                \
+    }                                                                    \
+                                                                         \
+    CAMLprim value lwt_unix_##FUNC##_job(ARGS_VAL)                       \
+    {                                                                    \
+        INIT;                                                            \
+        return lwt_unix_alloc_job(&(job->job));                          \
+    }
 
 #endif /* defined(HAVE_NETDB_REENTRANT) */
 
-
 JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB_STRING(job, getprotobyname, 0, name),
-               getprotobyname,
-               protoent,
-               value name,
-               char *name;
-               char data[],
-               job->name)
+               getprotobyname, protoent, value name, char *name;
+               char data[], job->name)
 JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB(job, getprotobynumber, 0);
-               job->num = Int_val(num),
-               getprotobynumber,
-               protoent,
-               value num,
-               int num,
-               job->num)
+               job->num = Int_val(num), getprotobynumber, protoent, value num,
+               int num, job->num)
 JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB_STRING2(job, getservbyname, 0, name, proto),
-               getservbyname,
-               servent,
-               ARGS(value name, value proto),
+               getservbyname, servent, ARGS(value name, value proto),
                char *name;
-               char *proto;
-               char data[],
-               ARGS(job->name, job->proto))
+               char *proto; char data[], ARGS(job->name, job->proto))
 JOB_GET_ENTRY2(LWT_UNIX_INIT_JOB_STRING(job, getservbyport, 0, proto);
-               job->port = htons(Int_val(port)),
-               getservbyport,
-               servent,
-               ARGS(value port, value proto),
-               int port;
-               char *proto;
-               char data[],
-               ARGS(job->port, job->proto))
+               job->port = htons(Int_val(port)), getservbyport, servent,
+               ARGS(value port, value proto), int port;
+               char *proto; char data[], ARGS(job->port, job->proto))
 
 /* +-----------------------------------------------------------------+
    | JOB: getaddrinfo                                                |
    +-----------------------------------------------------------------+ */
 
 struct job_getaddrinfo {
-  struct lwt_unix_job job;
-  char *node;
-  char *service;
-  struct addrinfo hints;
-  struct addrinfo *info;
-  int result;
-  char data[];
+    struct lwt_unix_job job;
+    char *node;
+    char *service;
+    struct addrinfo hints;
+    struct addrinfo *info;
+    int result;
+    char data[];
 };
 
 static value cst_to_constr(int n, int *tbl, int size, int deflt)
 {
-  int i;
-  for (i = 0; i < size; i++)
-    if (n == tbl[i]) return Val_int(i);
-  return Val_int(deflt);
+    int i;
+    for (i = 0; i < size; i++)
+        if (n == tbl[i]) return Val_int(i);
+    return Val_int(deflt);
 }
 
-static value convert_addrinfo(struct addrinfo * a)
+static value convert_addrinfo(struct addrinfo *a)
 {
-  CAMLparam0();
-  CAMLlocal3(vres,vaddr,vcanonname);
-  union sock_addr_union sa;
-  socklen_t len;
+    CAMLparam0();
+    CAMLlocal3(vres, vaddr, vcanonname);
+    union sock_addr_union sa;
+    socklen_t len;
 
-  len = a->ai_addrlen;
-  if (len > sizeof(sa)) len = sizeof(sa);
-  memcpy(&sa.s_gen, a->ai_addr, len);
-  vaddr = alloc_sockaddr(&sa, len, -1);
-  vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
-  vres = caml_alloc_small(5, 0);
-  Field(vres, 0) = cst_to_constr(a->ai_family, socket_domain_table, 3, 0);
-  Field(vres, 1) = cst_to_constr(a->ai_socktype, socket_type_table, 4, 0);
-  Field(vres, 2) = Val_int(a->ai_protocol);
-  Field(vres, 3) = vaddr;
-  Field(vres, 4) = vcanonname;
-  CAMLreturn(vres);
+    len = a->ai_addrlen;
+    if (len > sizeof(sa)) len = sizeof(sa);
+    memcpy(&sa.s_gen, a->ai_addr, len);
+    vaddr = alloc_sockaddr(&sa, len, -1);
+    vcanonname =
+        caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
+    vres = caml_alloc_small(5, 0);
+    Field(vres, 0) = cst_to_constr(a->ai_family, socket_domain_table, 3, 0);
+    Field(vres, 1) = cst_to_constr(a->ai_socktype, socket_type_table, 4, 0);
+    Field(vres, 2) = Val_int(a->ai_protocol);
+    Field(vres, 3) = vaddr;
+    Field(vres, 4) = vcanonname;
+    CAMLreturn(vres);
 }
 
 static void worker_getaddrinfo(struct job_getaddrinfo *job)
 {
-  job->result =
-    getaddrinfo(job->node[0]?job->node:NULL, job->service[0]?job->service:NULL,
-                &job->hints, &job->info);
+    job->result = getaddrinfo(job->node[0] ? job->node : NULL,
+                              job->service[0] ? job->service : NULL,
+                              &job->hints, &job->info);
 }
 
 static value result_getaddrinfo(struct job_getaddrinfo *job)
 {
-  CAMLparam0();
-  CAMLlocal3(vres, e, v);
-  vres = Val_int(0);
-  if (job->result == 0) {
-    struct addrinfo *r;
-    for (r = job->info; r; r = r->ai_next) {
-      e = convert_addrinfo(r);
-      v = caml_alloc_small(2, 0);
-      Field(v, 0) = e;
-      Field(v, 1) = vres;
-      vres = v;
+    CAMLparam0();
+    CAMLlocal3(vres, e, v);
+    vres = Val_int(0);
+    if (job->result == 0) {
+        struct addrinfo *r;
+        for (r = job->info; r; r = r->ai_next) {
+            e = convert_addrinfo(r);
+            v = caml_alloc_small(2, 0);
+            Field(v, 0) = e;
+            Field(v, 1) = vres;
+            vres = v;
+        }
     }
-  }
-  if (job->info != NULL)
-    freeaddrinfo(job->info);
-  lwt_unix_free_job(&job->job);
-  CAMLreturn(vres);
+    if (job->info != NULL) freeaddrinfo(job->info);
+    lwt_unix_free_job(&job->job);
+    CAMLreturn(vres);
 }
 
 CAMLprim value lwt_unix_getaddrinfo_job(value node, value service, value hints)
 {
-  LWT_UNIX_INIT_JOB_STRING2(job, getaddrinfo, 0, node, service);
-  job->info = NULL;
-  memset(&job->hints, 0, sizeof(struct addrinfo));
-  job->hints.ai_family = PF_UNSPEC;
-  for (/*nothing*/; Is_block(hints); hints = Field(hints, 1)) {
-    value v = Field(hints, 0);
-    if (Is_block(v))
-      switch (Tag_val(v)) {
-      case 0: /* AI_FAMILY of socket_domain */
-        job->hints.ai_family = socket_domain_table[Int_val(Field(v, 0))];
-        break;
-      case 1: /* AI_SOCKTYPE of socket_type */
-        job->hints.ai_socktype = socket_type_table[Int_val(Field(v, 0))];
-        break;
-      case 2: /* AI_PROTOCOL of int */
-        job->hints.ai_protocol = Int_val(Field(v, 0));
-        break;
-      }
-    else
-      switch (Int_val(v)) {
-      case 0: /* AI_NUMERICHOST */
-        job->hints.ai_flags |= AI_NUMERICHOST; break;
-      case 1: /* AI_CANONNAME */
-        job->hints.ai_flags |= AI_CANONNAME; break;
-      case 2: /* AI_PASSIVE */
-        job->hints.ai_flags |= AI_PASSIVE; break;
-      }
-  }
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB_STRING2(job, getaddrinfo, 0, node, service);
+    job->info = NULL;
+    memset(&job->hints, 0, sizeof(struct addrinfo));
+    job->hints.ai_family = PF_UNSPEC;
+    for (/*nothing*/; Is_block(hints); hints = Field(hints, 1)) {
+        value v = Field(hints, 0);
+        if (Is_block(v)) switch (Tag_val(v)) {
+                case 0: /* AI_FAMILY of socket_domain */
+                    job->hints.ai_family =
+                        socket_domain_table[Int_val(Field(v, 0))];
+                    break;
+                case 1: /* AI_SOCKTYPE of socket_type */
+                    job->hints.ai_socktype =
+                        socket_type_table[Int_val(Field(v, 0))];
+                    break;
+                case 2: /* AI_PROTOCOL of int */
+                    job->hints.ai_protocol = Int_val(Field(v, 0));
+                    break;
+            }
+        else
+            switch (Int_val(v)) {
+                case 0: /* AI_NUMERICHOST */
+                    job->hints.ai_flags |= AI_NUMERICHOST;
+                    break;
+                case 1: /* AI_CANONNAME */
+                    job->hints.ai_flags |= AI_CANONNAME;
+                    break;
+                case 2: /* AI_PASSIVE */
+                    job->hints.ai_flags |= AI_PASSIVE;
+                    break;
+            }
+    }
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -2931,49 +2912,48 @@ CAMLprim value lwt_unix_getaddrinfo_job(value node, value service, value hints)
    +-----------------------------------------------------------------+ */
 
 struct job_getnameinfo {
-  struct lwt_unix_job job;
-  union sock_addr_union addr;
-  socklen_t addr_len;
-  int opts;
-  char host[4096];
-  char serv[1024];
-  int result;
+    struct lwt_unix_job job;
+    union sock_addr_union addr;
+    socklen_t addr_len;
+    int opts;
+    char host[4096];
+    char serv[1024];
+    int result;
 };
 
-static int getnameinfo_flag_table[] = {
-  NI_NOFQDN, NI_NUMERICHOST, NI_NAMEREQD, NI_NUMERICSERV, NI_DGRAM
-};
+static int getnameinfo_flag_table[] = {NI_NOFQDN, NI_NUMERICHOST, NI_NAMEREQD,
+                                       NI_NUMERICSERV, NI_DGRAM};
 
 static void worker_getnameinfo(struct job_getnameinfo *job)
 {
-  job->result = getnameinfo((const struct sockaddr *)&job->addr.s_gen, job->addr_len,
-                            job->host, sizeof(job->host), job->serv, sizeof(job->serv),
-                            job->opts);
+    job->result = getnameinfo((const struct sockaddr *)&job->addr.s_gen,
+                              job->addr_len, job->host, sizeof(job->host),
+                              job->serv, sizeof(job->serv), job->opts);
 }
 
 static value result_getnameinfo(struct job_getnameinfo *job)
 {
-  CAMLparam0();
-  CAMLlocal3(vres, vhost, vserv);
-  if (job->result) {
-    lwt_unix_free_job(&job->job);
-    caml_raise_not_found();
-  } else {
-    vhost = caml_copy_string(job->host);
-    vserv = caml_copy_string(job->serv);
-    vres = caml_alloc_small(2, 0);
-    Field(vres, 0) = vhost;
-    Field(vres, 1) = vserv;
-    CAMLreturn(vres);
-  }
+    CAMLparam0();
+    CAMLlocal3(vres, vhost, vserv);
+    if (job->result) {
+        lwt_unix_free_job(&job->job);
+        caml_raise_not_found();
+    } else {
+        vhost = caml_copy_string(job->host);
+        vserv = caml_copy_string(job->serv);
+        vres = caml_alloc_small(2, 0);
+        Field(vres, 0) = vhost;
+        Field(vres, 1) = vserv;
+        CAMLreturn(vres);
+    }
 }
 
 CAMLprim value lwt_unix_getnameinfo_job(value sockaddr, value opts)
 {
-  LWT_UNIX_INIT_JOB(job, getnameinfo, 0);
-  get_sockaddr(sockaddr, &job->addr, &job->addr_len);
-  job->opts = caml_convert_flag_list(opts, getnameinfo_flag_table);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, getnameinfo, 0);
+    get_sockaddr(sockaddr, &job->addr, &job->addr_len);
+    job->opts = caml_convert_flag_list(opts, getnameinfo_flag_table);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* bind */
@@ -3020,7 +3000,7 @@ In the OCaml sources, getcwd is set as either
 struct job_getcwd {
     struct lwt_unix_job job;
     char buf[4096];
-    char* result;
+    char *result;
     int error_code;
 };
 
@@ -3063,203 +3043,189 @@ enum { Iflags, Oflags, Cflags, Lflags };
 /* Structure of the terminal_io record. Cf. unix.mli */
 
 static long terminal_io_descr[] = {
-  /* Input modes */
-  Bool, Iflags, IGNBRK,
-  Bool, Iflags, BRKINT,
-  Bool, Iflags, IGNPAR,
-  Bool, Iflags, PARMRK,
-  Bool, Iflags, INPCK,
-  Bool, Iflags, ISTRIP,
-  Bool, Iflags, INLCR,
-  Bool, Iflags, IGNCR,
-  Bool, Iflags, ICRNL,
-  Bool, Iflags, IXON,
-  Bool, Iflags, IXOFF,
-  /* Output modes */
-  Bool, Oflags, OPOST,
-  /* Control modes */
-  Speed, Output,
-  Speed, Input,
-  Enum, Cflags, 5, 4, CSIZE, CS5, CS6, CS7, CS8,
-  Enum, Cflags, 1, 2, CSTOPB, 0, CSTOPB,
-  Bool, Cflags, CREAD,
-  Bool, Cflags, PARENB,
-  Bool, Cflags, PARODD,
-  Bool, Cflags, HUPCL,
-  Bool, Cflags, CLOCAL,
-  /* Local modes */
-  Bool, Lflags, ISIG,
-  Bool, Lflags, ICANON,
-  Bool, Lflags, NOFLSH,
-  Bool, Lflags, ECHO,
-  Bool, Lflags, ECHOE,
-  Bool, Lflags, ECHOK,
-  Bool, Lflags, ECHONL,
-  /* Control characters */
-  Char, VINTR,
-  Char, VQUIT,
-  Char, VERASE,
-  Char, VKILL,
-  Char, VEOF,
-  Char, VEOL,
-  Char, VMIN,
-  Char, VTIME,
-  Char, VSTART,
-  Char, VSTOP,
-  End
-};
+    /* Input modes */
+    Bool, Iflags, IGNBRK, Bool, Iflags, BRKINT, Bool, Iflags, IGNPAR, Bool,
+    Iflags, PARMRK, Bool, Iflags, INPCK, Bool, Iflags, ISTRIP, Bool, Iflags,
+    INLCR, Bool, Iflags, IGNCR, Bool, Iflags, ICRNL, Bool, Iflags, IXON, Bool,
+    Iflags, IXOFF,
+    /* Output modes */
+    Bool, Oflags, OPOST,
+    /* Control modes */
+    Speed, Output, Speed, Input, Enum, Cflags, 5, 4, CSIZE, CS5, CS6, CS7, CS8,
+    Enum, Cflags, 1, 2, CSTOPB, 0, CSTOPB, Bool, Cflags, CREAD, Bool, Cflags,
+    PARENB, Bool, Cflags, PARODD, Bool, Cflags, HUPCL, Bool, Cflags, CLOCAL,
+    /* Local modes */
+    Bool, Lflags, ISIG, Bool, Lflags, ICANON, Bool, Lflags, NOFLSH, Bool,
+    Lflags, ECHO, Bool, Lflags, ECHOE, Bool, Lflags, ECHOK, Bool, Lflags,
+    ECHONL,
+    /* Control characters */
+    Char, VINTR, Char, VQUIT, Char, VERASE, Char, VKILL, Char, VEOF, Char, VEOL,
+    Char, VMIN, Char, VTIME, Char, VSTART, Char, VSTOP, End};
 
 static struct {
-  speed_t speed;
-  int baud;
-} speedtable[] = {
-  {B50,      50},
-  {B75,      75},
-  {B110,     110},
-  {B134,     134},
-  {B150,     150},
-  {B300,     300},
-  {B600,     600},
-  {B1200,    1200},
-  {B1800,    1800},
-  {B2400,    2400},
-  {B4800,    4800},
-  {B9600,    9600},
-  {B19200,   19200},
-  {B38400,   38400},
+    speed_t speed;
+    int baud;
+} speedtable[] = {{B50, 50},
+                  {B75, 75},
+                  {B110, 110},
+                  {B134, 134},
+                  {B150, 150},
+                  {B300, 300},
+                  {B600, 600},
+                  {B1200, 1200},
+                  {B1800, 1800},
+                  {B2400, 2400},
+                  {B4800, 4800},
+                  {B9600, 9600},
+                  {B19200, 19200},
+                  {B38400, 38400},
 #ifdef B57600
-  {B57600,   57600},
+                  {B57600, 57600},
 #endif
 #ifdef B115200
-  {B115200,  115200},
+                  {B115200, 115200},
 #endif
 #ifdef B230400
-  {B230400,  230400},
+                  {B230400, 230400},
 #endif
-  {B0,       0}
-};
+                  {B0, 0}};
 
 #define NSPEEDS (sizeof(speedtable) / sizeof(speedtable[0]))
 
-static tcflag_t* choose_field(struct termios *terminal_status, long field)
+static tcflag_t *choose_field(struct termios *terminal_status, long field)
 {
-  switch (field) {
-  case Iflags:
-    return &terminal_status->c_iflag;
-  case Oflags:
-    return &terminal_status->c_oflag;
-  case Cflags:
-    return &terminal_status->c_cflag;
-  case Lflags:
-    return &terminal_status->c_lflag;
-  default:
-    return 0;
-  }
-}
-
-static void encode_terminal_status(struct termios* terminal_status, value *dst)
-{
-  long * pc;
-  int i;
-
-  for(pc = terminal_io_descr; *pc != End; dst++) {
-    switch(*pc++) {
-    case Bool:
-      { tcflag_t * src = choose_field(terminal_status, *pc++);
-        tcflag_t msk = *pc++;
-        *dst = Val_bool(*src & msk);
-        break; }
-    case Enum:
-      { tcflag_t * src = choose_field(terminal_status, *pc++);
-        int ofs = *pc++;
-        int num = *pc++;
-        tcflag_t msk = *pc++;
-        for (i = 0; i < num; i++) {
-          if ((*src & msk) == pc[i]) {
-            *dst = Val_int(i + ofs);
-            break;
-          }
-        }
-        pc += num;
-        break; }
-    case Speed:
-      { int which = *pc++;
-        speed_t speed = 0;
-        *dst = Val_int(9600);   /* in case no speed in speedtable matches */
-        switch (which) {
-        case Output:
-          speed = cfgetospeed(terminal_status); break;
-        case Input:
-          speed = cfgetispeed(terminal_status); break;
-        }
-        for (i = 0; i < NSPEEDS; i++) {
-          if (speed == speedtable[i].speed) {
-            *dst = Val_int(speedtable[i].baud);
-            break;
-          }
-        }
-        break; }
-    case Char:
-      { int which = *pc++;
-        *dst = Val_int(terminal_status->c_cc[which]);
-        break; }
+    switch (field) {
+        case Iflags:
+            return &terminal_status->c_iflag;
+        case Oflags:
+            return &terminal_status->c_oflag;
+        case Cflags:
+            return &terminal_status->c_cflag;
+        case Lflags:
+            return &terminal_status->c_lflag;
+        default:
+            return 0;
     }
-  }
 }
 
-static void decode_terminal_status(struct termios* terminal_status, value* src)
+static void encode_terminal_status(struct termios *terminal_status, value *dst)
 {
-  long * pc;
-  int i;
+    long *pc;
+    int i;
 
-  for (pc = terminal_io_descr; *pc != End; src++) {
-    switch(*pc++) {
-    case Bool:
-      { tcflag_t * dst = choose_field(terminal_status, *pc++);
-        tcflag_t msk = *pc++;
-        if (Bool_val(*src))
-          *dst |= msk;
-        else
-          *dst &= ~msk;
-        break; }
-    case Enum:
-      { tcflag_t * dst = choose_field(terminal_status, *pc++);
-        int ofs = *pc++;
-        int num = *pc++;
-        tcflag_t msk = *pc++;
-        i = Int_val(*src) - ofs;
-        if (i >= 0 && i < num) {
-          *dst = (*dst & ~msk) | pc[i];
-        } else {
-          unix_error(EINVAL, "tcsetattr", Nothing);
-        }
-        pc += num;
-        break; }
-    case Speed:
-      { int which = *pc++;
-        int baud = Int_val(*src);
-        int res = 0;
-        for (i = 0; i < NSPEEDS; i++) {
-          if (baud == speedtable[i].baud) {
-            switch (which) {
-            case Output:
-              res = cfsetospeed(terminal_status, speedtable[i].speed); break;
-            case Input:
-              res = cfsetispeed(terminal_status, speedtable[i].speed); break;
+    for (pc = terminal_io_descr; *pc != End; dst++) {
+        switch (*pc++) {
+            case Bool: {
+                tcflag_t *src = choose_field(terminal_status, *pc++);
+                tcflag_t msk = *pc++;
+                *dst = Val_bool(*src & msk);
+                break;
             }
-            if (res == -1) uerror("tcsetattr", Nothing);
-            goto ok;
-          }
+            case Enum: {
+                tcflag_t *src = choose_field(terminal_status, *pc++);
+                int ofs = *pc++;
+                int num = *pc++;
+                tcflag_t msk = *pc++;
+                for (i = 0; i < num; i++) {
+                    if ((*src & msk) == pc[i]) {
+                        *dst = Val_int(i + ofs);
+                        break;
+                    }
+                }
+                pc += num;
+                break;
+            }
+            case Speed: {
+                int which = *pc++;
+                speed_t speed = 0;
+                *dst =
+                    Val_int(9600); /* in case no speed in speedtable matches */
+                switch (which) {
+                    case Output:
+                        speed = cfgetospeed(terminal_status);
+                        break;
+                    case Input:
+                        speed = cfgetispeed(terminal_status);
+                        break;
+                }
+                for (i = 0; i < NSPEEDS; i++) {
+                    if (speed == speedtable[i].speed) {
+                        *dst = Val_int(speedtable[i].baud);
+                        break;
+                    }
+                }
+                break;
+            }
+            case Char: {
+                int which = *pc++;
+                *dst = Val_int(terminal_status->c_cc[which]);
+                break;
+            }
         }
-        unix_error(EINVAL, "tcsetattr", Nothing);
-      ok:
-        break; }
-    case Char:
-      { int which = *pc++;
-        terminal_status->c_cc[which] = Int_val(*src);
-        break; }
     }
-  }
+}
+
+static void decode_terminal_status(struct termios *terminal_status, value *src)
+{
+    long *pc;
+    int i;
+
+    for (pc = terminal_io_descr; *pc != End; src++) {
+        switch (*pc++) {
+            case Bool: {
+                tcflag_t *dst = choose_field(terminal_status, *pc++);
+                tcflag_t msk = *pc++;
+                if (Bool_val(*src))
+                    *dst |= msk;
+                else
+                    *dst &= ~msk;
+                break;
+            }
+            case Enum: {
+                tcflag_t *dst = choose_field(terminal_status, *pc++);
+                int ofs = *pc++;
+                int num = *pc++;
+                tcflag_t msk = *pc++;
+                i = Int_val(*src) - ofs;
+                if (i >= 0 && i < num) {
+                    *dst = (*dst & ~msk) | pc[i];
+                } else {
+                    unix_error(EINVAL, "tcsetattr", Nothing);
+                }
+                pc += num;
+                break;
+            }
+            case Speed: {
+                int which = *pc++;
+                int baud = Int_val(*src);
+                int res = 0;
+                for (i = 0; i < NSPEEDS; i++) {
+                    if (baud == speedtable[i].baud) {
+                        switch (which) {
+                            case Output:
+                                res = cfsetospeed(terminal_status,
+                                                  speedtable[i].speed);
+                                break;
+                            case Input:
+                                res = cfsetispeed(terminal_status,
+                                                  speedtable[i].speed);
+                                break;
+                        }
+                        if (res == -1) uerror("tcsetattr", Nothing);
+                        goto ok;
+                    }
+                }
+                unix_error(EINVAL, "tcsetattr", Nothing);
+            ok:
+                break;
+            }
+            case Char: {
+                int which = *pc++;
+                terminal_status->c_cc[which] = Int_val(*src);
+                break;
+            }
+        }
+    }
 }
 
 /* +-----------------------------------------------------------------+
@@ -3267,33 +3233,33 @@ static void decode_terminal_status(struct termios* terminal_status, value* src)
    +-----------------------------------------------------------------+ */
 
 struct job_tcgetattr {
-  struct lwt_unix_job job;
-  int fd;
-  struct termios termios;
-  int result;
-  int error_code;
+    struct lwt_unix_job job;
+    int fd;
+    struct termios termios;
+    int result;
+    int error_code;
 };
 
 static void worker_tcgetattr(struct job_tcgetattr *job)
 {
-  job->result = tcgetattr(job->fd, &job->termios);
-  job->error_code = errno;
+    job->result = tcgetattr(job->fd, &job->termios);
+    job->error_code = errno;
 }
 
 static value result_tcgetattr(struct job_tcgetattr *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "tcgetattr");
-  value res = caml_alloc_tuple(NFIELDS);
-  encode_terminal_status(&job->termios, &Field(res, 0));
-  lwt_unix_free_job(&job->job);
-  return res;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "tcgetattr");
+    value res = caml_alloc_tuple(NFIELDS);
+    encode_terminal_status(&job->termios, &Field(res, 0));
+    lwt_unix_free_job(&job->job);
+    return res;
 }
 
 CAMLprim value lwt_unix_tcgetattr_job(value fd)
 {
-  LWT_UNIX_INIT_JOB(job, tcgetattr, 0);
-  job->fd = Int_val(fd);
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, tcgetattr, 0);
+    job->fd = Int_val(fd);
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+
@@ -3301,47 +3267,45 @@ CAMLprim value lwt_unix_tcgetattr_job(value fd)
    +-----------------------------------------------------------------+ */
 
 struct job_tcsetattr {
-  struct lwt_unix_job job;
-  int fd;
-  int when;
-  /* This array contains only non-allocated values. */
-  value termios[NFIELDS];
-  int result;
-  int error_code;
+    struct lwt_unix_job job;
+    int fd;
+    int when;
+    /* This array contains only non-allocated values. */
+    value termios[NFIELDS];
+    int result;
+    int error_code;
 };
 
-static int when_flag_table[] = {
-  TCSANOW, TCSADRAIN, TCSAFLUSH
-};
+static int when_flag_table[] = {TCSANOW, TCSADRAIN, TCSAFLUSH};
 
 static void worker_tcsetattr(struct job_tcsetattr *job)
 {
-  struct termios termios;
-  int result = tcgetattr(job->fd, &termios);
-  if (result < 0) {
-    job->result = result;
-    job->error_code = errno;
-  } else {
-    decode_terminal_status(&termios, &(job->termios[0]));
-    job->result = tcsetattr(job->fd, job->when, &termios);
-    job->error_code = errno;
-  }
+    struct termios termios;
+    int result = tcgetattr(job->fd, &termios);
+    if (result < 0) {
+        job->result = result;
+        job->error_code = errno;
+    } else {
+        decode_terminal_status(&termios, &(job->termios[0]));
+        job->result = tcsetattr(job->fd, job->when, &termios);
+        job->error_code = errno;
+    }
 }
 
 static value result_tcsetattr(struct job_tcsetattr *job)
 {
-  LWT_UNIX_CHECK_JOB(job, job->result < 0, "tcsetattr");
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    LWT_UNIX_CHECK_JOB(job, job->result < 0, "tcsetattr");
+    lwt_unix_free_job(&job->job);
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_tcsetattr_job(value fd, value when, value termios)
 {
-  LWT_UNIX_INIT_JOB(job, tcsetattr, 0);
-  job->fd = Int_val(fd);
-  job->when = when_flag_table[Int_val(when)];
-  memcpy(&job->termios, &Field(termios, 0), NFIELDS * sizeof(value));
-  return lwt_unix_alloc_job(&job->job);
+    LWT_UNIX_INIT_JOB(job, tcsetattr, 0);
+    job->fd = Int_val(fd);
+    job->when = when_flag_table[Int_val(when)];
+    memcpy(&job->termios, &Field(termios, 0), NFIELDS * sizeof(value));
+    return lwt_unix_alloc_job(&job->job);
 }
 
 /* +-----------------------------------------------------------------+

--- a/src/unix/lwt_unix_windows.h
+++ b/src/unix/lwt_unix_windows.h
@@ -23,139 +23,143 @@
 
 CAMLprim value lwt_unix_is_socket(value fd)
 {
-  return (Val_bool(Descr_kind_val(fd) == KIND_SOCKET));
+    return (Val_bool(Descr_kind_val(fd) == KIND_SOCKET));
 }
 
 CAMLprim value lwt_unix_write(value fd, value buf, value vofs, value vlen)
 {
-  intnat ofs, len, written;
-  DWORD numbytes, numwritten;
-  DWORD err = 0;
+    intnat ofs, len, written;
+    DWORD numbytes, numwritten;
+    DWORD err = 0;
 
-  Begin_root (buf);
+    Begin_root(buf);
     ofs = Long_val(vofs);
     len = Long_val(vlen);
     written = 0;
     if (len > 0) {
-      numbytes = len;
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        ret = send(s, &Byte(buf, ofs), numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        if (! WriteFile(h, &Byte(buf, ofs), numbytes, &numwritten, NULL))
-          err = GetLastError();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("write", Nothing);
-      }
-      written = numwritten;
+        numbytes = len;
+        if (Descr_kind_val(fd) == KIND_SOCKET) {
+            int ret;
+            SOCKET s = Socket_val(fd);
+            ret = send(s, &Byte(buf, ofs), numbytes, 0);
+            if (ret == SOCKET_ERROR) err = WSAGetLastError();
+            numwritten = ret;
+        } else {
+            HANDLE h = Handle_val(fd);
+            if (!WriteFile(h, &Byte(buf, ofs), numbytes, &numwritten, NULL))
+                err = GetLastError();
+        }
+        if (err) {
+            win32_maperr(err);
+            uerror("write", Nothing);
+        }
+        written = numwritten;
     }
-  End_roots();
-  return Val_long(written);
+    End_roots();
+    return Val_long(written);
 }
 
 CAMLprim value lwt_unix_bytes_write(value fd, value buf, value vofs, value vlen)
 {
-  intnat ofs, len, written;
-  DWORD numbytes, numwritten;
-  DWORD err = 0;
+    intnat ofs, len, written;
+    DWORD numbytes, numwritten;
+    DWORD err = 0;
 
-  Begin_root (buf);
+    Begin_root(buf);
     ofs = Long_val(vofs);
     len = Long_val(vlen);
     written = 0;
     if (len > 0) {
-      numbytes = len;
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        ret = send(s, (char*)Caml_ba_array_val(buf)->data + ofs, numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        if (! WriteFile(h, (char*)Caml_ba_array_val(buf)->data + ofs, numbytes, &numwritten, NULL))
-          err = GetLastError();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("write", Nothing);
-      }
-      written = numwritten;
+        numbytes = len;
+        if (Descr_kind_val(fd) == KIND_SOCKET) {
+            int ret;
+            SOCKET s = Socket_val(fd);
+            ret = send(s, (char *)Caml_ba_array_val(buf)->data + ofs, numbytes,
+                       0);
+            if (ret == SOCKET_ERROR) err = WSAGetLastError();
+            numwritten = ret;
+        } else {
+            HANDLE h = Handle_val(fd);
+            if (!WriteFile(h, (char *)Caml_ba_array_val(buf)->data + ofs,
+                           numbytes, &numwritten, NULL))
+                err = GetLastError();
+        }
+        if (err) {
+            win32_maperr(err);
+            uerror("write", Nothing);
+        }
+        written = numwritten;
     }
-  End_roots();
-  return Val_long(written);
+    End_roots();
+    return Val_long(written);
 }
 
 CAMLprim value lwt_unix_read(value fd, value buf, value vofs, value vlen)
 {
-  intnat ofs, len, written;
-  DWORD numbytes, numwritten;
-  DWORD err = 0;
+    intnat ofs, len, written;
+    DWORD numbytes, numwritten;
+    DWORD err = 0;
 
-  Begin_root (buf);
+    Begin_root(buf);
     ofs = Long_val(vofs);
     len = Long_val(vlen);
     written = 0;
     if (len > 0) {
-      numbytes = len;
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        ret = recv(s, &Byte(buf, ofs), numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        if (! ReadFile(h, &Byte(buf, ofs), numbytes, &numwritten, NULL))
-          err = GetLastError();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("write", Nothing);
-      }
-      written = numwritten;
+        numbytes = len;
+        if (Descr_kind_val(fd) == KIND_SOCKET) {
+            int ret;
+            SOCKET s = Socket_val(fd);
+            ret = recv(s, &Byte(buf, ofs), numbytes, 0);
+            if (ret == SOCKET_ERROR) err = WSAGetLastError();
+            numwritten = ret;
+        } else {
+            HANDLE h = Handle_val(fd);
+            if (!ReadFile(h, &Byte(buf, ofs), numbytes, &numwritten, NULL))
+                err = GetLastError();
+        }
+        if (err) {
+            win32_maperr(err);
+            uerror("write", Nothing);
+        }
+        written = numwritten;
     }
-  End_roots();
-  return Val_long(written);
+    End_roots();
+    return Val_long(written);
 }
 
 CAMLprim value lwt_unix_bytes_read(value fd, value buf, value vofs, value vlen)
 {
-  intnat ofs, len, written;
-  DWORD numbytes, numwritten;
-  DWORD err = 0;
+    intnat ofs, len, written;
+    DWORD numbytes, numwritten;
+    DWORD err = 0;
 
-  Begin_root (buf);
+    Begin_root(buf);
     ofs = Long_val(vofs);
     len = Long_val(vlen);
     written = 0;
     if (len > 0) {
-      numbytes = len;
-      if (Descr_kind_val(fd) == KIND_SOCKET) {
-        int ret;
-        SOCKET s = Socket_val(fd);
-        ret = recv(s, (char*)Caml_ba_array_val(buf)->data + ofs, numbytes, 0);
-        if (ret == SOCKET_ERROR) err = WSAGetLastError();
-        numwritten = ret;
-      } else {
-        HANDLE h = Handle_val(fd);
-        if (! ReadFile(h, (char*)Caml_ba_array_val(buf)->data + ofs, numbytes, &numwritten, NULL))
-          err = GetLastError();
-      }
-      if (err) {
-        win32_maperr(err);
-        uerror("write", Nothing);
-      }
-      written = numwritten;
+        numbytes = len;
+        if (Descr_kind_val(fd) == KIND_SOCKET) {
+            int ret;
+            SOCKET s = Socket_val(fd);
+            ret = recv(s, (char *)Caml_ba_array_val(buf)->data + ofs, numbytes,
+                       0);
+            if (ret == SOCKET_ERROR) err = WSAGetLastError();
+            numwritten = ret;
+        } else {
+            HANDLE h = Handle_val(fd);
+            if (!ReadFile(h, (char *)Caml_ba_array_val(buf)->data + ofs,
+                          numbytes, &numwritten, NULL))
+                err = GetLastError();
+        }
+        if (err) {
+            win32_maperr(err);
+            uerror("write", Nothing);
+        }
+        written = numwritten;
     }
-  End_roots();
-  return Val_long(written);
+    End_roots();
+    return Val_long(written);
 }
 
 /* +-----------------------------------------------------------------+
@@ -164,9 +168,9 @@ CAMLprim value lwt_unix_bytes_read(value fd, value buf, value vofs, value vlen)
 
 CAMLprim value lwt_unix_get_page_size(value Unit)
 {
-  SYSTEM_INFO si;
-  GetSystemInfo(&si);
-  return Val_long(si.dwPageSize);
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return Val_long(si.dwPageSize);
 }
 
 /* +-----------------------------------------------------------------+
@@ -174,66 +178,68 @@ CAMLprim value lwt_unix_get_page_size(value Unit)
    +-----------------------------------------------------------------+ */
 
 struct job_read {
-  struct lwt_unix_job job;
-  union {
-    HANDLE handle;
-    SOCKET socket;
-  } fd;
-  int kind;
-  DWORD length;
-  DWORD result;
-  DWORD error_code;
-  value string;
-  DWORD offset;
-  char buffer[];
+    struct lwt_unix_job job;
+    union {
+        HANDLE handle;
+        SOCKET socket;
+    } fd;
+    int kind;
+    DWORD length;
+    DWORD result;
+    DWORD error_code;
+    value string;
+    DWORD offset;
+    char buffer[];
 };
 
 static void worker_read(struct job_read *job)
 {
-  if (job->kind == KIND_SOCKET) {
-    int ret;
-    ret = recv(job->fd.socket, job->buffer, job->length, 0);
-    if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
-    job->result = ret;
-  } else {
-    if (!ReadFile(job->fd.handle, job->buffer, job->length, &(job->result), NULL))
-      job->error_code = GetLastError();
-  }
+    if (job->kind == KIND_SOCKET) {
+        int ret;
+        ret = recv(job->fd.socket, job->buffer, job->length, 0);
+        if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
+        job->result = ret;
+    } else {
+        if (!ReadFile(job->fd.handle, job->buffer, job->length, &(job->result),
+                      NULL))
+            job->error_code = GetLastError();
+    }
 }
 
 static value result_read(struct job_read *job)
 {
-  value result;
-  DWORD error = job->error_code;
-  if (error) {
+    value result;
+    DWORD error = job->error_code;
+    if (error) {
+        caml_remove_generational_global_root(&job->string);
+        lwt_unix_free_job(&job->job);
+        win32_maperr(error);
+        uerror("read", Nothing);
+    }
+    memcpy(String_val(job->string) + job->offset, job->buffer, job->result);
+    result = Val_long(job->result);
     caml_remove_generational_global_root(&job->string);
     lwt_unix_free_job(&job->job);
-    win32_maperr(error);
-    uerror("read", Nothing);
-  }
-  memcpy(String_val(job->string) + job->offset, job->buffer, job->result);
-  result = Val_long(job->result);
-  caml_remove_generational_global_root(&job->string);
-  lwt_unix_free_job(&job->job);
-  return result;
+    return result;
 }
 
-CAMLprim value lwt_unix_read_job(value val_fd, value val_string, value val_offset, value val_length)
+CAMLprim value lwt_unix_read_job(value val_fd, value val_string,
+                                 value val_offset, value val_length)
 {
-  struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
-  long length = Long_val(val_length);
-  LWT_UNIX_INIT_JOB(job, read, length);
-  job->kind = fd->kind;
-  if (fd->kind == KIND_HANDLE)
-    job->fd.handle = fd->fd.handle;
-  else
-    job->fd.socket = fd->fd.socket;
-  job->length = length;
-  job->error_code = 0;
-  job->string = val_string;
-  job->offset = Long_val(val_offset);
-  caml_register_generational_global_root(&(job->string));
-  return lwt_unix_alloc_job(&(job->job));
+    struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
+    long length = Long_val(val_length);
+    LWT_UNIX_INIT_JOB(job, read, length);
+    job->kind = fd->kind;
+    if (fd->kind == KIND_HANDLE)
+        job->fd.handle = fd->fd.handle;
+    else
+        job->fd.socket = fd->fd.socket;
+    job->length = length;
+    job->error_code = 0;
+    job->string = val_string;
+    job->offset = Long_val(val_offset);
+    caml_register_generational_global_root(&(job->string));
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -241,58 +247,60 @@ CAMLprim value lwt_unix_read_job(value val_fd, value val_string, value val_offse
    +-----------------------------------------------------------------+ */
 
 struct job_bytes_read {
-  struct lwt_unix_job job;
-  union {
-    HANDLE handle;
-    SOCKET socket;
-  } fd;
-  int kind;
-  char *buffer;
-  DWORD length;
-  DWORD result;
-  DWORD error_code;
+    struct lwt_unix_job job;
+    union {
+        HANDLE handle;
+        SOCKET socket;
+    } fd;
+    int kind;
+    char *buffer;
+    DWORD length;
+    DWORD result;
+    DWORD error_code;
 };
 
 static void worker_bytes_read(struct job_bytes_read *job)
 {
-  if (job->kind == KIND_SOCKET) {
-    int ret;
-    ret = recv(job->fd.socket, job->buffer, job->length, 0);
-    if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
-    job->result = ret;
-  } else {
-    if (!ReadFile(job->fd.handle, job->buffer, job->length, &(job->result), NULL))
-      job->error_code = GetLastError();
-  }
+    if (job->kind == KIND_SOCKET) {
+        int ret;
+        ret = recv(job->fd.socket, job->buffer, job->length, 0);
+        if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
+        job->result = ret;
+    } else {
+        if (!ReadFile(job->fd.handle, job->buffer, job->length, &(job->result),
+                      NULL))
+            job->error_code = GetLastError();
+    }
 }
 
 static value result_bytes_read(struct job_bytes_read *job)
 {
-  value result;
-  DWORD error = job->error_code;
-  if (error) {
+    value result;
+    DWORD error = job->error_code;
+    if (error) {
+        lwt_unix_free_job(&job->job);
+        win32_maperr(error);
+        uerror("bytes_read", Nothing);
+    }
+    result = Val_long(job->result);
     lwt_unix_free_job(&job->job);
-    win32_maperr(error);
-    uerror("bytes_read", Nothing);
-  }
-  result = Val_long(job->result);
-  lwt_unix_free_job(&job->job);
-  return result;
+    return result;
 }
 
-CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buffer, value val_offset, value val_length)
+CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buffer,
+                                       value val_offset, value val_length)
 {
-  struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
-  LWT_UNIX_INIT_JOB(job, bytes_read, 0);
-  job->kind = fd->kind;
-  if (fd->kind == KIND_HANDLE)
-    job->fd.handle = fd->fd.handle;
-  else
-    job->fd.socket = fd->fd.socket;
-  job->buffer = (char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
-  job->length = Long_val(val_length);
-  job->error_code = 0;
-  return lwt_unix_alloc_job(&(job->job));
+    struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
+    LWT_UNIX_INIT_JOB(job, bytes_read, 0);
+    job->kind = fd->kind;
+    if (fd->kind == KIND_HANDLE)
+        job->fd.handle = fd->fd.handle;
+    else
+        job->fd.socket = fd->fd.socket;
+    job->buffer = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
+    job->length = Long_val(val_length);
+    job->error_code = 0;
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -300,59 +308,61 @@ CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buffer, value val
    +-----------------------------------------------------------------+ */
 
 struct job_write {
-  struct lwt_unix_job job;
-  union {
-    HANDLE handle;
-    SOCKET socket;
-  } fd;
-  int kind;
-  DWORD length;
-  DWORD result;
-  DWORD error_code;
-  char buffer[];
+    struct lwt_unix_job job;
+    union {
+        HANDLE handle;
+        SOCKET socket;
+    } fd;
+    int kind;
+    DWORD length;
+    DWORD result;
+    DWORD error_code;
+    char buffer[];
 };
 
 static void worker_write(struct job_write *job)
 {
-  if (job->kind == KIND_SOCKET) {
-    int ret;
-    ret = send(job->fd.socket, job->buffer, job->length, 0);
-    if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
-    job->result = ret;
-  } else {
-    if (!WriteFile(job->fd.handle, job->buffer, job->length, &(job->result), NULL))
-      job->error_code = GetLastError();
-  }
+    if (job->kind == KIND_SOCKET) {
+        int ret;
+        ret = send(job->fd.socket, job->buffer, job->length, 0);
+        if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
+        job->result = ret;
+    } else {
+        if (!WriteFile(job->fd.handle, job->buffer, job->length, &(job->result),
+                       NULL))
+            job->error_code = GetLastError();
+    }
 }
 
 static value result_write(struct job_write *job)
 {
-  value result;
-  DWORD error = job->error_code;
-  if (error) {
+    value result;
+    DWORD error = job->error_code;
+    if (error) {
+        lwt_unix_free_job(&job->job);
+        win32_maperr(error);
+        uerror("write", Nothing);
+    }
+    result = Val_long(job->result);
     lwt_unix_free_job(&job->job);
-    win32_maperr(error);
-    uerror("write", Nothing);
-  }
-  result = Val_long(job->result);
-  lwt_unix_free_job(&job->job);
-  return result;
+    return result;
 }
 
-CAMLprim value lwt_unix_write_job(value val_fd, value val_string, value val_offset, value val_length)
+CAMLprim value lwt_unix_write_job(value val_fd, value val_string,
+                                  value val_offset, value val_length)
 {
-  struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
-  long length = Long_val(val_length);
-  LWT_UNIX_INIT_JOB(job, write, length);
-  job->kind = fd->kind;
-  if (fd->kind == KIND_HANDLE)
-    job->fd.handle = fd->fd.handle;
-  else
-    job->fd.socket = fd->fd.socket;
-  memcpy(job->buffer, String_val(val_string) + Long_val(val_offset), length);
-  job->length = length;
-  job->error_code = 0;
-  return lwt_unix_alloc_job(&(job->job));
+    struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
+    long length = Long_val(val_length);
+    LWT_UNIX_INIT_JOB(job, write, length);
+    job->kind = fd->kind;
+    if (fd->kind == KIND_HANDLE)
+        job->fd.handle = fd->fd.handle;
+    else
+        job->fd.socket = fd->fd.socket;
+    memcpy(job->buffer, String_val(val_string) + Long_val(val_offset), length);
+    job->length = length;
+    job->error_code = 0;
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -360,59 +370,61 @@ CAMLprim value lwt_unix_write_job(value val_fd, value val_string, value val_offs
    +-----------------------------------------------------------------+ */
 
 struct job_bytes_write {
-  struct lwt_unix_job job;
-  union {
-    HANDLE handle;
-    SOCKET socket;
-  } fd;
-  int kind;
-  char *buffer;
-  DWORD length;
-  DWORD result;
-  DWORD error_code;
+    struct lwt_unix_job job;
+    union {
+        HANDLE handle;
+        SOCKET socket;
+    } fd;
+    int kind;
+    char *buffer;
+    DWORD length;
+    DWORD result;
+    DWORD error_code;
 };
 
 static void worker_bytes_write(struct job_bytes_write *job)
 {
-  if (job->kind == KIND_SOCKET) {
-    int ret;
-    ret = send(job->fd.socket, job->buffer, job->length, 0);
-    if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
-    job->result = ret;
-  } else {
-    if (!WriteFile(job->fd.handle, job->buffer, job->length, &(job->result), NULL))
-      job->error_code = GetLastError();
-  }
+    if (job->kind == KIND_SOCKET) {
+        int ret;
+        ret = send(job->fd.socket, job->buffer, job->length, 0);
+        if (ret == SOCKET_ERROR) job->error_code = WSAGetLastError();
+        job->result = ret;
+    } else {
+        if (!WriteFile(job->fd.handle, job->buffer, job->length, &(job->result),
+                       NULL))
+            job->error_code = GetLastError();
+    }
 }
 
 CAMLprim value result_bytes_write(struct job_bytes_write *job)
 {
-  value result;
-  DWORD error = job->error_code;
-  if (error) {
+    value result;
+    DWORD error = job->error_code;
+    if (error) {
+        lwt_unix_free_job(&job->job);
+        win32_maperr(error);
+        uerror("bytes_write", Nothing);
+    }
+    result = Val_long(job->result);
     lwt_unix_free_job(&job->job);
-    win32_maperr(error);
-    uerror("bytes_write", Nothing);
-  }
-  result = Val_long(job->result);
-  lwt_unix_free_job(&job->job);
-  return result;
+    return result;
 }
 
-CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer, value val_offset, value val_length)
+CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer,
+                                        value val_offset, value val_length)
 {
-  struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
-  LWT_UNIX_INIT_JOB(job, bytes_write, 0);
-  job->job.worker = (lwt_unix_job_worker)worker_bytes_write;
-  job->kind = fd->kind;
-  if (fd->kind == KIND_HANDLE)
-    job->fd.handle = fd->fd.handle;
-  else
-    job->fd.socket = fd->fd.socket;
-  job->buffer = (char*)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
-  job->length = Long_val(val_length);
-  job->error_code = 0;
-  return lwt_unix_alloc_job(&(job->job));
+    struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
+    LWT_UNIX_INIT_JOB(job, bytes_write, 0);
+    job->job.worker = (lwt_unix_job_worker)worker_bytes_write;
+    job->kind = fd->kind;
+    if (fd->kind == KIND_HANDLE)
+        job->fd.handle = fd->fd.handle;
+    else
+        job->fd.socket = fd->fd.socket;
+    job->buffer = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
+    job->length = Long_val(val_length);
+    job->error_code = 0;
+    return lwt_unix_alloc_job(&(job->job));
 }
 
 /* +-----------------------------------------------------------------+
@@ -420,40 +432,39 @@ CAMLprim value lwt_unix_bytes_write_job(value val_fd, value val_buffer, value va
    +-----------------------------------------------------------------+ */
 
 struct job_fsync {
-  struct lwt_unix_job job;
-  HANDLE handle;
-  DWORD error_code;
+    struct lwt_unix_job job;
+    HANDLE handle;
+    DWORD error_code;
 };
 
 static void worker_fsync(struct job_fsync *job)
 {
-  if (!FlushFileBuffers(job->handle))
-    job->error_code = GetLastError();
+    if (!FlushFileBuffers(job->handle)) job->error_code = GetLastError();
 }
 
 static value result_fsync(struct job_fsync *job)
 {
-  DWORD error = job->error_code;
-  if (error) {
+    DWORD error = job->error_code;
+    if (error) {
+        lwt_unix_free_job(&job->job);
+        win32_maperr(error);
+        uerror("fsync", Nothing);
+    }
     lwt_unix_free_job(&job->job);
-    win32_maperr(error);
-    uerror("fsync", Nothing);
-  }
-  lwt_unix_free_job(&job->job);
-  return Val_unit;
+    return Val_unit;
 }
 
 CAMLprim value lwt_unix_fsync_job(value val_fd)
 {
-  struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
-  if (fd->kind != KIND_HANDLE) {
-    caml_invalid_argument("Lwt_unix.fsync");
-  } else {
-    LWT_UNIX_INIT_JOB(job, fsync, 0);
-    job->handle = fd->fd.handle;
-    job->error_code = 0;
-    return lwt_unix_alloc_job(&(job->job));
-  }
+    struct filedescr *fd = (struct filedescr *)Data_custom_val(val_fd);
+    if (fd->kind != KIND_HANDLE) {
+        caml_invalid_argument("Lwt_unix.fsync");
+    } else {
+        LWT_UNIX_INIT_JOB(job, fsync, 0);
+        job->handle = fd->fd.handle;
+        job->error_code = 0;
+        return lwt_unix_alloc_job(&(job->job));
+    }
 }
 
 /* +-----------------------------------------------------------------+
@@ -461,48 +472,49 @@ CAMLprim value lwt_unix_fsync_job(value val_fd)
    +-----------------------------------------------------------------+ */
 
 struct job_system {
-  struct lwt_unix_job job;
-  HANDLE handle;
+    struct lwt_unix_job job;
+    HANDLE handle;
 };
 
 static void worker_system(struct job_system *job)
 {
-  WaitForSingleObject(job->handle, INFINITE);
+    WaitForSingleObject(job->handle, INFINITE);
 }
 
 static value result_system(struct job_system *job)
 {
-  HANDLE handle = job->handle;
-  DWORD code;
-  DWORD err;
-  lwt_unix_free_job(&job->job);
-  if (!GetExitCodeProcess(handle, &code)) {
-    err = GetLastError();
+    HANDLE handle = job->handle;
+    DWORD code;
+    DWORD err;
+    lwt_unix_free_job(&job->job);
+    if (!GetExitCodeProcess(handle, &code)) {
+        err = GetLastError();
+        CloseHandle(handle);
+        win32_maperr(err);
+        uerror("GetExitCodeProcess", Nothing);
+    }
     CloseHandle(handle);
-    win32_maperr(err);
-    uerror("GetExitCodeProcess", Nothing);
-  }
-  CloseHandle(handle);
-  return Val_int(code);
+    return Val_int(code);
 }
 
 CAMLprim value lwt_unix_system_job(value cmdline)
 {
-  STARTUPINFO si;
-  PROCESS_INFORMATION pi;
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
 
-  ZeroMemory(&si, sizeof(si));
-  ZeroMemory(&pi, sizeof(pi));
-  si.cb = sizeof(si);
-  if (!CreateProcess(NULL, String_val(cmdline), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
-    win32_maperr(GetLastError());
-    uerror("CreateProcess", Nothing);
-  } else {
-    LWT_UNIX_INIT_JOB(job, system, 0);
-    CloseHandle(pi.hThread);
-    job->handle = pi.hProcess;
-    return lwt_unix_alloc_job(&(job->job));
-  }
+    ZeroMemory(&si, sizeof(si));
+    ZeroMemory(&pi, sizeof(pi));
+    si.cb = sizeof(si);
+    if (!CreateProcess(NULL, String_val(cmdline), NULL, NULL, TRUE, 0, NULL,
+                       NULL, &si, &pi)) {
+        win32_maperr(GetLastError());
+        uerror("CreateProcess", Nothing);
+    } else {
+        LWT_UNIX_INIT_JOB(job, system, 0);
+        CloseHandle(pi.hThread);
+        job->handle = pi.hProcess;
+        return lwt_unix_alloc_job(&(job->job));
+    }
 }
 
 /* +-----------------------------------------------------------------+


### PR DESCRIPTION
This PR is a continuation of the work started in PRs #400 and #409 about issue #393.

I added a `.clang-format` file enforcing Google-style formatting for C files. I also applied this style to Lwt's C codebase.

Overall, I'm happy with the way the files were indented, even if I find the 80-column limit too strict sometimes ([example](https://github.com/ocsigen/lwt/compare/master...Richard-Degenne:c-formatting?expand=1#diff-da2f75024a2915ba1c1e888053121f95R135)).

`clang-format` has quite a lot of options and if you have remarks on what the files look like, please go ahead, I should be able to find the right configuration. :)