### PR TITLE
Deprecate >> in ppx

### DIFF
--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -339,15 +339,29 @@ let mapper =
           let pat = if !strict_seq then [%pat? ()] else [%pat? _] in
           let lhs, rhs = mapper.expr mapper lhs, mapper.expr mapper rhs in
           if !debug then
-            [%expr Lwt.backtrace_bind (fun exn -> try raise exn with exn -> exn)
-                                      [%e lhs]
-                                      (fun [%p pat] -> [%e rhs])
-              [@ocaml.ppwarning "The operator >> is deprecated"]
-            ]
+            Ast_helper.Exp.attr
+              [%expr Lwt.backtrace_bind (fun exn -> try raise exn with exn -> exn)
+                                        [%e lhs]
+                                        (fun [%p pat] -> [%e rhs])
+              ]
+              (Ast_mapper.attribute_of_warning
+                { Location.
+                  loc_start = lhs.pexp_loc.Location.loc_end;
+                  loc_end = rhs.pexp_loc.Location.loc_start;
+                  loc_ghost = false;
+                }
+                "The operator >> is deprecated"
+              )
           else
-            [%expr (Lwt.bind [%e lhs] (fun [%p pat] -> [%e rhs]))
-              [@ocaml.ppwarning "The operator >> is deprecated"]
-            ]
+            Ast_helper.Exp.attr
+              [%expr (Lwt.bind [%e lhs] (fun [%p pat] -> [%e rhs]))]
+              (Ast_mapper.attribute_of_warning
+                { Location.
+                  loc_start = lhs.pexp_loc.Location.loc_end;
+                  loc_end = rhs.pexp_loc.Location.loc_start;
+                  loc_ghost = false;
+                }
+                "The operator >> is deprecated")
         else
           default_mapper.expr mapper expr
       | { pexp_desc = Pexp_apply (fn, args); pexp_attributes; pexp_loc } when !log ->

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -334,7 +334,7 @@ let mapper =
             "Lwt's finally should be used only with the syntax: \"(<expr>)[%%finally ...]\"."
         ))
 
-      | [%expr [%e? lhs] >> [%e? rhs]] ->
+      | [%expr [%e? lhs] >> [%e? rhs]] as e ->
         if !sequence then
           let pat = if !strict_seq then [%pat? ()] else [%pat? _] in
           let lhs, rhs = mapper.expr mapper lhs, mapper.expr mapper rhs in
@@ -344,23 +344,12 @@ let mapper =
                                         [%e lhs]
                                         (fun [%p pat] -> [%e rhs])
               ]
-              (Ast_mapper.attribute_of_warning
-                { Location.
-                  loc_start = lhs.pexp_loc.Location.loc_end;
-                  loc_end = rhs.pexp_loc.Location.loc_start;
-                  loc_ghost = false;
-                }
-                "The operator >> is deprecated"
-              )
+              (Ast_mapper.attribute_of_warning e.pexp_loc
+                "The operator >> is deprecated")
           else
             Ast_helper.Exp.attr
               [%expr (Lwt.bind [%e lhs] (fun [%p pat] -> [%e rhs]))]
-              (Ast_mapper.attribute_of_warning
-                { Location.
-                  loc_start = lhs.pexp_loc.Location.loc_end;
-                  loc_end = rhs.pexp_loc.Location.loc_start;
-                  loc_ghost = false;
-                }
+              (Ast_mapper.attribute_of_warning e.pexp_loc
                 "The operator >> is deprecated")
         else
           default_mapper.expr mapper expr

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -335,6 +335,7 @@ let mapper =
         ))
 
       | [%expr [%e? lhs] >> [%e? rhs]] ->
+        prerr_string "Warning: the operator >> is deprecated\n";
         if !sequence then
           let pat = if !strict_seq then [%pat? ()] else [%pat? _] in
           let lhs, rhs = mapper.expr mapper lhs, mapper.expr mapper rhs in

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -335,16 +335,19 @@ let mapper =
         ))
 
       | [%expr [%e? lhs] >> [%e? rhs]] ->
-        prerr_string "Warning: the operator >> is deprecated\n";
         if !sequence then
           let pat = if !strict_seq then [%pat? ()] else [%pat? _] in
           let lhs, rhs = mapper.expr mapper lhs, mapper.expr mapper rhs in
           if !debug then
             [%expr Lwt.backtrace_bind (fun exn -> try raise exn with exn -> exn)
                                       [%e lhs]
-                                      (fun [%p pat] -> [%e rhs])]
+                                      (fun [%p pat] -> [%e rhs])
+              [@ocaml.ppwarning "The operator >> is deprecated"]
+            ]
           else
-            [%expr Lwt.bind [%e lhs] (fun [%p pat] -> [%e rhs])]
+            [%expr (Lwt.bind [%e lhs] (fun [%p pat] -> [%e rhs]))
+              [@ocaml.ppwarning "The operator >> is deprecated"]
+            ]
         else
           default_mapper.expr mapper expr
       | { pexp_desc = Pexp_apply (fn, args); pexp_attributes; pexp_loc } when !log ->

--- a/test/ppx/jbuild
+++ b/test/ppx/jbuild
@@ -3,7 +3,8 @@
 (executable
  ((name main)
   (libraries (lwttester))
-  (preprocess (pps (lwt.ppx)))))
+  (preprocess (pps (lwt.ppx)))
+  (flags (:standard -w -22))))
 
 (alias
  ((name runtest)

--- a/test/ppx/jbuild
+++ b/test/ppx/jbuild
@@ -4,7 +4,8 @@
  ((name main)
   (libraries (lwttester))
   (preprocess (pps (lwt.ppx)))
-  (flags (:standard -w -22))))
+  (flags (:standard -w -22))
+))
 
 (alias
  ((name runtest)

--- a/test/ppx/jbuild
+++ b/test/ppx/jbuild
@@ -4,7 +4,7 @@
  ((name main)
   (libraries (lwttester))
   (preprocess (pps (lwt.ppx)))
-  (flags (:standard -w -22))
+  (flags (:standard -warn-error -22))
 ))
 
 (alias

--- a/test/ppx/main.ml
+++ b/test/ppx/main.ml
@@ -155,14 +155,6 @@ let suite = suite "ppx" [
          return !x
     ) ;
 
-  test "sequence"
-    (fun () ->
-       let lst = ref [] in
-       (lst := 2 :: !lst; Lwt.return_unit) >>
-       (lst := 1 :: !lst; Lwt.return_unit) >>
-       (Lwt.return (!lst = [1;2]))
-    ) ;
-
   test "log"
     (fun () ->
        Lwt_log.ign_debug "bar";

--- a/test/ppx/main.ml
+++ b/test/ppx/main.ml
@@ -155,6 +155,16 @@ let suite = suite "ppx" [
          return !x
     ) ;
 
+  test "sequence"
+    (fun () ->
+       let lst = ref [] in
+       (lst := 2 :: !lst; Lwt.return_unit) >>
+       (lst := 1 :: !lst; Lwt.return_unit) >>
+       (Lwt.return (!lst = [1;2]))
+    ) ;
+
+
+
   test "log"
     (fun () ->
        Lwt_log.ign_debug "bar";

--- a/test/ppx/main.ml
+++ b/test/ppx/main.ml
@@ -163,8 +163,6 @@ let suite = suite "ppx" [
        (Lwt.return (!lst = [1;2]))
     ) ;
 
-
-
   test "log"
     (fun () ->
        Lwt_log.ign_debug "bar";


### PR DESCRIPTION
This PR is for issue: #387

It adds a warning to generated code that uses `>>` from ppx.

Note that, in its current form, the PR removes tests for `>>` altogether. These tests fails because of `-w @a` in the flags which turn all warning into errors. Comments and suggestions on this are welcome.

EDIT by @aantron: resolves #387.