### PR TITLE
Begin factoring out the PPX

### DIFF
--- a/META.lwt
+++ b/META.lwt
@@ -28,7 +28,7 @@ package "log" (
 package "ppx" (
   #directory = "ppx"
   version = "dev"
-  description = "Lwt PPX syntax extension"
+  description = "Lwt PPX syntax extension (deprecated; use lwt_ppx)"
   requires(ppx_driver) = "lwt.omp"
   requires(-ppx_driver) = "bytes lwt result"
   ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
@@ -92,7 +92,7 @@ package "simple-top" (
 package "syntax" (
   #directory = "syntax"
   version = "dev"
-  description = "Camlp4 syntax for Lwt (deprecated; use lwt.ppx)"
+  description = "Camlp4 syntax for Lwt (deprecated; use lwt_ppx)"
   requires = "camlp4 lwt.syntax.options"
   archive(syntax, preprocessor) = "lwt_syntax.cma"
   archive(syntax, toploop) = "lwt_syntax.cma"
@@ -103,7 +103,7 @@ package "syntax" (
   package "log" (
     #directory = "log"
     version = "dev"
-    description = "Camlp4 syntax for Lwt logging (deprecated; use lwt.ppx)"
+    description = "Camlp4 syntax for Lwt logging (deprecated; use lwt_ppx)"
     requires = "camlp4 lwt.syntax.options"
     archive(syntax, preprocessor) = "lwt_syntax_log.cma"
     archive(syntax, toploop) = "lwt_syntax_log.cma"
@@ -115,7 +115,7 @@ package "syntax" (
   package "options" (
     #directory = "options"
     version = "dev"
-    description = "Options for Lwt Camlp4 syntax extension (deprecated; use lwt.ppx)"
+    description = "Options for Lwt Camlp4 syntax extension (deprecated; use lwt_ppx)"
     requires = "camlp4"
     archive(syntax, preprocessor) = "lwt_syntax_options.cma"
     archive(syntax, toploop) = "lwt_syntax_options.cma"

--- a/META.lwt_ppx
+++ b/META.lwt_ppx
@@ -1,0 +1,7 @@
+# The Lwt PPX will, in the future, be moved out to this package lwt_ppx. For
+# now, this package is a compatibility wrapper for the PPX's current location in
+# lwt.ppx.
+
+version = "dev"
+description = "Lwt PPX syntax extension"
+requires = "lwt.ppx"

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ packaging-test:
 	ocamlfind query lwt
 	for TEST in `ls -d test/packaging/*/*` ; \
 	do \
-	    make -wC $$TEST ; \
+	    make -wC $$TEST || exit 1 ; \
 	done
 
 .PHONY: install-for-packaging-test

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,12 @@ packaging-test:
 .PHONY: install-for-packaging-test
 install-for-packaging-test: clean
 	opam pin add --yes --no-action lwt .
+	opam pin add --yes --no-action lwt_ppx .
 	opam pin add --yes --no-action lwt_react .
 	opam pin add --yes --no-action lwt_ssl .
 	opam pin add --yes --no-action lwt_glib .
 	opam install --yes camlp4
-	opam reinstall --yes lwt lwt_react lwt_ssl lwt_glib
+	opam reinstall --yes lwt lwt_ppx lwt_react lwt_ssl lwt_glib
 
 .PHONY: clean
 clean:

--- a/lwt.opam
+++ b/lwt.opam
@@ -53,6 +53,8 @@ messages: [
     {lablgtk:installed & !lwt_glib:installed}
   "For module Lwt_react, please install package lwt_react"
     {react:installed & !lwt_react:installed}
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
 ]
 post-messages: [
   "Lwt 4.0.0 will make some breaking changes to packaging in late 2017. See

--- a/lwt.opam
+++ b/lwt.opam
@@ -48,11 +48,11 @@ available: [ocaml-version >= "4.02.0" & compiler != "4.02.1+BER"]
 
 messages: [
   "For module Lwt_ssl, please install package lwt_ssl"
-  {ssl:installed & !lwt_ssl:installed}
+    {ssl:installed & !lwt_ssl:installed}
   "For module Lwt_glib, please install package lwt_glib"
-  {lablgtk:installed & !lwt_glib:installed}
+    {lablgtk:installed & !lwt_glib:installed}
   "For module Lwt_react, please install package lwt_react"
-  {react:installed & !lwt_react:installed}
+    {react:installed & !lwt_react:installed}
 ]
 post-messages: [
   "Lwt 4.0.0 will make some breaking changes to packaging in late 2017. See

--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "jbuilder" {build}
+  # This will be constrained with an upper bound once the PPX is fully factored
+  # out of package lwt. At that point, the dependencies of lwt on
+  # ppx_tools_versioned and ocaml-migrate-parsetree need to be moved to this
+  # package.
+  "lwt"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -144,6 +144,7 @@ install_extra_package () {
     opam install -y --verbose lwt_$PACKAGE
 }
 
+install_extra_package ppx
 install_extra_package react
 install_extra_package ssl
 install_extra_package glib

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -10,7 +10,7 @@ packages_apt () {
         4.03) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
         4.04) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
         4.05) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
-        4.06) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes; HAVE_CAMLP4=no;;
+        4.06) PPA=avsm/ocaml42+opam12; DO_SWITCH=yes;;
            *) echo Unsupported compiler $COMPILER; exit 1;;
     esac
 

--- a/test/packaging/jbuilder/ppx/jbuild
+++ b/test/packaging/jbuilder/ppx/jbuild
@@ -3,4 +3,4 @@
 (executable
  ((name user)
   (libraries (lwt))
-  (preprocess (pps (lwt.ppx)))))
+  (preprocess (pps (lwt_ppx)))))

--- a/test/packaging/jbuilder/ppx_ppxopt/jbuild
+++ b/test/packaging/jbuilder/ppx_ppxopt/jbuild
@@ -3,4 +3,4 @@
 (executable
  ((name user)
   (libraries (lwt))
-  (preprocess (pps (lwt.ppx -no-sequence)))))
+  (preprocess (pps (lwt_ppx -no-sequence)))))

--- a/test/packaging/ocamlfind/ppx/Makefile
+++ b/test/packaging/ocamlfind/ppx/Makefile
@@ -1,10 +1,10 @@
 .PHONY : test
 test : clean
-	ocamlfind opt -package lwt.ppx -c user.ml
+	ocamlfind opt -package lwt_ppx -c user.ml
 	ocamlfind opt -package lwt -linkpkg user.cmx
 	./a.out
 	# Expecting failure with "Unbound value >>":
-	! ocamlfind opt -package lwt.ppx \
+	! ocamlfind opt -package lwt_ppx \
 	    -ppxopt lwt.ppx,-no-sequence -c user.ml
 
 .PHONY : clean


### PR DESCRIPTION
Discussed in #338.

This is pretty much following our "normal" procedure:

1. This commit creates an opam package `lwt_ppx`, containing a Findlib package `lwt_ppx`, which is a proxy for the current `lwt.ppx` (which is in opam package `lwt`). We will release the commit as part of 3.2.0, and announce the upcoming change.
2. In 4.0.0, we will delete `lwt.ppx` and move the PPX fully to `lwt_ppx`.

There is one flaw: even when using `lwt_ppx`, PPX options still have to be passed to `lwt.ppx`, not to `lwt_ppx`. Once 4.0.0 lands, they will suddenly have to be passed to `lwt_ppx`. This applies only to ocamlfind and tools that use it (like Ocamlbuild). Jbuilder, or any other build tool that runs the PPX as a library linked into a driver, will handle options correctly. I looked through opam users of Lwt, and only sqlexpr seems to use `lwt.ppx` options, in its `README` and a test (cc @mfp). So, we can hope that this breakage in 4.0.0 won't be too bad.