### PR TITLE
Make Lwt_ssl -safe-string-compatible

### DIFF
--- a/src/ssl/lwt_ssl.mli
+++ b/src/ssl/lwt_ssl.mli
@@ -58,8 +58,8 @@ val ssl_perform_handshake : uninitialized_socket -> socket Lwt.t
 val ssl_accept_handshake  : uninitialized_socket -> socket Lwt.t
 (** Await a SSL/TLS handshake on the specified socket (used by servers). *)
 
-val read : socket -> string -> int -> int -> int Lwt.t
-val write : socket -> string -> int -> int -> int Lwt.t
+val read : socket -> bytes -> int -> int -> int Lwt.t
+val write : socket -> bytes -> int -> int -> int Lwt.t
 
 val read_bytes : socket -> Lwt_bytes.t -> int -> int -> int Lwt.t
 val write_bytes : socket -> Lwt_bytes.t -> int -> int -> int Lwt.t


### PR DESCRIPTION
This makes `Lwt_ssl` 4.06-friendly by changing `Lwt_ssl.read` and `Lwt_ssl.write` so that they operate on buffers of type `bytes` rather than `string`.

This could be a breaking change for some code. It is, however, consistent with `Lwt_unix`. `Lwt_unix` also has a `write_string` function for writing buffers of type `string`. We may want to add that to `Lwt_ssl` in a separate PR.

As I'm not a user of `Lwt_ssl`, I'd appreciate feedback on this change.

EDIT: This fixes #478.