### PR TITLE
[WIP, hack] Hardcode coverage analysis for the core library (during development only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,12 @@ clean:
 	rm -f *.install
 	rm -fr doc/api
 	rm -f src/jbuild-ignore src/unix/lwt_config
-
-clean-coverage:
 	rm -rf bisect*.out
 	rm -rf _coverage/
 
-coverage: test
-	bisect-ppx-report -I _build/ -html _coverage/ bisect*.out
-	bisect-ppx-report -text - -summary-only bisect*.out
+coverage: clean test
+	bisect-ppx-report -I _build/ -html _coverage/ `find . -name 'bisect*.out'`
+	bisect-ppx-report -text - -summary-only `find . -name 'bisect*.out'`
 	@echo See _coverage/index.html
 
 .PHONY: \

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -5,4 +5,5 @@
   (public_name lwt)
   (synopsis "Monadic promises and concurrent I/O")
   (wrapped false)
+  (preprocess (pps (bisect_ppx)))
   (libraries (bytes result))))


### PR DESCRIPTION
Lwt needs coverage analysis for any large-scale development. Coverage analysis has been made problematic by Jbuilder. This PR is some kind of effort to hack around the problems.

This PR hardcodes preprocessing of some Lwt source files by [Bisect_ppx](https://github.com/aantron/bisect_ppx). The hardcoding will be removed for release (but ideally, all problems will be solved during development).

Bisect_ppx was previously triggered conditionally from the `Makefile` in the old OASIS/Ocamlbuild setup, but there doesn't seem to be a nice way to do this now (janestreet/jbuilder#57).

Remaining issues:

- [ ] The Lwt Unix library has some files preprocessed with cppo. I'm not yet clear on how to combine preprocessing by both Bisect_ppx and cppo. For this reason, I limited coverage to the core library only, but we need to apply it to Unix to proceed reasonably with libuv.
- [ ] As currently configured, Jbuilder doesn't always rerun all tests. This incrementalism produces misleading coverage reports. I'm not sure if this is a flaw of Jbuilder, the Lwt build system, or something that should be changed in the design of Bisect. For now, I inserted a `make clean` before running tests for coverage.

Testing this PR requires pinning `bisect_ppx` to the development repo, for the time being.

cc @andrewray 