### PR TITLE
Extend coverage analysis to more files in Lwt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,14 @@ clean:
 	done
 	rm -rf _coverage/
 
-BISECT_FILES_PATTERN := _build/default/test/core/bisect*.out
+BISECT_FILES_PATTERN := _build/default/test/*/bisect*.out
+BISECT_REPORT := bisect-ppx-report
 
 .PHONY: coverage
 coverage: clean
-	BISECT_COVERAGE=yes jbuilder runtest --dev --only-packages lwt
-	bisect-ppx-report -I _build/ -html _coverage/ -text - -summary-only \
+	BISECT_ENABLE=yes jbuilder runtest --dev
+	bisect-ppx-report \
+	    -I _build/default/ -html _coverage/ \
+		-text - -summary-only \
 	    $(BISECT_FILES_PATTERN)
 	@echo See _coverage/index.html

--- a/lwt.opam
+++ b/lwt.opam
@@ -24,6 +24,9 @@ build: [
 build-test: [ [ "jbuilder" "runtest" "-p" name ] ]
 
 depends: [
+  # Bisect_ppx is used only during development. This dependency should be
+  # removed when preparing a release.
+  "bisect_ppx" {>= "1.3.0"}
   "cppo" {build & >= "1.1.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   # We are only using ocamlfind during configuration of the Unix binding.

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -10,10 +10,7 @@ let top = {|
   (public_name lwt)
   (synopsis "Monadic promises and concurrent I/O")
   (wrapped false)
-|}
-
-let optional_bisect_stanza = {|
-  (preprocess (pps (bisect_ppx)))
+  (preprocess (pps (bisect_ppx -conditional)))
 |}
 
 let optional_flambda_flags = {|
@@ -32,11 +29,6 @@ let accumulate_content_if condition more_content content =
     content
 
 let () =
-  let generating_coverage =
-    try Sys.getenv "BISECT_COVERAGE" = "yes"
-    with Not_found -> false
-  in
-
   (* Compilers starting from 4.03 support Flambda flags, even if not configured
      with Flambda support. *)
   let compiler_has_flambda_flags =
@@ -45,7 +37,6 @@ let () =
   in
 
   top
-  |> accumulate_content_if generating_coverage optional_bisect_stanza
   |> accumulate_content_if compiler_has_flambda_flags optional_flambda_flags
   |> fun content -> content ^ bottom
   |> Jbuild_plugin.V1.send

--- a/src/preemptive/jbuild
+++ b/src/preemptive/jbuild
@@ -6,4 +6,5 @@
   (synopsis "Preemptive thread support for Lwt")
   (wrapped false)
   (libraries (lwt lwt.unix threads))
+  (preprocess (pps (bisect_ppx -conditional)))
   (flags (:standard -w +A))))

--- a/src/react/jbuild
+++ b/src/react/jbuild
@@ -6,4 +6,5 @@
   (synopsis "Reactive programming helpers for Lwt")
   (wrapped false)
   (libraries (lwt react))
+  (preprocess (pps (bisect_ppx -conditional)))
   (flags (:standard -w +A))))

--- a/src/unix/jbuild
+++ b/src/unix/jbuild
@@ -5,12 +5,14 @@
 (rule
  ((targets (lwt_unix.ml))
   (deps    (lwt_unix.cppo.ml))
-  (action  (run ${bin:cppo} -V OCAML:${ocaml_version} ${<} -o ${@}))))
+  (action
+   (chdir ${ROOT} (run ${bin:cppo} -V OCAML:${ocaml_version} ${<} -o ${@})))))
 
 (rule
  ((targets (lwt_unix.mli))
   (deps    (lwt_unix.cppo.mli))
-  (action  (run ${bin:cppo} -V OCAML:${ocaml_version} ${<} -o ${@}))))
+  (action
+   (chdir ${ROOT} (run ${bin:cppo} -V OCAML:${ocaml_version} ${<} -o ${@})))))
 
 ;; lwt feature discovery
 ;;

--- a/src/unix/jbuild
+++ b/src/unix/jbuild
@@ -94,6 +94,7 @@
   (optional)
   (wrapped false)
   (libraries (lwt lwt.log unix bigarray))
+  (preprocess (pps (bisect_ppx -conditional)))
   (flags (:standard -w +A-29))
   (c_names (
     lwt_unix_stubs


### PR DESCRIPTION
Bisect_ppx 1.3.0 adds the `-conditional` workaround for Jbuilder, which allows us to apply Bisect_ppx to more of Lwt without having to change more `jbuild` files to OCaml syntax. There are still some kinks – see commit messages if interested.

cc @andrewray I credited the first commit to you, since it is based on the diff you kindly provided in https://github.com/ocsigen/lwt/issues/411#issuecomment-311962036. Hope that's okay.