### PR TITLE
Npick fix

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2534,7 +2534,6 @@ struct
         let callback in_completion_loop _result =
           let State_may_now_be_pending_proxy p = may_now_be_proxy p in
           let p = underlying p in
-          List.iter cancel ps;
           let State_may_have_changed p =
             finish_nchoose_or_npick_after_pending in_completion_loop p [] ps in
           ignore p

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2536,6 +2536,7 @@ struct
           let p = underlying p in
           let State_may_have_changed p =
             finish_nchoose_or_npick_after_pending in_completion_loop p [] ps in
+          List.iter cancel ps;
           ignore p
         in
         add_explicitly_removable_callback_to_each_of ps callback;

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2317,6 +2317,20 @@ let pick_tests = [
       (Lwt.state p1 = Lwt.Fail Lwt.Canceled &&
        Lwt.state p2 = Lwt.Fail Lwt.Canceled)
   end;
+  
+  test "pick: all pending" begin fun () ->
+    let p1, r = Lwt.task () in
+    let p2, _ = Lwt.task () in
+    let p3 = Lwt.pick [p1; p2] in
+    Lwt.wakeup r ();
+    (* Expected: *)
+    Lwt.return (Lwt.state p3 = Lwt.Return ())
+    (* Actual: *)
+    (*Lwt.return (Lwt.state p3 = Lwt.Fail Lwt.Canceled)*)
+  end;
+
+    (*Lwt.return (Lwt.state p3 = Lwt.Fail Lwt.Canceled)*)
+
 ]
 let tests = tests @ pick_tests
 
@@ -2354,15 +2368,11 @@ let npick_tests = [
     let p2, _ = Lwt.task () in
     let p3 = Lwt.npick [p1; p2] in
     Lwt.wakeup r ();
-    (* Expected: *)
     Lwt.return (Lwt.state p3 = Lwt.Return [()])
-    (* Actual: *)
-    (*Lwt.return (Lwt.state p3 = Lwt.Fail Lwt.Canceled)*)
   end;
 
-(* ocamlfind opt -linkpkg -package lwt npick.ml && ./a.out *)
-
-  (* The behavior of [p] tested here is a current bug in [Lwt.npick]. 
+(* 
+  (* The behavior of [p] tested here is a current bug in [Lwt.npick]. *)
   test "npick: pending, resolves" begin fun () ->
     let p1, _ = Lwt.task () in
     let p2, r = Lwt.task () in
@@ -2374,7 +2384,7 @@ let npick_tests = [
        Lwt.state p = Lwt.Fail Lwt.Canceled)
   end;
 
-  This is the same bug as above. 
+  (*JThis is the same bug as above. *)
   test "npick: pending, fails" begin fun () ->
     let p1, _ = Lwt.task () in
     let p2, r = Lwt.task () in

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2349,7 +2349,20 @@ let npick_tests = [
        Lwt.state p2 = Lwt.Return ["foo"; "bar"])
   end;
 
-  (* The behavior of [p] tested here is a current bug in [Lwt.npick]. *)
+  test "npick: all pending" begin fun () ->
+    let p1, r = Lwt.task () in
+    let p2, _ = Lwt.task () in
+    let p3 = Lwt.npick [p1; p2] in
+    Lwt.wakeup r ();
+    (* Expected: *)
+    Lwt.return (Lwt.state p3 = Lwt.Return [()])
+    (* Actual: *)
+    (*Lwt.return (Lwt.state p3 = Lwt.Fail Lwt.Canceled)*)
+  end;
+
+(* ocamlfind opt -linkpkg -package lwt npick.ml && ./a.out *)
+
+  (* The behavior of [p] tested here is a current bug in [Lwt.npick]. 
   test "npick: pending, resolves" begin fun () ->
     let p1, _ = Lwt.task () in
     let p2, r = Lwt.task () in
@@ -2361,7 +2374,7 @@ let npick_tests = [
        Lwt.state p = Lwt.Fail Lwt.Canceled)
   end;
 
-  (* This is the same bug as above. *)
+  This is the same bug as above. 
   test "npick: pending, fails" begin fun () ->
     let p1, _ = Lwt.task () in
     let p2, r = Lwt.task () in
@@ -2370,7 +2383,7 @@ let npick_tests = [
     Lwt.return
       (Lwt.state p1 = Lwt.Fail Lwt.Canceled &&
        Lwt.state p = Lwt.Fail Lwt.Canceled)
-  end;
+  end; *)
 
   test "npick: diamond" begin fun () ->
     let p, r = Lwt.wait () in


### PR DESCRIPTION
#340 - removed the line that causes a list of pending promises to be canceled. 