### PR TITLE
Fix locations in generated lwt ppx

### DIFF
--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -71,7 +71,7 @@ let gen_binds e_loc l e =
         (evar (gen_name i)) [@metaloc binding.pvb_expr.pexp_loc]
       in
       let fun_ =
-        [%expr (fun [%p binding.pvb_pat] -> [%e aux (i+1) t])] [@metaloc binding.pvb_loc]
+        [%expr (fun [%p binding.pvb_pat] -> [%e aux (i+1) t])] [@metaloc e_loc]
       in
       let new_exp =
         if !debug then

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -56,7 +56,7 @@ let gen_name i = lwt_prefix ^ string_of_int i
 let gen_bindings l =
   let aux i binding =
     { binding with
-      pvb_pat = (pvar (gen_name i)) [@metaloc binding.pvb_expr.pexp_loc]
+      pvb_pat = pvar ~loc:binding.pvb_expr.pexp_loc (gen_name i)
     }
   in
   List.mapi aux l
@@ -68,7 +68,7 @@ let gen_binds e_loc l e =
     | [] -> e
     | binding :: t ->
       let name = (* __ppx_lwt_$i, at the position of $x$ *)
-        (evar (gen_name i)) [@metaloc binding.pvb_expr.pexp_loc]
+        evar ~loc:binding.pvb_expr.pexp_loc (gen_name i)
       in
       let fun_ =
         [%expr (fun [%p binding.pvb_pat] -> [%e aux (i+1) t])] [@metaloc e_loc]

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -30,7 +30,7 @@ let add_wildcard_case cases =
     List.exists is_catchall cases
   in
   if not has_wildcard
-  then cases @ [Exp.case [%pat? exn] [%expr Lwt.fail exn]]
+  then cases @ [Exp.case [%pat? exn] [%expr Lwt.fail exn]] [@metaloc Location.none]
   else cases
 
 (** {3 Internal names} *)


### PR DESCRIPTION
This fixes two problems in the generation of `let%lwt` expressions:

1. The location of the generated body (i.e. `Lwt.bind t (fun v -> body)`)  didn't contain the actual body (first commit) 
2. The problem mentioned [here](https://github.com/ocsigen/lwt/issues/337#issuecomment-296160837), i.e. the right hand side of the let binding spanning the whole expression (second commit)

For reference, the diff between the broken parse tree and the fixed one: https://gist.github.com/copy/97aafc69a2467fa390e3f02f5aa97f09 By manual inspection, the locations look correct now.

This fixes #337.