### PR TITLE
[WIP] Enable ppx_bisect.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,13 @@ clean-coverage:
 	rm -rf bisect*.out
 	rm -rf _coverage/
 
+.PHONY: test-coverage
+test-coverage:
+	jbuilder runtest --enable-optional-pps=bisect_ppx
+
 .PHONY: coverage
-coverage: test
-	bisect-ppx-report -I _build/ -html _coverage/ bisect*.out
-	bisect-ppx-report -text - -summary-only bisect*.out
+coverage: clean test-coverage
+	bisect-ppx-report -I _build/ -html _coverage/ `find . -name 'bisect*.out'`
+	bisect-ppx-report -text - -summary-only `find . -name 'bisect*.out'`
 	@echo See _coverage/index.html
+

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -5,4 +5,5 @@
   (public_name lwt)
   (synopsis "Monadic promises and concurrent I/O")
   (wrapped false)
-  (libraries (bytes result))))
+  (libraries (bytes result))
+  (preprocess (pps (?bisect_ppx)))))


### PR DESCRIPTION
Requires github.com/andrewray/jbuilder#bisect

for support for optional preprocessors.

Lightly tested for now, but appears to be working.