### PR TITLE
Lwt semantic improvements: exception safety and stack overflows

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1073,33 +1073,7 @@ sig
   val async_exception_hook : (exn -> unit) ref
 end =
 struct
-  (* Every now and then, Lwt enters the promise resolution loop. In this loop,
-     Lwt sets the state of one promise to [Fulfilled _] or [Rejected _], i.e.
-     resolves it. That triggers the running of its callbacks. The callbacks
-     might, in turn, resolve more promises, triggering more callbacks, and so
-     on. The process continues until Lwt runs out of promises that it can
-     immediately resolve, typically because all the remaining promises, whether
-     pre-existing or created during the loop, are blocked on I/O. So, the
-     resolution loop is started by resolving one promise, and then Lwt eagerly
-     resolves as many more promises as it can.
-
-     The loop is triggered by calling [Lwt.wakeup_later] and related functions.
-     Lwt maintains a queue of callbacks that need to be run.
-     [Lwt.wakeup_later p _] places the callbacks of [p] onto that queue. Lwt
-     then dequeues the callbacks and runs each one. As each one runs, if it
-     resolves more promises, those promises' callbacks are added to the queue
-     as well. Lwt eventually runs them, and so on.
-
-     Current Lwt is not quite as clean as suggested by the above description.
-     See [Lwt.wakeup], [Lwt.resolve], [Lwt.cancel], and [Lwt.bind] for notes on
-     deviations from this idealized procedure. Basically, all the deviations
-     involve running callbacks immediately on the current stack, instead of
-     deferring them by placing them into the queue. Maintainer's note: these are
-     probably mistakes, as they create the potential for stack overflow. See
-     discussion in:
-
-       https://github.com/ocsigen/lwt/issues/329
-
+  (*
      * Context
 
      The resolution loop handles only promises that can be resolved

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1073,10 +1073,76 @@ sig
   val async_exception_hook : (exn -> unit) ref
 end =
 struct
-  (*
+  (* When Lwt needs to call a callback, it enters the resolution loop. This
+     typically happens when Lwt sets the state of one promise to [Fulfilled _]
+     or [Rejected _]. The callbacks that were attached to the promise when it
+     was pending must then be called.
+
+     This also happens in a few other situations. For example, when [Lwt.bind]
+     is called on a promise, but that promise is already resolved, the callback
+     passed to [bind] must be called.
+
+     The callbacks triggered during the resolution loop might resolve more
+     promises, triggering more callbacks, and so on. This is what makes the
+     resolution loop a {e loop}.
+
+     Lwt generally tries to call each callback immediately. However, this can
+     lead to a progressive deepening of the call stack, until there is a stack
+     overflow. This can't be avoided by doing tail calls, because Lwt always
+     needs to do book-keeping after callbacks return. Instead, what Lwt does is
+     track the current callback call depth. Once that depth reaches a certain
+     number, [default_maximum_callback_nesting_depth], defined below, further
+     callbacks are deferred into a queue instead. That queue is drained when Lwt
+     exits from the top-most callback call that triggered the resolution loop in
+     the first place.
+
+     To ensure that this deferral mechanism is always properly invoked, all
+     callbacks called by Lwt are called through one of three functions provided
+     by this module:
+
+     - [resolve], which calls all the callbacks associated to a pending promise
+       (and resolves it, changing its state).
+     - [run_callbacks_or_defer_them], which is internally used by [resolve] to
+       call callbacks that are in a record of type ['a callbacks], which records
+       are associated with pending promises. This function is exposed because
+       the current implementation of [Lwt.cancel] needs to call it directly.
+       Promise resolution and callback calling are separated in a unique way in
+       [cancel].
+     - [run_callback_or_defer_it], which is used by [Lwt.bind] and similar
+       functions to call single callbacks when the promises passed to
+       [Lwt.bind], etc., are already resolved.
+
+     Current Lwt actually has a messy mix of callback-calling behaviors. For
+     example, [Lwt.bind] is expected to always call its callback immediately,
+     while [Lwt.wakeup_later] is expected to defer all callbacks of the promise
+     resolved, {e unless} Lwt is not already inside the resolution loop.
+
+     These behaviors will be made uniform in Lwt 4.0.0. However, in the
+     meantime, the above callback-invoking functions support several optional
+     arguments to emulate the behaviors:
+
+     - [~allow_deferring:false] allows ignoring the callback stack depth, and
+       calling the callbacks immediately. This emulates the old resolution
+       behavior.
+     - [~maximum_callback_nesting_depth:1] allows limiting the depth which
+       triggers deferral on a per-call-site basis. This is used by
+       [Lwt.wakeup_later].
+     - [~run_immediately_and_ensure_tail_call:true] is like
+       [~allow_deferring:false], which ignores the callback stack depth.
+       However, to ensure that the callback is tail-called, Lwt doesn't even
+       update the callback stack depth for the benefit of *other* callback
+       calls. It just blindly calls the callback.
+
+     It should be possible to eliminate these optional arguments in Lwt 4.0.0,
+     or restrict their usage to only deprecated APIs.
+
+     See discussion of callback-calling semantics in:
+
+       https://github.com/ocsigen/lwt/issues/329
+
      * Context
 
-     The resolution loop handles only promises that can be resolved
+     The resolution loop effectively handles all promises that can be resolved
      immediately, without blocking on I/O. A complete program that does I/O
      calls [Lwt_main.run]. See "No I/O" in the Overview. *)
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1213,7 +1213,7 @@ struct
 
 
 
-  let currently_in_resolution_loop = ref false
+  let current_callback_nesting_depth = ref 0
 
   type deferred_callbacks =
     Deferred : ('a callbacks * 'a resolved_state) -> deferred_callbacks
@@ -1226,30 +1226,28 @@ struct
      the callbacks that will be run will modify the storage. The storage is
      restored to the snapshot when the resolution loop is exited. *)
   let enter_resolution_loop () =
+    current_callback_nesting_depth := !current_callback_nesting_depth + 1;
     let storage_snapshot = !current_storage in
-    let top_level_entry = not !currently_in_resolution_loop in
-    currently_in_resolution_loop := true;
-    top_level_entry, storage_snapshot
+    storage_snapshot
 
   let leave_resolution_loop
       in_resolution_loop
-      (top_level_entry : bool)
       (storage_snapshot : storage) : unit =
 
-    if top_level_entry then begin
+    if !current_callback_nesting_depth = 1 then begin
       while not (Queue.is_empty deferred_callbacks) do
         let Deferred (callbacks, result) = Queue.pop deferred_callbacks in
         run_callbacks in_resolution_loop callbacks result
-      done;
-      currently_in_resolution_loop := false;
+      done
     end;
+    current_callback_nesting_depth := !current_callback_nesting_depth - 1;
     current_storage := storage_snapshot
 
   let run_in_resolution_loop (f : in_resolution_loop -> unit) : unit =
-    let top_level_entry, storage_snapshot = enter_resolution_loop () in
+    let storage_snapshot = enter_resolution_loop () in
     let in_resolution_loop : in_resolution_loop = Obj.magic () in
     f in_resolution_loop;
-    leave_resolution_loop in_resolution_loop top_level_entry storage_snapshot
+    leave_resolution_loop in_resolution_loop storage_snapshot
 
   (* This is basically a hack to fix https://github.com/ocsigen/lwt/issues/48.
      If currently resolving promises, it immediately exits all recursive
@@ -1258,9 +1256,9 @@ struct
 
      The name should probably be [abaondon_resolution_loop]. *)
   let abandon_wakeups () =
-    if !currently_in_resolution_loop then
+    if !current_callback_nesting_depth <> 0 then
       let in_resolution_loop : in_resolution_loop = Obj.magic () in
-      leave_resolution_loop in_resolution_loop true Storage_map.empty
+      leave_resolution_loop in_resolution_loop Storage_map.empty
 
 
 
@@ -1307,7 +1305,7 @@ struct
       let State_may_have_changed p = set_promise_state p result in
       ignore p;
       begin
-        if !currently_in_resolution_loop then
+        if !current_callback_nesting_depth <> 0 then
           Queue.push (Deferred (callbacks, result)) deferred_callbacks
         else
           run_in_resolution_loop (fun in_resolution_loop ->

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -556,7 +556,8 @@ struct
            Lwt_sequence.remove node))].
          This was probably done to avoid a closure allocation.
 
-     - The [cleanups_deferred] field is explained in module [Callbacks]. *)
+     - The [cleanups_deferred] field is explained in module
+       [Pending_callbacks]. *)
 end
 open Main_internal_types
 
@@ -842,7 +843,7 @@ include Sequence_associated_storage
 
 
 
-module Callbacks :
+module Pending_callbacks :
 sig
   (* Mutating callback lists attached to pending promises *)
   val add_implicitly_removed_callback :
@@ -1039,7 +1040,7 @@ struct
       | Cancel_callback_list_concat _ ->
         Cancel_callback_list_concat (node, callbacks.cancel_callbacks)
 end
-open Callbacks
+open Pending_callbacks
 
 
 
@@ -1214,11 +1215,11 @@ struct
 
   let currently_in_resolution_loop = ref false
 
-  type queued_callbacks =
-    Queued : ('a callbacks * 'a resolved_state) -> queued_callbacks
+  type deferred_callbacks =
+    Deferred : ('a callbacks * 'a resolved_state) -> deferred_callbacks
     [@@ocaml.unboxed]
 
-  let queued_callbacks : queued_callbacks Queue.t = Queue.create ()
+  let deferred_callbacks : deferred_callbacks Queue.t = Queue.create ()
 
   (* Before entering a resolution loop, it is necessary to take a snapshot of
      the current state of sequence-associated storage. This is because many of
@@ -1236,8 +1237,8 @@ struct
       (storage_snapshot : storage) : unit =
 
     if top_level_entry then begin
-      while not (Queue.is_empty queued_callbacks) do
-        let Queued (callbacks, result) = Queue.pop queued_callbacks in
+      while not (Queue.is_empty deferred_callbacks) do
+        let Deferred (callbacks, result) = Queue.pop deferred_callbacks in
         run_callbacks in_resolution_loop callbacks result
       done;
       currently_in_resolution_loop := false;
@@ -1307,7 +1308,7 @@ struct
       ignore p;
       begin
         if !currently_in_resolution_loop then
-          Queue.push (Queued (callbacks, result)) queued_callbacks
+          Queue.push (Deferred (callbacks, result)) deferred_callbacks
         else
           run_in_resolution_loop (fun in_resolution_loop ->
             run_callbacks in_resolution_loop callbacks result)

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1056,6 +1056,12 @@ sig
     'a resolved_state ->
       unit
 
+  val run_callback_or_defer_it :
+    ?run_immediately_and_ensure_tail_call:bool ->
+    callback:(unit -> 'a) ->
+    if_deferred:(unit -> 'a * 'b regular_callback * 'b resolved_state) ->
+      'a
+
   val handle_with_async_exception_hook : ('a -> unit) -> 'a -> unit
 
   (* Internal interface exposed to other modules in Lwt *)
@@ -1206,10 +1212,11 @@ struct
     current_callback_nesting_depth := !current_callback_nesting_depth - 1;
     current_storage := storage_snapshot
 
-  let run_in_resolution_loop f : unit =
+  let run_in_resolution_loop f =
     let storage_snapshot = enter_resolution_loop () in
-    f ();
-    leave_resolution_loop storage_snapshot
+    let result = f () in
+    leave_resolution_loop storage_snapshot;
+    result
 
   (* This is basically a hack to fix https://github.com/ocsigen/lwt/issues/48.
      If currently resolving promises, it immediately exits all recursive
@@ -1247,6 +1254,41 @@ struct
       ?allow_deferring ?maximum_callback_nesting_depth callbacks result;
 
     p
+
+  let run_callback_or_defer_it
+      ?(run_immediately_and_ensure_tail_call = false)
+      ~callback:f
+      ~if_deferred =
+
+    if run_immediately_and_ensure_tail_call then
+      f ()
+
+    else
+      let should_defer =
+        !current_callback_nesting_depth
+          >= default_maximum_callback_nesting_depth
+      in
+
+      if should_defer then begin
+        let immediate_result, deferred_callback, deferred_result =
+          if_deferred () in
+        let deferred_record =
+          {
+            regular_callbacks =
+              Regular_callback_list_implicitly_removed_callback
+                deferred_callback;
+            cancel_callbacks = Cancel_callback_list_empty;
+            how_to_cancel = Not_cancelable;
+            cleanups_deferred = 0
+          }
+        in
+        Queue.push
+          (Deferred (deferred_record, deferred_result)) deferred_callbacks;
+        immediate_result
+      end
+      else
+        run_in_resolution_loop (fun () ->
+          f ())
 end
 include Resolution_loop
 
@@ -1723,13 +1765,28 @@ struct
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled v ->
-      f v   (* See https://github.com/ocsigen/lwt/issues/329. *)
-    | Rejected _ as result ->
-      to_public_promise {state = result}
+    (* In case [Lwt.bind] needs to defer the call to [f], this function will be
+       called to create:
 
-    | Pending p_callbacks ->
+       1. The promise, [p''], that must be returned to the caller immediately.
+       2. The callback that resolves [p''].
+
+       [Lwt.bind] defers the call to [f] in two circumstances:
+
+       1. The promise [p] is pending.
+       2. The promise [p] is fulfilled, but the current callback call nesting
+          depth is such that the call to [f] must go into the callback queue, in
+          order to avoid stack overflow.
+
+      Mechanism (2) is currently disabled, to emulate pre-3.2.0 Lwt semantics.
+      It will be enabled in Lwt 4.0.0.
+
+      Functions other than [Lwt.bind] have analogous deferral behavior. For
+      example, in Lwt 4.0.0, [Lwt.catch] will defer the call to its callback [h]
+      if either the promise [f ()] is pending, or if that promise is rejected,
+      but the callback nesting depth is too high to safely call [h]
+      immediately. *)
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
       (* The result promise is a fresh pending promise.
 
@@ -1772,21 +1829,33 @@ struct
             resolve ~allow_deferring:false p'' p_result in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> f v)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Rejected _ as result ->
+      to_public_promise {state = result}
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let backtrace_bind add_loc p f =
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled v ->
-      f v
-    | Rejected exn ->
-      to_public_promise {state = Rejected (add_loc exn)}
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -1811,21 +1880,33 @@ struct
             resolve ~allow_deferring:false p'' (Rejected (add_loc exn)) in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> f v)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Rejected exn ->
+      to_public_promise {state = Rejected (add_loc exn)}
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let map f p =
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled v ->
-      to_public_promise {state = try Fulfilled (f v) with exn -> Rejected exn}
-    | Rejected _ as result ->
-      to_public_promise {state = result}
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -1848,22 +1929,36 @@ struct
             resolve ~allow_deferring:false p'' p_result in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () ->
+          to_public_promise
+            {state = try Fulfilled (f v) with exn -> Rejected exn})
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Rejected _ as result ->
+      to_public_promise {state = result}
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let catch f h =
     let p = try f () with exn -> fail exn in
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled _ ->
-      to_public_promise p
-    | Rejected exn ->
-      h exn
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -1888,22 +1983,34 @@ struct
             make_into_proxy ~outer_promise:p'' ~user_provided_promise:p' in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled _ ->
+      to_public_promise p
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> h exn)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let backtrace_catch add_loc f h =
     let p = try f () with exn -> fail exn in
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled _ ->
-      to_public_promise p
-    | Rejected exn ->
-      h (add_loc exn)
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -1928,22 +2035,34 @@ struct
             make_into_proxy ~outer_promise:p'' ~user_provided_promise:p' in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled _ ->
+      to_public_promise p
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> h (add_loc exn))
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let try_bind f f' h =
     let p = try f () with exn -> fail exn in
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled v ->
-      f' v
-    | Rejected exn ->
-      h exn
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -1973,22 +2092,40 @@ struct
             make_into_proxy ~outer_promise:p'' ~user_provided_promise:p' in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> f' v)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> h exn)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let backtrace_try_bind add_loc f f' h =
     let p = try f () with exn -> fail exn in
     let Internal p = to_internal_promise p in
     let p = underlying p in
 
-    match p.state with
-    | Fulfilled v ->
-      f' v
-    | Rejected exn ->
-      h (add_loc exn)
-
-    | Pending p_callbacks ->
+    let create_result_promise_and_callback_if_deferred () =
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
@@ -2018,9 +2155,33 @@ struct
             make_into_proxy ~outer_promise:p'' ~user_provided_promise:p' in
           ignore p''
       in
-      add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p''
+      (to_public_promise p'', callback)
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> f' v)
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> h (add_loc exn))
+        ~if_deferred:(fun () ->
+          let (p'', callback) =
+            create_result_promise_and_callback_if_deferred () in
+          (p'', callback, p.state))
+
+    | Pending p_callbacks ->
+      let (p'', callback) = create_result_promise_and_callback_if_deferred () in
+      add_implicitly_removed_callback p_callbacks callback;
+      p''
 
   let finalize f f' =
     try_bind f
@@ -2036,97 +2197,163 @@ struct
 
   let on_cancel p f =
     let Internal p = to_internal_promise p in
-    match (underlying p).state with
-    | Rejected Canceled -> handle_with_async_exception_hook f ()
-    | Rejected _ -> ()
-    | Fulfilled _ -> ()
-    | Pending callbacks -> add_cancel_callback callbacks f
+    let p = underlying p in
+
+    match p.state with
+    | Rejected Canceled ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f ())
+        ~if_deferred:(fun () ->
+          ((), (fun _ -> handle_with_async_exception_hook f ()), Fulfilled ()))
+
+    | Rejected _ ->
+      ()
+
+    | Fulfilled _ ->
+      ()
+
+    | Pending callbacks ->
+      add_cancel_callback callbacks f
 
 
 
   let on_success p f =
     let Internal p = to_internal_promise p in
+    let p = underlying p in
 
-    match (underlying p).state with
-    | Fulfilled v ->
-      handle_with_async_exception_hook f v
-    | Rejected _ ->
-      ()
-
-    | Pending p_callbacks ->
+    let callback_if_deferred () =
       let saved_storage = !current_storage in
 
-      let callback result =
+      fun result ->
         match result with
         | Fulfilled v ->
           current_storage := saved_storage;
           handle_with_async_exception_hook f v
+
         | Rejected _ ->
           ()
-      in
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f v)
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Rejected _ ->
+      ()
+
+    | Pending p_callbacks ->
+      let callback = callback_if_deferred () in
       add_implicitly_removed_callback p_callbacks callback
 
   let on_failure p f =
     let Internal p = to_internal_promise p in
+    let p = underlying p in
 
-    match (underlying p).state with
-    | Fulfilled _ ->
-      ()
-    | Rejected exn ->
-      handle_with_async_exception_hook f exn
-
-    | Pending p_callbacks ->
+    let callback_if_deferred () =
       let saved_storage = !current_storage in
 
-      let callback result =
+      fun result ->
         match result with
         | Fulfilled _ ->
           ()
+
         | Rejected exn ->
           current_storage := saved_storage;
           handle_with_async_exception_hook f exn
-      in
+    in
+
+    match p.state with
+    | Fulfilled _ ->
+      ()
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f exn)
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Pending p_callbacks ->
+      let callback = callback_if_deferred () in
       add_implicitly_removed_callback p_callbacks callback
 
   let on_termination p f =
     let Internal p = to_internal_promise p in
+    let p = underlying p in
 
-    match (underlying p).state with
-    | Fulfilled _ ->
-      handle_with_async_exception_hook f ()
-    | Rejected _ ->
-      handle_with_async_exception_hook f ()
-
-    | Pending p_callbacks ->
+    let callback_if_deferred () =
       let saved_storage = !current_storage in
 
-      let callback _result =
+      fun _result ->
         current_storage := saved_storage;
         handle_with_async_exception_hook f ()
-      in
+    in
+
+    match p.state with
+    | Fulfilled _ ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f ())
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Rejected _ ->
+      run_callback_or_defer_it
+      ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f ())
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Pending p_callbacks ->
+      let callback = callback_if_deferred () in
       add_implicitly_removed_callback p_callbacks callback
 
   let on_any p f g =
     let Internal p = to_internal_promise p in
+    let p = underlying p in
 
-    match (underlying p).state with
-    | Fulfilled v ->
-      handle_with_async_exception_hook f v
-    | Rejected exn ->
-      handle_with_async_exception_hook g exn
-
-    | Pending p_callbacks ->
+    let callback_if_deferred () =
       let saved_storage = !current_storage in
 
-      let callback result =
+      fun result ->
         match result with
         | Fulfilled v ->
           current_storage := saved_storage;
           handle_with_async_exception_hook f v
+
         | Rejected exn ->
           current_storage := saved_storage;
           handle_with_async_exception_hook g exn
-      in
+    in
+
+    match p.state with
+    | Fulfilled v ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook f v)
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Rejected exn ->
+      run_callback_or_defer_it
+        ~run_immediately_and_ensure_tail_call:true
+        ~callback:(fun () -> handle_with_async_exception_hook g exn)
+        ~if_deferred:(fun () ->
+          let callback = callback_if_deferred () in
+          ((), callback, p.state))
+
+    | Pending p_callbacks ->
+      let callback = callback_if_deferred () in
       add_implicitly_removed_callback p_callbacks callback
 end
 include Sequential_composition

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1037,6 +1037,10 @@ open Pending_callbacks
 
 module Resolution_loop :
 sig
+  (* All user-provided callbacks are called by Lwt only through this module. It
+     tracks the current callback stack depth, and decides whether each callback
+     call should be deferred or not. *)
+
   (* Internal interface used only in this module Lwt *)
   val resolve :
     ?allow_deferring:bool ->
@@ -1045,23 +1049,20 @@ sig
     'a resolved_state ->
       ('a, underlying, resolved) state_changed
 
+  val run_callbacks_or_defer_them :
+    ?allow_deferring:bool ->
+    ?maximum_callback_nesting_depth:int ->
+    ('a callbacks) ->
+    'a resolved_state ->
+      unit
+
   val handle_with_async_exception_hook : ('a -> unit) -> 'a -> unit
 
   (* Internal interface exposed to other modules in Lwt *)
   val abandon_wakeups : unit -> unit
 
   (* Public interface *)
-  val wakeup_later_result : 'a u -> 'a lwt_result -> unit
-  val wakeup_later : 'a u -> 'a -> unit
-  val wakeup_later_exn : _ u -> exn -> unit
-
-  val wakeup_result : 'a u -> 'a lwt_result -> unit
-  val wakeup : 'a u -> 'a -> unit
-  val wakeup_exn : _ u -> exn -> unit
-
   exception Canceled
-
-  val cancel : 'a t -> unit
 
   val async_exception_hook : (exn -> unit) ref
 end =
@@ -1246,9 +1247,24 @@ struct
       ?allow_deferring ?maximum_callback_nesting_depth callbacks result;
 
     p
+end
+include Resolution_loop
 
 
 
+module Resolving :
+sig
+  val wakeup_later_result : 'a u -> 'a lwt_result -> unit
+  val wakeup_later : 'a u -> 'a -> unit
+  val wakeup_later_exn : _ u -> exn -> unit
+
+  val wakeup_result : 'a u -> 'a lwt_result -> unit
+  val wakeup : 'a u -> 'a -> unit
+  val wakeup_exn : _ u -> exn -> unit
+
+  val cancel : 'a t -> unit
+end =
+struct
   (* Note that this function deviates from the "ideal" callback deferral
      behavior: it runs callbacks directly on the current stack. It should
      therefore be possible to cause a stack overflow using this function. *)
@@ -1360,7 +1376,7 @@ struct
       run_callbacks_or_defer_them
         ~allow_deferring:false callbacks canceled_result)
 end
-include Resolution_loop
+include Resolving
 
 
 


### PR DESCRIPTION
This PR improves the stack- and exception-safety of most functions in Lwt: `bind`, `catch`, `try_bind`, `finalize`, `join`, `choose`, `pick`, `nchoose`, `npick`, `nchoose_split`, `cancel`, `protected`, `no_cancel`, `on_cancel`, `on_success`, `on_failure`, `on_any`, and `on_termination`.

To present, the text describes:

- the two problems, stack- and exception-safety,
- the solution in this PR (to both of them),
- what is actually implemented in this PR, and a soft upgrade path for users,
- some miscellaneous thoughts.

<br/>

## Problem 1: `Lwt.bind` and similar functions leak exceptions

This program raises an exception:

```ocaml
let () =
  Lwt.bind Lwt.return_unit (fun () -> raise Exit) |> ignore
```

The behavior one would expect from `Lwt.bind` here is that the exception be stored in the promise `Lwt.bind` creates, i.e. the promise is created and rejected. Indeed, that is what happens with `map`:

```ocaml
let () =
  let p = Lwt.map (fun () -> raise Exit) Lwt.return_unit in
  assert (Lwt.state p = Lwt.Fail Exit)
```

Much more disturbingly, that is what happens in `Lwt.bind` if the promise it is called on started out *pending* instead of resolved:

```ocaml
let () =
  let (p, r) = Lwt.wait () in
  let p' = Lwt.bind p (fun () -> raise Exit) in
  Lwt.wakeup r ();
  assert (Lwt.state p' = Lwt.Fail Exit)
```

...which suggests that merely refactoring some code, or a different execution trace, could alter which way exceptions go from a callback of `bind`: forward into a promise, or back up the stack. That seems like a needless source of anxiety.

This was originally reported in #329. Besides `bind`, analogous problems also affect `catch`, `try_bind`, `finalize`, and their `backtrace_*` variants, which are used internally by the PPX.

The reason for this problem is that if `p` is already resolved, `Lwt.bind p f` calls `f` immediately, as a performance optimization. However, since `bind` might be called in a loop, the call to `f` is implemented as a tail call: otherwise, a loop that does a few hundred thousand `bind`s will overflow the stack. This means that it is not possible for `bind` to wrap an exception handler around the call to `f`.

<br/>

## Problem 2: Lwt can resolve an unbounded number of promises in one go

...and since each promise resolution deepens the stack, this can trigger a stack overflow.

I didn't originally set out to fix this problem, but fixing it is a side effect of fixing problem 1.

Basically, if one promise triggers the resolution of another, and so on, for long enough, the result is a crash. Here is a contrived example using only `Lwt.join`, but actually this can be triggered using *any* sufficiently large combination of the functions listed at the beginning of this PR:

```ocaml
let rec make_huge_promise_chain n last_promise =
  if n = 0 then
    last_promise
  else
    make_huge_promise_chain (n - 1) (Lwt.join [last_promise])
in
let (p, r) = Lwt.wait () in
make_huge_promise_chain 1_000_000 p |> ignore;

Lwt.wakeup r ()
```

<br/>

## How the problems are solved by this PR

The observation is that Lwt actually never can do tail calls: all the places where Lwt does tail calls before this PR, are places where Lwt sacrifices correct exception semantics.

So, this PR abandons tail calls completely. As a result, the callbacks called by `Lwt.bind`, etc., can now be wrapped in exception handlers for correct exception semantics. Without doing anything else, this introduces unbounded stack growth in loops of `Lwt.bind`.

To avoid this stack growth due to `Lwt.bind`, and eveywhere else, the PR [introduces a disciplined callback deferral mechanism](https://github.com/ocsigen/lwt/blob/d798a45342947f3c942d8f643f5502103e649547/src/core/lwt.ml#L1038-L1063). Lwt now [tracks](https://github.com/ocsigen/lwt/blob/d798a45342947f3c942d8f643f5502103e649547/src/core/lwt.ml#L1252-L1254) how many callback calls it has nested inside each other. There is a limit of 42 such nested callback calls. When Lwt needs to call a callback, if the depth is less than 42, it increments the depth and calls the callback immediately. Otherwise, if the depth is 42 or more, Lwt defers the callback call into a [queue](https://github.com/ocsigen/lwt/blob/d798a45342947f3c942d8f643f5502103e649547/src/core/lwt.ml#L1256-L1260), which is drained later, when the depth is about to reach zero again.

So, instead of immediate callback calls, Lwt now has hybrid immeidate/deferred callback calls.

I don't expect this change to affect most code that uses Lwt. However, it can still be dangerous for some programs, so this PR takes a somewhat gentle approach. The code here introduces a [generalized mechanism](https://github.com/ocsigen/lwt/blob/d798a45342947f3c942d8f643f5502103e649547/src/core/lwt.ml#L1099-L1137), that is capable of both the broken and the patched behavior, and choosing between the two is a matter of [changing a few lines of code](https://github.com/ocsigen/lwt/compare/disciplined-callbacks...safer-semantics#diff-94d283dcf718f431e5e0c2fc228c84bc). The code is currently used to emulate the broken behavior. There is a separate branch, [`safer-semantics`](https://github.com/ocsigen/lwt/commit/64523e1dda5f615a5804ce9310a1861a4633e863), which adds one commit over this PR, and has the patched behavior. I suggest releasing this PR in 3.2.0 with the broken behavior, announcing the patched branch so that users can test against it, and then applying the final patch in Lwt 4.0.0.

The [changes to the test suite in `safer-semantics`](https://github.com/ocsigen/lwt/compare/disciplined-callbacks...safer-semantics#diff-1efdc224c85ad2db494deaa909f84fee) suggest some of the improvements that will be made in 4.0.0.

Note that `safer-semantics` needs PR #499, in order to be able to fully pass the Lwt test suite, because fixing `Lwt.bind` turns out to be one way to (accidentally) fix some bugs in `Lwt_list`. The `Lwt_list` test suite without #499 expects incorrect `Lwt_list` behavior.

<br/>

## Effect on performance

These are timings of an `Lwt.bind` loop on my machine:

- 8ns per `bind` for current (broken) Lwt.
- 16ns per `bind` for this PR, when emulating broken behavior (as I suggest to release in 3.2.0).
- 50ns per `bind` with the patched behavior (4.0.0, with a deferral every 42 binds).

All the measurements were done with Flambda disabled, as it seems Flambda is being reworked right now.

The 16ns can be decreased somewhat. For example, avoiding capture in some new closures in `bind` reduced it to 13ns. It should be possible to restore something close to 8ns, but I wanted to stick with idiomatic and relatively concise code for now, and not get into premature optimization. I suspect the 50ns can also be improved in this way, though probably to a lesser degree.

I chose 42 for the maximum number of immediate callback calls based on a few measurements:

```
nesting    time per
 limit       bind

  1         144ns
  8          66ns
 16          53ns
 42          50ns
420          50ns
```

It seems that 42 is close to where the cost of deferral is amortized enough to become insignificant.

<br/>

## Miscellaneous

Calling callbacks immediately is a kind of LIFO callback-calling strategy, while deferral, as implemented, is FIFO, and the hybrid behavior in this PR is just unpredictable. Lwt does not promise any callback-calling order in its API, but I am worried about surprising effects and starvation. We could set the nesting limit to 1, to get JS-like always-defer FIFO behavior, except maybe on the first callback call.

Since Lwt now has a centralized mechanism for deferring callbacks, or deciding where in the queue they will go, it should be fairly easy to randomize behavior for testing. cc @stedolan, @yomimono.

@domsj, @copy, @smondet, if you have time at all, would you be willing to run this branch `disciplined-callbacks`, and the patched branch `safer-semantics` through your stress tests? It could be very helpful :)

cc also @mfp, @rgrinberg, @hcarty, @mfp, @c-cube based on past interest in this topic, overheard(seen) discussions on IRC, etc. :)
