### PR TITLE
Use `readdir` instead of deprecated `readdir_r` to avoid warnings

### DIFF
--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1835,19 +1835,21 @@ static void worker_readdir_n(struct job_readdir_n *job)
 {
     long i;
     for (i = 0; i < job->count; i++) {
-        struct dirent *ptr;
-        int result = readdir_r(job->dir, &job->entries[i], &ptr);
+        errno = 0;
+        struct dirent *entry = readdir(job->dir);
 
         /* An error happened. */
-        if (result != 0) {
-            job->error_code = result;
+        if (entry == NULL && errno != 0) {
+            job->error_code = errno;
             return;
         }
 
         /* End of directory reached */
-        if (ptr == NULL) break;
-    }
+        if (entry == NULL && errno == 0) break;
 
+        /* All is good */
+        job->entries[i] = *entry;
+    }
     job->count = i;
     job->error_code = 0;
 }

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1811,6 +1811,13 @@ CAMLprim value lwt_unix_readdir_job(value val_dir)
 struct job_readdir_n {
     struct lwt_unix_job job;
     DIR *dir;
+    /* count serves two purpose:
+       1. Transmit the maximum number of entries requested by the programmer.
+          See `readdir_n`'s OCaml side documentation.
+       2. Transmit the number of actually read entries from the `worker` to
+          the result parser.
+          See below `worker_readdir_n` and `result_readdir_n`
+    */
     long count;
     int error_code;
     char *entries[];

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -841,8 +841,6 @@ CAMLprim value lwt_unix_mcast_set_ttl(value fd, value ttl)
 #define VAL_MCAST_ACTION_ADD (Val_int(0))
 #define VAL_MCAST_ACTION_DROP (Val_int(1))
 
-#define GET_INET_ADDR(v) (*((struct in_addr *)(v)))
-
 CAMLprim value lwt_unix_mcast_modify_membership(value fd, value v_action,
                                                 value if_addr, value group_addr)
 {
@@ -2364,10 +2362,7 @@ struct job_gethostbyname {
 };
 
 CAMLexport value alloc_inet_addr(struct in_addr *inaddr);
-#define GET_INET_ADDR(v) (*((struct in_addr *)(v)))
-
 CAMLexport value alloc_inet6_addr(struct in6_addr *inaddr);
-#define GET_INET6_ADDR(v) (*((struct in6_addr *)(v)))
 
 static value alloc_one_addr(char const *a)
 {

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1849,7 +1849,7 @@ static void worker_readdir_n(struct job_readdir_n *job)
         }
 
         /* All is good */
-        job->entries[i] = strdup(entry->d_name);
+        job->entries[i] = name;
     }
     job->count = i;
     job->error_code = 0;

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1754,21 +1754,6 @@ CAMLprim value lwt_unix_rewinddir_job(value dir)
     return lwt_unix_alloc_job(&(job->job));
 }
 
-/* struct dirent size */
-
-/* Some kind of estimate of the true size of a dirent structure, including the
-   space used for the name. This is controversial, and there is an ongoing
-   discussion (see Internet) about deprecating readdir_r because of the need to
-   guess the size in this way. */
-static size_t dirent_size(DIR *dir)
-{
-    size_t size = offsetof(struct dirent, d_name) +
-                  fpathconf(dirfd(dir), _PC_NAME_MAX) + 1;
-
-    if (size < sizeof(struct dirent)) size = sizeof(struct dirent);
-
-    return size;
-}
 
 /* +-----------------------------------------------------------------+
    | JOB: readdir                                                    |
@@ -1878,7 +1863,7 @@ CAMLprim value lwt_unix_readdir_n_job(value val_dir, value val_count)
     long count = Long_val(val_count);
     DIR *dir = DIR_Val(val_dir);
 
-    LWT_UNIX_INIT_JOB(job, readdir_n, dirent_size(dir) * count);
+    LWT_UNIX_INIT_JOB(job, readdir_n, sizeof(struct dirent) * count);
     job->dir = dir;
     job->count = count;
 

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1832,8 +1832,8 @@ static void worker_readdir_n(struct job_readdir_n *job)
 
         /* An error happened. */
         if (entry == NULL && errno != 0) {
+            job->count = i;
             job->error_code = errno;
-            job->count = i - 1;
             return;
         }
 
@@ -1843,8 +1843,8 @@ static void worker_readdir_n(struct job_readdir_n *job)
         /* readdir is good */
         char *name = strdup(entry->d_name);
         if (name == NULL) {
+            job->count = i;
             job->error_code = errno;
-            job->count = i - 1;
             return;
         }
 
@@ -3199,7 +3199,12 @@ CAMLprim value lwt_unix_getcwd_job(value unit)
        The last argument is the number of bytes of storage to reserve in memory
        immediately following the `struct`. This is for fields such as
        `char data[]` at the end of the struct. It is typically zero. For an
-       example where it is not zero, see `lwt_unix_read_job` again. */
+       example where it is not zero, see `lwt_unix_read_job` again.
+
+       If the additional data is stored inline in the job struct, it is
+       deallocated with `lwt_unix_free_job`. If the additional data is for
+       pointers to additional structure, you must remember to deallocate it
+       yourself. For an example of this, see `readdir_n`.*/
     LWT_UNIX_INIT_JOB(job, getcwd, 0);
 
     /* Allocate a corresponding object in the OCaml heap. `&job->job` is the

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1754,7 +1754,6 @@ CAMLprim value lwt_unix_rewinddir_job(value dir)
     return lwt_unix_alloc_job(&(job->job));
 }
 
-
 /* +-----------------------------------------------------------------+
    | JOB: readdir                                                    |
    +-----------------------------------------------------------------+ */
@@ -1781,7 +1780,8 @@ static void worker_readdir(struct job_readdir *job)
 
 static value result_readdir(struct job_readdir *job)
 {
-    LWT_UNIX_CHECK_JOB(job, job->entry == NULL && job->error_code != 0, "readdir");
+    LWT_UNIX_CHECK_JOB(job, job->entry == NULL && job->error_code != 0,
+                       "readdir");
     if (job->entry == NULL) {
         // From the man page
         // On success, readdir() returns a pointer to a dirent structure.

--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -1813,7 +1813,7 @@ struct job_readdir_n {
     DIR *dir;
     long count;
     int error_code;
-    struct dirent entries[];
+    char *entries[];
 };
 
 static void worker_readdir_n(struct job_readdir_n *job)
@@ -1833,7 +1833,7 @@ static void worker_readdir_n(struct job_readdir_n *job)
         if (entry == NULL && errno == 0) break;
 
         /* All is good */
-        job->entries[i] = *entry;
+        job->entries[i] = strdup(entry->d_name);
     }
     job->count = i;
     job->error_code = 0;
@@ -1851,7 +1851,7 @@ static value result_readdir_n(struct job_readdir_n *job)
         result = caml_alloc(job->count, 0);
         long i;
         for (i = 0; i < job->count; i++) {
-            Store_field(result, i, caml_copy_string(job->entries[i].d_name));
+            Store_field(result, i, caml_copy_string(job->entries[i]));
         }
         lwt_unix_free_job(&job->job);
         CAMLreturn(result);


### PR DESCRIPTION
Fixed all C warning for unix on my machine. I'll have a look at the windows ones (although I'm not sure how much help I'd be there).

It passes tests but I don't trust myself and because it's C I don't trust the compiler to shout at me when I'm wrong. A second pair of eyes is definitely welcome.

I should also probably rebase to avoid a separate commit for cosmetics.