### PR TITLE
attempt to move lwt.log into separate lwt_log

### DIFF
--- a/META.lwt
+++ b/META.lwt
@@ -16,7 +16,7 @@ plugin(native) = "lwt.cmxs"
 package "log" (
   #directory = "log"
   version = "dev"
-  description = "Logger for Lwt"
+  description = "Logger for Lwt (deprecated; use lwt_log)"
   requires = "bytes lwt result"
   archive(byte) = "lwt_log.cma"
   archive(native) = "lwt_log.cmxa"

--- a/META.lwt_log
+++ b/META.lwt_log
@@ -3,7 +3,7 @@
 # lwt.log.
 
 version = "dev"
-description = "Logger for lwt"
+description = "Logger for lwt (deprecated; use logs library)"
 requires = "lwt_log.unix"
 
 package "core" (

--- a/META.lwt_log
+++ b/META.lwt_log
@@ -4,4 +4,16 @@
 
 version = "dev"
 description = "Logger for lwt"
-requires = "lwt.log"
+requires = "lwt_log.unix"
+
+package "core" (
+  version = "dev"
+  description = "Logger for Lwt (pure-OCaml core)"
+  requires = "lwt.log"
+)
+
+package "unix" (
+  version = "dev"
+  description = "Logger for Lwt (Unix logging destinations)"
+  requires = "lwt.log lwt.unix"
+)

--- a/META.lwt_log
+++ b/META.lwt_log
@@ -1,0 +1,7 @@
+# The Lwt log will, in the future, be moved out to this package lwt_log. For
+# now, this package is a compatibility wrapper for the log's current location in
+# lwt.log.
+
+version = "dev"
+description = "Logger for lwt"
+requires = "lwt.log"

--- a/META.lwt_log
+++ b/META.lwt_log
@@ -4,16 +4,10 @@
 
 version = "dev"
 description = "Logger for lwt (deprecated; use logs library)"
-requires = "lwt_log.unix"
+requires = "lwt.log lwt.unix"
 
 package "core" (
   version = "dev"
   description = "Logger for Lwt (pure-OCaml core)"
   requires = "lwt.log"
-)
-
-package "unix" (
-  version = "dev"
-  description = "Logger for Lwt (Unix logging destinations)"
-  requires = "lwt.log lwt.unix"
 )

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,10 @@ install-for-packaging-test: clean
 	opam pin add --yes --no-action lwt_react .
 	opam pin add --yes --no-action lwt_ssl .
 	opam pin add --yes --no-action lwt_glib .
+	opam pin add --yes --no-action lwt_log .
 	opam pin add --yes --no-action lwt_camlp4 .
-	opam reinstall --yes lwt lwt_ppx lwt_react lwt_ssl lwt_glib lwt_camlp4
+	opam reinstall --yes \
+	  lwt lwt_ppx lwt_react lwt_ssl lwt_glib lwt_log lwt_camlp4
 
 .PHONY: clean
 clean:

--- a/lwt_log.opam
+++ b/lwt_log.opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_log"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL"
+
+depends: [
+  "jbuilder" {build}
+  # This will be constrained with an upper bound once the log is fully factored
+  # out of package lwt.
+  "lwt"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/lwt_log.opam
+++ b/lwt_log.opam
@@ -4,7 +4,8 @@ maintainer: [
   "Anton Bachin <antonbachin@yahoo.com>"
 ]
 authors: [
-  "Gabriel Radanne"
+  "Shawn Wagner"
+  "Jérémie Dimino"
 ]
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/api/Lwt_log"
@@ -14,8 +15,8 @@ license: "LGPL"
 
 depends: [
   "jbuilder" {build}
-  # This will be constrained with an upper bound once the log is fully factored
-  # out of package lwt.
+  # This will be constrained with an upper bound once the log library is fully
+  # factored out of package lwt.
   "lwt"
 ]
 

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -152,6 +152,7 @@ install_extra_package ppx
 install_extra_package react
 install_extra_package ssl
 install_extra_package glib
+install_extra_package log
 
 if [ "$HAVE_CAMLP4" != no ]
 then

--- a/test/packaging/jbuilder/log/Makefile
+++ b/test/packaging/jbuilder/log/Makefile
@@ -1,0 +1,8 @@
+.PHONY : test
+test : clean
+	jbuilder build user.exe --root .
+	_build/default/user.exe
+
+.PHONY : clean
+clean :
+	jbuilder clean --root .

--- a/test/packaging/jbuilder/log/jbuild
+++ b/test/packaging/jbuilder/log/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name user)
+  (libraries (lwt_log))))

--- a/test/packaging/jbuilder/log/user.ml
+++ b/test/packaging/jbuilder/log/user.ml
@@ -1,0 +1,2 @@
+let () =
+  Lwt_log.default |> ignore


### PR DESCRIPTION
this is a first attempt to move lwt.log into its own package, so for a 4.0 release it can really be split.  please let me know what you think.