### PR TITLE
Testing: be sure we test thoroughly on Flambda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - os: linux
       env: COMPILER=4.04
     - os: linux
-      env: COMPILER=4.05
-    - os: linux
       env: COMPILER=4.05 FLAMBDA=yes
+    - os: linux
+      env: COMPILER=4.06 FLAMBDA=yes
     - os: osx
       env: COMPILER=system
     - os: osx

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -16,10 +16,20 @@ let optional_bisect_stanza = {|
   (preprocess (pps (bisect_ppx)))
 |}
 
+let optional_flambda_flags = {|
+  (ocamlopt_flags (:standard -O3))
+|}
+
 let bottom = {|
   (libraries (bytes result))
   (flags (:standard -w +A-29))))
 |}
+
+let accumulate_content_if condition more_content content =
+  if condition then
+    content ^ more_content
+  else
+    content
 
 let () =
   let generating_coverage =
@@ -27,11 +37,15 @@ let () =
     with Not_found -> false
   in
 
-  let jbuild_file_contents =
-    if generating_coverage then
-      top ^ optional_bisect_stanza ^ bottom
-    else
-      top ^ bottom
+  (* Compilers starting from 4.03 support Flambda flags, even if not configured
+     with Flambda support. *)
+  let compiler_has_flambda_flags =
+    Scanf.sscanf Jbuild_plugin.V1.ocaml_version "%i.%i" (fun major minor ->
+      major >= 4 && minor >= 3)
   in
 
-  Jbuild_plugin.V1.send jbuild_file_contents
+  top
+  |> accumulate_content_if generating_coverage optional_bisect_stanza
+  |> accumulate_content_if compiler_has_flambda_flags optional_flambda_flags
+  |> fun content -> content ^ bottom
+  |> Jbuild_plugin.V1.send

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -10,6 +10,7 @@ packages_apt () {
         4.03) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
         4.04) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
         4.05) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
+        4.06) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes; HAVE_CAMLP4=no;;
            *) echo Unsupported compiler $COMPILER; exit 1;;
     esac
 
@@ -87,6 +88,7 @@ case $COMPILER in
     4.03) OCAML_VERSION=4.03.0;;
     4.04) OCAML_VERSION=4.04.2;;
     4.05) OCAML_VERSION=4.05.0+rc1;;
+    4.06) OCAML_VERSION=4.06.0+trunk;;
     system) OCAML_VERSION=`ocamlc -version`;;
        *) echo Unsupported compiler $COMPILER; exit 1;;
 esac
@@ -120,7 +122,12 @@ fi
 opam pin add -y --no-action lwt .
 
 opam install -y --deps-only lwt
-opam install -y camlp4
+
+if [ "$HAVE_CAMLP4" != no ]
+then
+    opam install -y camlp4
+fi
+
 if [ "$LIBEV" = yes ]
 then
     opam install -y conf-libev
@@ -146,14 +153,21 @@ opam install -y ounit
 cd `opam config var lib`/../build/lwt.*
 make clean
 
-if [ "$LIBEV" == yes ]
+if [ "$LIBEV" = yes ]
 then
     LIBEV_FLAG=true
 else
     LIBEV_FLAG=false
 fi
 
-ocaml src/util/configure.ml -use-libev $LIBEV_FLAG -use-camlp4 true
+if [ "$HAVE_CAMLP4" = no ]
+then
+    CAMLP4_FLAG=false
+else
+    CAMLP4_FLAG=true
+fi
+
+ocaml src/util/configure.ml -use-libev $LIBEV_FLAG -use-camlp4 $CAMLP4_FLAG
 make build-all test-all
 
 

--- a/test/core/jbuild
+++ b/test/core/jbuild
@@ -1,10 +1,41 @@
+(* -*- tuareg -*- *)
+(* The above line tells Jbuilder that this file is in OCaml syntax. *)
+
+let top = {|
 (jbuild_version 1)
 
 (executable
  ((name main)
+|}
+
+let optional_flambda_flags = {|
+  (ocamlopt_flags (:standard -O3))
+|}
+
+let bottom = {|
   (libraries (lwttester))))
 
 (alias
  ((name runtest)
   (package lwt)
   (action (run ${exe:main.exe}))))
+|}
+
+let accumulate_content_if condition more_content content =
+  if condition then
+    content ^ more_content
+  else
+    content
+
+let () =
+  (* Compilers starting from 4.03 support Flambda flags, even if not configured
+     with Flambda support. *)
+  let compiler_has_flambda_flags =
+    Scanf.sscanf Jbuild_plugin.V1.ocaml_version "%i.%i" (fun major minor ->
+      major >= 4 && minor >= 3)
+  in
+
+  top
+  |> accumulate_content_if compiler_has_flambda_flags optional_flambda_flags
+  |> fun content -> content ^ bottom
+  |> Jbuild_plugin.V1.send


### PR DESCRIPTION
Passes `-O3` to the compiler when there is Flambda support. Before this PR, our Flambda builds were using an Flambda compiler, but perhaps the optimizations applied were [not aggressive enough](https://caml.inria.fr/pub/docs/manual-ocaml/flambda.html#sec478) for catching any potential problems.

Lwt [uses some `Obj.magic`][objmagic], so it's important we test thoroughly on Flambda, including on development versions of the compiler. In addition to `-O3`, this PR adds CI testing on 4.06.0+trunk+flambda.

`-O3` is passed to the compiler when the version is at least 4.03. These compilers accept the flag even if not configured with Flambda. At the same time, we have to avoid passing `-O3` to 4.02.3. That compiler exits with an error if given the flag. This conditional flag-passing is achieved by writing even more OCaml code in `src/core/jbuild` (see the diff). @diml, is there any nice way to avoid that in current Jbuilder?

I'd like to avoid turning all of our `jbuild` files into OCaml source, in part because we would have a lot of duplicate code in them. I guess if we have to go down that route with the `jbuild` files, we will have to write a separate generating pass. To limit the number of `jbuild` files turned to OCaml syntax in this PR, I added `-O3` to only the core (`src/core/*`) and the core tests (`test/core/*`). This should be enough for rudimentary testing of Flambda during compilation of `lwt.ml`, and during cross-module optimization when the test suite is compiled against `lwt.cmx`.

I confirmed that `-O3` is being passed, and working, by running `jbuilder --verbose` manually, and also by temporarily passing `-inlining-report` and checking the generated `*.inlining.*` files.

We don't seem to be having any problems from Flambda at the moment – at least none triggered by our tests :)

Resolves #436.

cc @bluddy (thanks for getting this rolling)

[objmagic]: https://discuss.ocaml.org/t/lwt-core-refactored-and-documented-to-be-contributor-friendly/161/24