### PR TITLE
Add expect tests for ppx

### DIFF
--- a/test/ppx_expect/cases/let_1.expect
+++ b/test/ppx_expect/cases/let_1.expect
@@ -1,0 +1,3 @@
+File "./let_1.ml", line 6, characters 10-12:
+Error: This pattern matches values of type unit
+       but a pattern was expected which matches values of type int

--- a/test/ppx_expect/cases/let_1.ml
+++ b/test/ppx_expect/cases/let_1.ml
@@ -1,0 +1,7 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  let%lwt () = Lwt.return 5 in
+  Lwt.return ();;

--- a/test/ppx_expect/cases/let_2.expect
+++ b/test/ppx_expect/cases/let_2.expect
@@ -1,0 +1,3 @@
+File "./let_2.ml", line 7, characters 2-4:
+Error: This expression has type unit but an expression was expected of type
+         'a Lwt.t

--- a/test/ppx_expect/cases/let_2.ml
+++ b/test/ppx_expect/cases/let_2.ml
@@ -1,0 +1,7 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  let%lwt () = Lwt.return () in
+  ();;

--- a/test/ppx_expect/cases/let_3.expect
+++ b/test/ppx_expect/cases/let_3.expect
@@ -1,0 +1,3 @@
+File "./let_3.ml", line 6, characters 33-35:
+Error: This pattern matches values of type unit
+       but a pattern was expected which matches values of type int

--- a/test/ppx_expect/cases/let_3.ml
+++ b/test/ppx_expect/cases/let_3.ml
@@ -1,0 +1,7 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  let%lwt () = Lwt.return () and () = Lwt.return 5 in
+  Lwt.return ();;

--- a/test/ppx_expect/cases/let_4.expect
+++ b/test/ppx_expect/cases/let_4.expect
@@ -1,0 +1,3 @@
+File "./let_4.ml", line 7, characters 14-17:
+Error: This expression has type unit but an expression was expected of type
+         int

--- a/test/ppx_expect/cases/let_4.ml
+++ b/test/ppx_expect/cases/let_4.ml
@@ -1,0 +1,7 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  let%lwt foo = Lwt.return () and bar = Lwt.return 5 in
+  Lwt.return (foo + bar);;

--- a/test/ppx_expect/cases/match_1.expect
+++ b/test/ppx_expect/cases/match_1.expect
@@ -1,0 +1,3 @@
+File "./match_1.ml", line 9, characters 4-6:
+Error: This pattern matches values of type unit
+       but a pattern was expected which matches values of type int

--- a/test/ppx_expect/cases/match_1.ml
+++ b/test/ppx_expect/cases/match_1.ml
@@ -1,0 +1,10 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  match%lwt
+    Lwt.return 5
+  with
+  | () ->
+    Lwt.return ();;

--- a/test/ppx_expect/cases/match_2.expect
+++ b/test/ppx_expect/cases/match_2.expect
@@ -1,0 +1,3 @@
+File "./match_2.ml", line 7, characters 4-6:
+Error: This expression has type unit but an expression was expected of type
+         'a Lwt.t

--- a/test/ppx_expect/cases/match_2.ml
+++ b/test/ppx_expect/cases/match_2.ml
@@ -1,0 +1,10 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  match%lwt
+    ()
+  with
+  | () ->
+    Lwt.return ();;

--- a/test/ppx_expect/cases/match_3.expect
+++ b/test/ppx_expect/cases/match_3.expect
@@ -1,0 +1,3 @@
+File "./match_3.ml", line 10, characters 4-5:
+Error: This expression has type int but an expression was expected of type
+         'a Lwt.t

--- a/test/ppx_expect/cases/match_3.ml
+++ b/test/ppx_expect/cases/match_3.ml
@@ -1,0 +1,10 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  match%lwt
+    Lwt.return ()
+  with
+  | () ->
+    5;;

--- a/test/ppx_expect/cases/match_4.expect
+++ b/test/ppx_expect/cases/match_4.expect
@@ -1,0 +1,4 @@
+File "./match_4.ml", line 12, characters 4-16:
+Error: This expression has type int Lwt.t
+       but an expression was expected of type unit Lwt.t
+       Type int is not compatible with type unit 

--- a/test/ppx_expect/cases/match_4.ml
+++ b/test/ppx_expect/cases/match_4.ml
@@ -1,0 +1,12 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  match%lwt
+    Lwt.return ()
+  with
+  | () ->
+    Lwt.return ()
+  | exception End_of_file ->
+    Lwt.return 5

--- a/test/ppx_expect/cases/try_1.expect
+++ b/test/ppx_expect/cases/try_1.expect
@@ -1,0 +1,3 @@
+File "./try_1.ml", line 7, characters 4-5:
+Error: This expression has type int but an expression was expected of type
+         'a Lwt.t

--- a/test/ppx_expect/cases/try_1.ml
+++ b/test/ppx_expect/cases/try_1.ml
@@ -1,0 +1,8 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  try%lwt
+    5
+  with _ -> Lwt.return ();;

--- a/test/ppx_expect/cases/try_2.expect
+++ b/test/ppx_expect/cases/try_2.expect
@@ -1,0 +1,3 @@
+File "./try_2.ml", line 8, characters 12-13:
+Error: This expression has type int but an expression was expected of type
+         unit Lwt.t

--- a/test/ppx_expect/cases/try_2.ml
+++ b/test/ppx_expect/cases/try_2.ml
@@ -1,0 +1,8 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  try%lwt
+    Lwt.return ()
+  with _ -> 5;;

--- a/test/ppx_expect/cases/try_3.expect
+++ b/test/ppx_expect/cases/try_3.expect
@@ -1,0 +1,4 @@
+File "./try_3.ml", line 8, characters 12-24:
+Error: This expression has type int Lwt.t
+       but an expression was expected of type unit Lwt.t
+       Type int is not compatible with type unit 

--- a/test/ppx_expect/cases/try_3.ml
+++ b/test/ppx_expect/cases/try_3.ml
@@ -1,0 +1,8 @@
+#use "topfind";;
+#require "lwt";;
+#require "lwt.ppx";;
+
+let _ =
+  try%lwt
+    Lwt.return ()
+  with _ -> Lwt.return 5;;

--- a/test/ppx_expect/jbuild
+++ b/test/ppx_expect/jbuild
@@ -1,0 +1,12 @@
+(jbuild_version 1)
+
+(executable
+ ((name main)
+  (libraries (lwttester))
+  (preprocess (pps (lwt.ppx)))))
+
+(alias
+ ((name runtest)
+  (package lwt)
+  (deps ((files_recursively_in cases)))
+  (action (run ${exe:main.exe}))))

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -1,0 +1,78 @@
+let test_directory = "cases"
+let test_cases = [
+  "let_1";
+  "let_2";
+  "let_3";
+  "let_4";
+  "match_1";
+  "match_2";
+  "match_3";
+  "match_4";
+  "try_1";
+  "try_2";
+  "try_3";
+]
+
+let _read_file name =
+  let buffer = Buffer.create 4096 in
+  let channel = open_in name in
+
+  try
+    let rec read () =
+      try input_char channel |> Buffer.add_char buffer; read ()
+      with End_of_file -> ()
+    in
+    read ();
+    close_in channel;
+
+    Buffer.contents buffer
+
+  with exn ->
+    close_in_noerr channel;
+    raise exn
+
+let _command_failed ?status command =
+  match status with
+  | None -> Printf.sprintf "'%s' did not exit" command |> failwith
+  | Some v -> Printf.sprintf "'%s' failed with status %i" command v |> failwith
+
+let _run_int command =
+  match Unix.system command with
+  | Unix.WEXITED v -> v
+  | _ -> _command_failed command
+
+let run command =
+  let v = _run_int command in
+  if v <> 0 then _command_failed command ~status:v
+
+let diff reference result =
+  let command = Printf.sprintf "diff -au %s %s" reference result in
+  let status = _run_int (command ^ " > /dev/null") in
+  match status with
+  | 0 -> ()
+  | 1 ->
+    let _ : int =_run_int (command ^ " > delta") in
+    let delta = _read_file "delta" in
+    Printf.sprintf "> %s:\n\n%s" command delta
+    |> failwith
+  | _ -> _command_failed command ~status
+
+let run_test name =
+  let ml_name = name ^ ".ml" in
+  let expect_name = name ^ ".expect" in
+  let fixed_name = name ^ ".fixed" in
+  let command = Printf.sprintf "ocaml %s 2> %s" ml_name fixed_name in
+  let ocaml_return_code = _run_int command in
+  begin if ocaml_return_code = 0 then
+      failwith (Printf.sprintf "Unexpected toplevel return code: %d" ocaml_return_code)
+  end;
+  diff expect_name fixed_name
+
+let () =
+  Sys.chdir test_directory;
+  try
+    List.iter run_test test_cases
+  with
+  | Failure f ->
+    prerr_endline f;
+    exit 1

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -1,17 +1,4 @@
 let test_directory = "cases"
-let test_cases = [
-  "let_1";
-  "let_2";
-  "let_3";
-  "let_4";
-  "match_1";
-  "match_2";
-  "match_3";
-  "match_4";
-  "try_1";
-  "try_2";
-  "try_3";
-]
 
 let _read_file name =
   let buffer = Buffer.create 4096 in
@@ -69,6 +56,12 @@ let run_test name =
   diff expect_name fixed_name
 
 let () =
+  let test_cases =
+    Sys.readdir test_directory
+    |> Array.to_list
+    |> List.filter (fun file -> Filename.check_suffix file ".ml")
+    |> List.map Filename.chop_extension
+  in
   Sys.chdir test_directory;
   try
     List.iter run_test test_cases

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -67,7 +67,7 @@ let () =
     Sys.cygwin = false && Sys.win32 = false &&
     (* 4.02.3 prints file paths differently *)
     Scanf.sscanf Sys.ocaml_version "%u.%u"
-      (fun major minor -> major >= 4 && minor >= 3)
+      (fun major minor -> (major, minor) >= (4, 3))
   in
   let suite = Test.suite "ppx_expect" (
     List.map (fun test_case ->

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -48,7 +48,7 @@ let run_test name =
   let ml_name = name ^ ".ml" in
   let expect_name = name ^ ".expect" in
   let fixed_name = name ^ ".fixed" in
-  let command = Printf.sprintf "ocaml %s 2> %s" ml_name fixed_name in
+  let command = Printf.sprintf "ocaml -noinit %s 2> %s" ml_name fixed_name in
   let ocaml_return_code = _run_int command in
   begin if ocaml_return_code = 0 then
       failwith (Printf.sprintf "Unexpected toplevel return code: %d" ocaml_return_code)


### PR DESCRIPTION
This adds expect tests for some of the ppx constructs. It uses some code from [ppx_bisect's test helpers](https://github.com/aantron/bisect_ppx/blob/f1b1899609cfa1f77cdd5f0e32d614ed0d6d9db4/test/src/test_helpers.ml). It doesn't work on Windows, due to using `diff`.

cc @Drup @aantron 