### PR TITLE
Issue #336: Add temporary file creation capabilities to Lwt_io

### DIFF
--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1491,9 +1491,7 @@ let open_temp_file:
 
 let with_temp_file ?buffer ?flags ?perm ?temp_dir ?prefix f =
   open_temp_file
-    ?buffer:buffer ?flags:flags
-    ?perm:perm ?temp_dir:temp_dir
-    ?prefix: prefix () >>= fun (fname, chan) ->
+    ?buffer ?flags ?perm ?temp_dir ?prefix () >>= fun (fname, chan) ->
   Lwt.finalize
     (fun () -> f (fname, chan))
     (fun () -> close chan >>= fun _ ->

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1454,7 +1454,7 @@ let with_file ?buffer ?flags ?perm ~mode filename f =
     (fun () -> f ic)
     (fun () -> close ic)
 
-let open_temp_file_with_filename:
+let open_temp_file:
   ?buffer : Lwt_bytes.t ->
   ?perm : Unix.file_perm ->
   unit -> (string * output_channel) Lwt.t
@@ -1473,18 +1473,10 @@ let open_temp_file_with_filename:
     in
     fun () -> helper 0
 
-let open_temp_file:
-  ?buffer : Lwt_bytes.t ->
-  ?perm : Unix.file_perm ->
-  unit -> output_channel Lwt.t
-  = fun ?buffer ?perm ->
-    fun () ->
-      open_temp_file_with_filename ?buffer:buffer ?perm:perm () >|= snd
-
 let with_temp_file ?buffer ?perm f =
-  open_temp_file_with_filename ?buffer:buffer ?perm:perm () >>= fun (fname, chan) ->
+  open_temp_file ?buffer:buffer ?perm:perm () >>= fun (fname, chan) ->
   Lwt.finalize
-    (fun () -> f chan)
+    (fun () -> f (fname, chan))
     (fun () -> close chan >>= fun _ ->
       Lwt_unix.unlink fname)
 

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1368,8 +1368,10 @@ let open_temp_file:
   ?perm : Unix.file_perm ->
   unit -> output_channel Lwt.t
   = fun ?buffer ?perm ->
+    let f = Some [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC;
+                  Unix.O_NONBLOCK; Unix.O_EXCL] in
     fun () -> temp_filename () >>= fun fname ->
-      open_file ?buffer:buffer ?perm:perm ~mode:Output fname
+      open_file ?buffer:buffer ?flags:f ?perm:perm ~mode:Output fname
 
 let with_temp_file ?buffer ?perm f =
   temp_filename () >>= fun fname ->

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -123,7 +123,7 @@ and 'mode _channel = {
 
 and typ =
   | Type_normal of
-    (Lwt_bytes.t -> int -> int -> int Lwt.t) * 
+    (Lwt_bytes.t -> int -> int -> int Lwt.t) *
       (int64 -> Unix.seek_command -> int64 Lwt.t)
   (* The channel has been created with [make]. The first argument
      is the refill/flush function and the second is the seek
@@ -1478,12 +1478,11 @@ let open_temp_file:
   ?perm : Unix.file_perm ->
   unit -> output_channel Lwt.t
   = fun ?buffer ?perm ->
-    let f = open_temp_file_with_filename ?buffer:buffer ?perm:perm in
-    fun () -> f () >>= (fun (_, chan) -> Lwt.return chan)
+    fun () ->
+      open_temp_file_with_filename ?buffer:buffer ?perm:perm () >|= snd
 
 let with_temp_file ?buffer ?perm f =
-  let otf = open_temp_file_with_filename ?buffer:buffer ?perm:perm in
-  otf () >>= fun (fname, chan) ->
+  open_temp_file_with_filename ?buffer:buffer ?perm:perm () >>= fun (fname, chan) ->
   Lwt.finalize
     (fun () -> f chan)
     (fun () -> close chan >>= fun _ ->

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1372,10 +1372,12 @@ let open_temp_file:
       open_file ?buffer:buffer ?perm:perm ~mode:Output fname
 
 let with_temp_file ?buffer ?perm f =
-  open_temp_file ?buffer ?perm () >>= fun ic ->
+  temp_filename () >>= fun fname ->
+  open_file ?buffer:buffer ?perm:perm ~mode:Output fname >>= fun chan ->
   Lwt.finalize
-    (fun () -> f ic)
-    (fun () -> close ic)
+    (fun () -> f chan)
+    (fun () -> close chan >>= fun _ ->
+      Lwt_unix.unlink fname)
 
 let file_length filename = with_file ~mode:input filename length
 

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -406,11 +406,15 @@ val with_file :
 
 val open_temp_file :
   ?buffer:Lwt_bytes.t ->
-  ?perm:Unix.file_perm -> unit -> (string * output_channel) Lwt.t
+  ?flags : Unix.open_flag list ->
+  ?perm:Unix.file_perm ->
+  unit -> (string * output_channel) Lwt.t
 
 val with_temp_file :
   ?buffer:Lwt_bytes.t ->
-  ?perm:Unix.file_perm -> (string * output_channel -> 'b Lwt.t) -> 'b Lwt.t
+  ?flags : Unix.open_flag list ->
+  ?perm:Unix.file_perm ->
+  (string * output_channel -> 'b Lwt.t) -> 'b Lwt.t
 
 val open_connection :
   ?fd : Lwt_unix.file_descr ->

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -405,15 +405,19 @@ val with_file :
       channel is closed when [f ch] terminates (even if it fails). *)
 
 val open_temp_file :
-  ?buffer:Lwt_bytes.t ->
+  ?buffer : Lwt_bytes.t ->
   ?flags : Unix.open_flag list ->
-  ?perm:Unix.file_perm ->
+  ?perm : Unix.file_perm ->
+  ?temp_dir : string ->
+  ?prefix : string ->
   unit -> (string * output_channel) Lwt.t
 
 val with_temp_file :
   ?buffer:Lwt_bytes.t ->
   ?flags : Unix.open_flag list ->
-  ?perm:Unix.file_perm ->
+  ?perm : Unix.file_perm ->
+  ?temp_dir : string ->
+  ?prefix : string ->
   (string * output_channel -> 'b Lwt.t) -> 'b Lwt.t
 
 val open_connection :

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -406,11 +406,11 @@ val with_file :
 
 val open_temp_file :
   ?buffer:Lwt_bytes.t ->
-  ?perm:Unix.file_perm -> unit -> output_channel Lwt.t
+  ?perm:Unix.file_perm -> unit -> (string * output_channel) Lwt.t
 
 val with_temp_file :
   ?buffer:Lwt_bytes.t ->
-  ?perm:Unix.file_perm -> (output_channel -> 'b Lwt.t) -> 'b Lwt.t
+  ?perm:Unix.file_perm -> (string * output_channel -> 'b Lwt.t) -> 'b Lwt.t
 
 val open_connection :
   ?fd : Lwt_unix.file_descr ->

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -404,9 +404,6 @@ val with_file :
       file and passes the channel to [f]. It is ensured that the
       channel is closed when [f ch] terminates (even if it fails). *)
 
-val temp_filename :
-  unit -> string Lwt.t
-
 val open_temp_file :
   ?buffer:Lwt_bytes.t ->
   ?perm:Unix.file_perm -> unit -> output_channel Lwt.t

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -404,6 +404,17 @@ val with_file :
       file and passes the channel to [f]. It is ensured that the
       channel is closed when [f ch] terminates (even if it fails). *)
 
+val temp_filename :
+  unit -> string Lwt.t
+
+val open_temp_file :
+  ?buffer:Lwt_bytes.t ->
+  ?perm:Unix.file_perm -> unit -> output_channel Lwt.t
+
+val with_temp_file :
+  ?buffer:Lwt_bytes.t ->
+  ?perm:Unix.file_perm -> (output_channel -> 'b Lwt.t) -> 'b Lwt.t
+
 val open_connection :
   ?fd : Lwt_unix.file_descr ->
   ?in_buffer : Lwt_bytes.t -> ?out_buffer : Lwt_bytes.t ->

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -333,6 +333,7 @@ let suite = suite "lwt_io" [
 
   test "with_temp_filename"
     (fun () ->
+       let prefix = "test_tempfile" in
        let startswith x y =
          let n = String.length x and
              m = String.length y in
@@ -341,13 +342,13 @@ let suite = suite "lwt_io" [
          let handle = Unix.opendir "." in
          let rec helper x =
            try
-              not (startswith (Unix.readdir x) "lwt_io_temp_file_") && helper x
+              not (startswith (Unix.readdir x) prefix) && helper x
            with End_of_file -> true in
          helper handle
        in
        let write_data (_, chan) = Lwt_io.write chan "test file content" in
        let write_data_fail _ = Lwt.fail Dummy_error in
-       Lwt_io.with_temp_file write_data >>= fun _ ->
+       Lwt_io.with_temp_file write_data ~prefix:prefix >>= fun _ ->
        Lwt.return (check_no_tempfiles ()) >>= fun no_temps1 ->
        Lwt.catch
          (fun () -> Lwt_io.with_temp_file write_data_fail)
@@ -358,5 +359,14 @@ let suite = suite "lwt_io" [
          )
        >>= fun no_temps2 ->
        Lwt.return (no_temps1 && no_temps2)
+    );
+
+  (* Verify that no exceptions are thrown if the function passed to
+     with_temp_file closes the channel on its own. *)
+  test "with_temp_filename close handle"
+    (fun () ->
+       let f (_, chan) = Lwt_io.write chan "test file content" >>= fun _ ->
+         Lwt_io.close chan in
+       Lwt_io.with_temp_file f >>= fun _ -> Lwt.return_true;
     );
 ]

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -337,7 +337,7 @@ let suite = suite "lwt_io" [
        let startswith x y =
          let n = String.length x and
              m = String.length y in
-         (n >= m && String.equal y (String.sub x 0 m)) in
+         (n >= m && y = (String.sub x 0 m)) in
        let check_no_tempfiles () =
          let handle = Unix.opendir "." in
          let rec helper x =

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -310,4 +310,17 @@ let suite = suite "lwt_io" [
           ) >|= fun () ->
         !exceptions_observed = 2
     );
+
+  test "open_temp_file"
+    (fun () ->
+       Lwt_io.open_temp_file () >>= fun out_chan ->
+       Lwt_io.write out_chan "test_file_content" >>= fun () ->
+       Lwt_io.close out_chan >>= fun () ->
+       Lwt.return_true
+    );
+
+  test "get_temp_filename"
+    (fun () ->
+       Lwt_io.temp_filename () >>= Lwt_unix.file_exists >|= fun e -> not e
+    );
 ]

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -1,7 +1,7 @@
 (* OCaml promise library
  * http://www.ocsigen.org/lwt
  * Copyright (C) 2009 Jérémie Dimino
-n *
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, with linking exceptions;

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -348,7 +348,7 @@ let suite = suite "lwt_io" [
        in
        let write_data (_, chan) = Lwt_io.write chan "test file content" in
        let write_data_fail _ = Lwt.fail Dummy_error in
-       Lwt_io.with_temp_file write_data ~prefix:prefix >>= fun _ ->
+       Lwt_io.with_temp_file write_data ~prefix >>= fun _ ->
        Lwt.return (check_no_tempfiles ()) >>= fun no_temps1 ->
        Lwt.catch
          (fun () -> Lwt_io.with_temp_file write_data_fail)


### PR DESCRIPTION
This change adds two new functions, `open_temp_file` and `with_temp_file` to `Lwt_io`, as was requested in #336.

@aantron, @copy: Please let me know if this was what you had in mind when #336 was opened/added to the milestone; I haven't worked in this module before, so I'm not sure if I'm breaking any important conventions.