### PR TITLE
Add a script to post-process lwt.install

### DIFF
--- a/META.lwt.template
+++ b/META.lwt.template
@@ -13,7 +13,7 @@ archive(native) = "lwt.cmxa"
 plugin(byte) = "lwt.cma"
 plugin(native) = "lwt.cmxs"
 package "log" (
-  directory = "log"
+  #directory = "log"
   version = "dev"
   description = "Logger for Lwt"
   requires = "bytes lwt result"
@@ -24,7 +24,7 @@ package "log" (
   exists_if = "lwt_log.cma"
 )
 package "ppx" (
-  directory = "ppx"
+  #directory = "ppx"
   version = "dev"
   description = "Lwt PPX syntax extension"
   requires(ppx_driver) = "compiler-libs
@@ -51,7 +51,7 @@ package "ppx" (
   )
 )
 package "preemptive" (
-  directory = "preemptive"
+  #directory = "preemptive"
   version = "dev"
   description = "Preemptive thread support for Lwt"
   requires = "bigarray
@@ -70,7 +70,7 @@ package "preemptive" (
   exists_if = "lwt_preemptive.cma"
 )
 package "simple-top" (
-  directory = "simple-top"
+  #directory = "simple-top"
   version = "dev"
   description = "Lwt-OCaml top level integration (deprecated; use utop)"
   requires = "bigarray
@@ -89,7 +89,7 @@ package "simple-top" (
   exists_if = "lwt_simple_top.cma"
 )
 package "syntax" (
-  directory = "syntax"
+  #directory = "syntax"
   version = "dev"
   description = "Camlp4 syntax for Lwt (deprecated; use lwt.ppx)"
   requires = "camlp4 lwt.syntax.options"
@@ -99,7 +99,7 @@ package "syntax" (
   archive(syntax, preprocessor, native, plugin) = "lwt_syntax.cmxs"
   exists_if = "lwt_syntax.cma"
   package "log" (
-    directory = "log"
+    #directory = "log"
     version = "dev"
     description = "Camlp4 syntax for Lwt logging (deprecated; use lwt.ppx)"
     requires = "camlp4 lwt.syntax.options"
@@ -110,7 +110,7 @@ package "syntax" (
     exists_if = "lwt_syntax_log.cma"
   )
   package "options" (
-    directory = "options"
+    #directory = "options"
     version = "dev"
     description = "Options for Lwt Camlp4 syntax extension (deprecated; use lwt.ppx)"
     requires = "camlp4"
@@ -122,7 +122,7 @@ package "syntax" (
   )
 )
 package "unix" (
-  directory = "unix"
+  #directory = "unix"
   version = "dev"
   description = "Unix support for Lwt"
   requires = "bigarray bytes lwt lwt.log result unix"

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,27 @@ doc-api-html: all
 doc-api-wiki: all
 	make -C doc api/wiki/index.wiki
 
+#install:
+#	ocaml src/util/install_filter.ml
+#	jbuilder install
+#
+#uninstall:
+#	jbuilder uninstall
+#
+#reinstall:
+#	jbuilder uninstall
+#	jbuilder install
+
+# Use opam-installer, rather than jbuilder while we need to 
+# post-process the lwt.install file
 install:
-	jbuilder install
+	ocaml src/util/install_filter.ml
+	opam-installer --prefix `opam config var prefix` -i lwt.install
 
 uninstall:
-	jbuilder uninstall
+	opam-installer --prefix `opam config var prefix` -u lwt.install
 
-reinstall:
-	jbuilder uninstall
-	jbuilder install
+reinstall: uninstall install
 
 clean:
 	rm -fr _build

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ doc-api-wiki: all
 #	jbuilder uninstall
 #	jbuilder install
 
-# Use opam-installer, rather than jbuilder while we need to 
+# Use opam-installer, rather than jbuilder while we need to
 # post-process the lwt.install file
 install:
 	ocaml src/util/install_filter.ml

--- a/lwt.opam
+++ b/lwt.opam
@@ -19,6 +19,7 @@ build: [
   [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
                                     "-use-camlp4" "%{camlp4:installed}%" ]
   [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "src/util/install_filter.ml" ]
 ]
 build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 depends: [
@@ -48,4 +49,9 @@ messages: [
 post-messages: [
   "Lwt 3.0.0 made some minor breaking changes, announced in 2.7.0. See
   https://github.com/ocsigen/lwt/issues/308"
+  "Lwt > 3.1.0 will reorganise various packages; the old camlp4 syntax
+  extension will be moved into it's own package and the sub-libraries
+  will be installed in separate directories.  The later change affects
+  a few packages which, for example, use Lwt_unix functions, but only
+  link with Lwt"
 ]

--- a/src/util/install_filter.ml
+++ b/src/util/install_filter.ml
@@ -1,0 +1,59 @@
+(* By default jbuilder will create sub-directories for each sub-project
+   in the main lwt library.  This is probably preferred overall, however,
+   we would like to avoid this change for (at least) 1 release cycle so
+   it can be announced first.
+
+   This script will be run after jbuilder and modify the generated 
+   lwt.install file to remove the sub-directories.
+
+   This works in concert with removing (actually commenting out for now)
+   the "directory = ..." clauses in META.lwt.template.
+
+   Note that we could create a .install file by hand, however,
+   we would then have to deal with configuration options (ie does
+   camlp4,unix,threads etc exist).  This scheme lets jbuilder work
+   all that out for us.
+*)
+
+let filter_sub_path path s =
+  try 
+    (* look for the string *)
+    let start = String.index s '{' in
+    let end_ = String.index_from s start '/' in
+    if String.sub s (start + 2) (end_ - start - 2) = path then
+      (* remove the path bit *)
+      let ofs = start + 3 + String.length path in
+      String.sub s 0 (start + 2) ^ String.sub s ofs (String.length s - ofs)
+    else 
+      s
+  with _ -> s
+
+let sub_paths = [
+  "unix";
+  "preemptive";
+  "log";
+  "options";
+  "syntax";
+  "simple-top";
+  "ppx";
+]
+
+let filter_sub_paths s = List.fold_right filter_sub_path sub_paths s
+
+let main () = 
+  let read_line file = try Some(input_line file) with End_of_file -> None in
+  let rec read_lines file = 
+    match read_line file with
+    | Some(x) -> x :: read_lines file
+    | None -> []
+  in
+  let file = open_in "lwt.install" in
+  let lines = List.map filter_sub_paths (read_lines file) in
+  let () = close_in file in
+  let file = open_out "lwt.install" in
+  let () = List.iter (Printf.fprintf file "%s\n") lines in
+  let () = close_out file in
+  flush stdout
+
+let () = main ()
+

--- a/src/util/install_filter.ml
+++ b/src/util/install_filter.ml
@@ -3,7 +3,7 @@
    we would like to avoid this change for (at least) 1 release cycle so
    it can be announced first.
 
-   This script will be run after jbuilder and modify the generated 
+   This script will be run after jbuilder and modify the generated
    lwt.install file to remove the sub-directories.
 
    This works in concert with removing (actually commenting out for now)
@@ -16,7 +16,7 @@
 *)
 
 let filter_sub_path path s =
-  try 
+  try
     (* look for the string *)
     let start = String.index s '{' in
     let end_ = String.index_from s start '/' in
@@ -24,7 +24,7 @@ let filter_sub_path path s =
       (* remove the path bit *)
       let ofs = start + 3 + String.length path in
       String.sub s 0 (start + 2) ^ String.sub s ofs (String.length s - ofs)
-    else 
+    else
       s
   with _ -> s
 
@@ -40,9 +40,9 @@ let sub_paths = [
 
 let filter_sub_paths s = List.fold_right filter_sub_path sub_paths s
 
-let main () = 
+let main () =
   let read_line file = try Some(input_line file) with End_of_file -> None in
-  let rec read_lines file = 
+  let rec read_lines file =
     match read_line file with
     | Some(x) -> x :: read_lines file
     | None -> []


### PR DESCRIPTION
This flattens the installation directory for the 3.1.0 release and
hopefully helps maintains compatibility with various packages that
dont link with lwt.XXX sublibraries correctly.

We use a post-process step rather than a custom hand-written install
file so that jbuilder can work out for us exactly which packages
were built.

The opam build step calls the post-processing script after running
jbuilder.

The META file is lightly modified to remove the directory
specifications.  They have been commented out for now so they can
be easily added back.

Finally, the install and uninstall steps in the Makefile were modified
to use opam-installer.  Invoking "jbuilder install" after the
post-processing step didn't seem to work.