### PR TITLE
Improve exception safety of some Lwt_list APIs

### DIFF
--- a/src/core/lwt_list.ml
+++ b/src/core/lwt_list.ml
@@ -41,11 +41,11 @@ let rec iter_s f l =
   | [] ->
     Lwt.return_unit
   | x :: l ->
-    f x >>= fun () ->
+    Lwt.apply f x >>= fun () ->
     iter_s f l
 
 let iter_p f l =
-  let ts = tail_recursive_map f l in
+  let ts = tail_recursive_map (Lwt.apply f) l in
   Lwt.join ts
 
 let rec iteri_s i f l =
@@ -66,7 +66,7 @@ let map_s f l =
   let rec inner acc = function
     | [] -> List.rev acc |> Lwt.return
     | hd::tl ->
-      f hd >>= fun r ->
+      Lwt.apply f hd >>= fun r ->
       (inner [@ocaml.tailcall]) (r::acc) tl
   in
   inner [] l
@@ -79,7 +79,7 @@ let rec _collect acc = function
     (_collect [@ocaml.tailcall]) (i::acc) ts
 
 let map_p f l =
-  let ts = tail_recursive_map f l in
+  let ts = tail_recursive_map (Lwt.apply f) l in
   _collect [] ts
 
 let rec filter_map_s f l =

--- a/test/core/jbuild
+++ b/test/core/jbuild
@@ -3,7 +3,8 @@
 (executable
  ((name main)
   (ocamlopt_flags (:standard (:include ../../src/core/flambda.flag)))
-  (libraries (lwttester))))
+  (libraries (lwttester))
+  (flags (:standard -w +A-40-42))))
 
 (alias
  ((name runtest)


### PR DESCRIPTION
Before the last commit in this PR, if `Lwt_list.iter_s`, `iter_p`, `map_s`, `map_p` raised an exception (immediately) after being applied to a list element, the exception could leak out of the list combinator (`iter_s`, etc). This seems like an incorrect behavior: the promise that the combinator ordinarily creates should still be created, but rejected with the exception instead.

Other functions in `Lwt_list` still have this problem, e.g. `iteri_s`. They should be fixed in follow-on PRs (I'll open an issue to review `Lwt_list` in detail). I fixed these four now mainly because they have tests, and those tests are affected by fixing #329, which is about the exception safety of `Lwt.bind` and many other Lwt core functions, among other things.