### PR TITLE
Add packaging tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ scratch/
 
 # Wikidoc output.
 /doc/api/
+
+# Junk from packaging tests.
+*.cm*
+*.o
+a.out

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: check-config
 all: check-config
 	jbuilder build @install
 
-# run all tests
+# run all unit tests
 test: check-config
 	jbuilder runtest
 
@@ -65,11 +65,32 @@ uninstall:
 
 reinstall: uninstall install
 
+# Packaging tests. These are run with Lwt installed by OPAM, typically during
+# CI. To run locally, run the install-for-packaging-test target first.
+packaging-test:
+	ocamlfind query lwt
+	for TEST in `ls -d tests/packaging/*/*` ; \
+	do \
+	    make -wC $$TEST ; \
+	done
+
+install-for-packaging-test: clean
+	opam pin add --yes --no-action lwt .
+	opam pin add --yes --no-action lwt_react .
+	opam pin add --yes --no-action lwt_ssl .
+	opam pin add --yes --no-action lwt_glib .
+	opam install --yes camlp4
+	opam reinstall --yes lwt lwt_react lwt_ssl lwt_glib
+
 clean:
 	rm -fr _build
 	rm -f *.install
 	rm -fr doc/api
 	rm -f src/jbuild-ignore src/unix/lwt_config
+	for TEST in `ls -d tests/packaging/*/*` ; \
+	do \
+	    make -wC $$TEST clean ; \
+	done
 
 clean-coverage:
 	rm -rf bisect*.out

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -148,6 +148,11 @@ make test
 
 
 
+# Run the packaging tests.
+make packaging-test
+
+
+
 # Some sanity checks.
 if [ "$LIBEV" != yes ]
 then

--- a/tests/packaging/README.md
+++ b/tests/packaging/README.md
@@ -1,0 +1,9 @@
+# Packaging tests
+
+This directory contains a few tiny programs that *depend* on Lwt, through one of
+two build systems: Findlib or Jbuilder. Each program is built to ensure that Lwt
+packaging remains usable by Lwt users. To do this, run `make packaging-test`
+from the Lwt repository root. Before that, you may want to run
+`make install-for-packaging-test`. This will install Lwt and all helper
+libraries into your current OPAM switch. The packaging tests are run against
+this installation.

--- a/tests/packaging/jbuilder/core/Makefile
+++ b/tests/packaging/jbuilder/core/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	jbuilder build user.exe --root .
+	_build/default/user.exe
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/tests/packaging/jbuilder/core/jbuild
+++ b/tests/packaging/jbuilder/core/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt))))

--- a/tests/packaging/jbuilder/core/user.ml
+++ b/tests/packaging/jbuilder/core/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt.return () |> ignore

--- a/tests/packaging/jbuilder/ppx/Makefile
+++ b/tests/packaging/jbuilder/ppx/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	jbuilder build user.exe --root .
+	_build/default/user.exe
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/tests/packaging/jbuilder/ppx/jbuild
+++ b/tests/packaging/jbuilder/ppx/jbuild
@@ -1,0 +1,6 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt))
+  (preprocess (pps (lwt.ppx)))))

--- a/tests/packaging/jbuilder/ppx/user.ml
+++ b/tests/packaging/jbuilder/ppx/user.ml
@@ -1,0 +1,3 @@
+let () =
+  let p = Lwt.return () >> Lwt.return () in
+  ignore p

--- a/tests/packaging/jbuilder/ppx_ppxopt/Makefile
+++ b/tests/packaging/jbuilder/ppx_ppxopt/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	# Expecting failure with "Unbound value >>".
+	! jbuilder build user.exe --root .
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/tests/packaging/jbuilder/ppx_ppxopt/jbuild
+++ b/tests/packaging/jbuilder/ppx_ppxopt/jbuild
@@ -1,0 +1,6 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt))
+  (preprocess (pps (lwt.ppx -no-sequence)))))

--- a/tests/packaging/jbuilder/ppx_ppxopt/user.ml
+++ b/tests/packaging/jbuilder/ppx_ppxopt/user.ml
@@ -1,0 +1,3 @@
+let () =
+  let p = Lwt.return () >> Lwt.return () in
+  ignore p

--- a/tests/packaging/jbuilder/preemptive/Makefile
+++ b/tests/packaging/jbuilder/preemptive/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	jbuilder build user.exe --root .
+	_build/default/user.exe
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/tests/packaging/jbuilder/preemptive/jbuild
+++ b/tests/packaging/jbuilder/preemptive/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt.preemptive))))

--- a/tests/packaging/jbuilder/preemptive/user.ml
+++ b/tests/packaging/jbuilder/preemptive/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt_preemptive.simple_init |> ignore

--- a/tests/packaging/jbuilder/unix/Makefile
+++ b/tests/packaging/jbuilder/unix/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	jbuilder build user.exe --root .
+	_build/default/user.exe
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/tests/packaging/jbuilder/unix/jbuild
+++ b/tests/packaging/jbuilder/unix/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt.unix))))

--- a/tests/packaging/jbuilder/unix/user.ml
+++ b/tests/packaging/jbuilder/unix/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt_unix.stdout |> ignore

--- a/tests/packaging/ocamlfind/camlp4/Makefile
+++ b/tests/packaging/ocamlfind/camlp4/Makefile
@@ -1,0 +1,9 @@
+.PHONY : test
+test : clean
+	ocamlfind opt -syntax camlp4o -package lwt.syntax -c user.ml
+	ocamlfind opt -package lwt -linkpkg user.cmx
+	./a.out
+
+.PHONY : clean
+clean :
+	rm -f *.cm* *.o a.out

--- a/tests/packaging/ocamlfind/camlp4/user.ml
+++ b/tests/packaging/ocamlfind/camlp4/user.ml
@@ -1,0 +1,6 @@
+let () =
+  let p =
+    lwt () = Lwt.return () in
+    Lwt.return ()
+  in
+  ignore p

--- a/tests/packaging/ocamlfind/core/Makefile
+++ b/tests/packaging/ocamlfind/core/Makefile
@@ -1,0 +1,9 @@
+.PHONY : test
+test : clean
+	ocamlfind opt -package lwt -c user.ml
+	ocamlfind opt -package lwt -linkpkg user.cmx
+	./a.out
+
+.PHONY : clean
+clean :
+	rm -f *.cm* *.o a.out

--- a/tests/packaging/ocamlfind/core/user.ml
+++ b/tests/packaging/ocamlfind/core/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt.return () |> ignore

--- a/tests/packaging/ocamlfind/ppx/Makefile
+++ b/tests/packaging/ocamlfind/ppx/Makefile
@@ -1,0 +1,15 @@
+.PHONY : test
+test : clean
+	ocamlfind opt -package lwt.ppx -c user.ml
+	ocamlfind opt -package lwt -linkpkg user.cmx
+	./a.out
+	@# The PPX option needs to be passed to lwt.ppx.deprecated-ppx-method
+	@# instead of lwt.ppx. This is a bug awaiting a fix in
+	@#   https://github.com/ocsigen/lwt/issues/417
+	# Expecting failure with "Unbound value >>":
+	! ocamlfind opt -package lwt.ppx \
+	    -ppxopt lwt.ppx.deprecated-ppx-method,-no-sequence -c user.ml
+
+.PHONY : clean
+clean :
+	rm -f *.cm* *.o a.out

--- a/tests/packaging/ocamlfind/ppx/user.ml
+++ b/tests/packaging/ocamlfind/ppx/user.ml
@@ -1,0 +1,3 @@
+let () =
+  let p = Lwt.return () >> Lwt.return () in
+  ignore p

--- a/tests/packaging/ocamlfind/preemptive/Makefile
+++ b/tests/packaging/ocamlfind/preemptive/Makefile
@@ -1,0 +1,11 @@
+.PHONY : test
+test : clean
+	@# Deliberately link with lwt.preemptive incorrectly, as Lwt is supporting
+	@# this usage until 4.0.0.
+	ocamlfind opt -package lwt -c user.ml
+	ocamlfind opt -package lwt.preemptive -thread -linkpkg user.cmx
+	./a.out
+
+.PHONY : clean
+clean :
+	rm -f *.cm* *.o a.out

--- a/tests/packaging/ocamlfind/preemptive/user.ml
+++ b/tests/packaging/ocamlfind/preemptive/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt_preemptive.simple_init |> ignore

--- a/tests/packaging/ocamlfind/unix/Makefile
+++ b/tests/packaging/ocamlfind/unix/Makefile
@@ -1,0 +1,11 @@
+.PHONY : test
+test : clean
+	@# Deliberately link with lwt.unix incorrectly, as Lwt is supporting this
+	@# usage until 4.0.0.
+	ocamlfind opt -package lwt -c user.ml
+	ocamlfind opt -package lwt.unix -linkpkg user.cmx
+	./a.out
+
+.PHONY : clean
+clean :
+	rm -f *.cm* *.o a.out

--- a/tests/packaging/ocamlfind/unix/user.ml
+++ b/tests/packaging/ocamlfind/unix/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt_unix.stdout |> ignore


### PR DESCRIPTION
This adds a `Makefile` target, `make packaging-test`, to run automatically most of what I've been running manually each time we mess with the packaging. Basically, it adds around ten little programs in `tests/packaging/ocamlfind/*` and `tests/packaging/jbuilder/*` that try to use the various subpackages of Lwt. Each program comes with its own `Makefile` that tries to build the program.

Some notes:

- The tests depend on a final installation into the developer's OPAM switch, rather than Jbuilder's installation into `./_build/install/`. This is because the former is authoritative, and what we want to test. In particular, I think the two installations are different since at least #420, though we want to get rid of this difference over time.
- This verifies that we have broken the passing of options to `lwt.ppx` when it is running standalone (`lwt.ppx.depreacted-ppx-method`) during the port to Jbuilder (#417). That's something to fix before 3.1.0.
- The ocamlfind tests currently deliberately compile against just `lwt` when linking with `lwt.unix` and `lwt.preemptive`. This tests #420, and should remain until 4.0.0.
- I didn't include any tests for `simple-top`. I just run them manually in the REPL, and I hope the next time we touch that package will be to delete it in 4.0.0 (#371).
- There is no test for Camlp4 usage from Jbuilder. I'm not sure how to use Camlp4 from Jbuilder, and anyway, I hope projects using Jbuilder are not using our deprecated Camlp4 syntax extension.

cc @andrewray