### PR TITLE
Packaging: refresh opam file messages

### DIFF
--- a/lwt.opam
+++ b/lwt.opam
@@ -52,11 +52,6 @@ messages: [
   {react:installed & !lwt_react:installed}
 ]
 post-messages: [
-  "Lwt 3.0.0 made some minor breaking changes, announced in 2.7.0. See
-  https://github.com/ocsigen/lwt/issues/308"
-  "Lwt > 3.1.0 will reorganise various packages; the old camlp4 syntax
-  extension will be moved into it's own package and the sub-libraries
-  will be installed in separate directories.  The later change affects
-  a few packages which, for example, use Lwt_unix functions, but only
-  link with Lwt"
+  "Lwt 4.0.0 will make some breaking changes to packaging in late 2017. See
+  https://github.com/ocsigen/lwt/issues/453"
 ]


### PR DESCRIPTION
@andrewray I preferred to move most of the specific text out into an issue (#453). We can modify both the issue and an extra warning to the `lwt.opam` file when 3.2.0 is released and we are actually on the way to changing the rest of the packaging, and breaking wrong uses of `lwt.unix` :)

I decided to leave the hints about `lwt_ssl`, etc., in the file, even though they are only relevant to 3.0.0. They may still help people for a while. Maybe we can remove them in 3.2.0 or 4.0.0.

(Submitting the 3.1.0 release tomorrow, I hope).