### PR TITLE
Testing: conditional coverage analysis for Lwt core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,13 @@ clean:
 	do \
 	    make -wC $$TEST clean ; \
 	done
-
-.PHONY: clean-coverage
-clean-coverage:
-	rm -rf bisect*.out
 	rm -rf _coverage/
 
+BISECT_FILES_PATTERN := _build/default/test/core/bisect*.out
+
 .PHONY: coverage
-coverage: test
-	bisect-ppx-report -I _build/ -html _coverage/ bisect*.out
-	bisect-ppx-report -text - -summary-only bisect*.out
+coverage: clean
+	BISECT_COVERAGE=yes jbuilder runtest --dev --only-packages lwt
+	bisect-ppx-report -I _build/ -html _coverage/ $(BISECT_FILES_PATTERN)
+	bisect-ppx-report -text - -summary-only $(BISECT_FILES_PATTERN)
 	@echo See _coverage/index.html

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Those things having been noted, thank you! :tada:
 - [OPAM+git workflow](#Workflow)
   - [Getting the code](#Checkout)
   - [Testing](#Testing)
+  - [Testing with coverage analysis](#Test_with_coverage_analysis)
   - [Getting your change merged](#Getting_your_change_merged)
   - [Making additional changes](#Making_additional_changes)
   - [Cleaning up](#Cleaning_up)
@@ -88,14 +89,6 @@ git clone https://github.com/your-user-name/lwt.git
 cd lwt/
 ```
 
-If you want to use code coverage, you have to do this (for now):
-
-```
-git checkout -b working-coverage origin/working-coverage
-```
-
-This is a temporary result of the recent port to jbuilder.
-
 We'll use Lwt's own [`opam`][opam-depends] file to install Lwt's dependencies
 automatically. Before doing that, you may want to switch to a special OPAM
 switch just for Lwt:
@@ -126,13 +119,6 @@ git checkout -b my-awesome-change
 <a id="Testing"></a>
 #### Testing
 
-If you are working from the `origin/working-coverage` branch, first enable tests
-by running
-
-```
-ocaml setup.ml -configure --enable-tests --enable-coverage --disable-camlp4
-```
-
 Each time you are ready to test, run
 
 ```
@@ -155,6 +141,25 @@ opam upgrade lwt
 Since Lwt is pinned, these commands will install Lwt from your modified code.
 All installed OPAM packages that depend on Lwt will be rebuilt against your
 modified code when you run these commands.
+
+<a id="Testing_with_coverage_analysis"></a>
+#### Testing with coverage analysis
+
+Coverage analysis is only enabled for `src/core/*` for now. To generate coverage
+reports, first pin Bisect_ppx to its development version:
+
+```
+opam pin add --dev-repo bisect_ppx
+```
+
+Then run
+
+```
+make coverage
+```
+
+in the Lwt repo. To view the coverage report, open `_coverage/index.html` in
+your browser.
 
 <a id="Getting_your_change_merged"></a>
 #### Getting your change merged

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -1,3 +1,8 @@
+(* -*- tuareg -*- *)
+(* The above line is how one tells Jbuilder that this file is in OCaml
+   syntax. *)
+
+let top = {|
 (jbuild_version 1)
 
 (library
@@ -5,5 +10,28 @@
   (public_name lwt)
   (synopsis "Monadic promises and concurrent I/O")
   (wrapped false)
+|}
+
+let optional_bisect_stanza = {|
+  (preprocess (pps (bisect_ppx)))
+|}
+
+let bottom = {|
   (libraries (bytes result))
   (flags (:standard -w +A-29))))
+|}
+
+let () =
+  let generating_coverage =
+    try Sys.getenv "BISECT_COVERAGE" = "yes"
+    with Not_found -> false
+  in
+
+  let jbuild_file_contents =
+    if generating_coverage then
+      top ^ optional_bisect_stanza ^ bottom
+    else
+      top ^ bottom
+  in
+
+  Jbuild_plugin.V1.send jbuild_file_contents


### PR DESCRIPTION
Instruments the Lwt core for coverage analysis with Bisect_ppx, but only if `BISECT_COVERAGE` is set to `yes` during the build. This is all triggered by running `make coverage`.

It is necessary to install the development version of Bisect_ppx for now, until the next Bisect release:

```
opam pin add --dev-repo bisect_ppx
```

This is to make #385 easier to work on. It eliminates the need for maintaining an OASIS build system in the `working-coverage` branch.

<br/>

`src/core/jbuild` is now in OCaml syntax. This PR is an improved version of #419 (which adds intrumentation unconditionally), and will be superseded by #424 once janestreet/jbuilder#57 is resolved somehow, probably by janestreet/jbuilder#168.

The instructions in `doc/CONTRIBUTING.md` are updated.

cc @andrewray @jsthomas