### PR TITLE
lwt_unix_free_job if getnameinfo was successfull

### DIFF
--- a/src/unix/lwt_unix_unix.h
+++ b/src/unix/lwt_unix_unix.h
@@ -2971,6 +2971,7 @@ static value result_getnameinfo(struct job_getnameinfo *job)
         vres = caml_alloc_small(2, 0);
         Field(vres, 0) = vhost;
         Field(vres, 1) = vserv;
+        lwt_unix_free_job(&job->job);
         CAMLreturn(vres);
     }
 }


### PR DESCRIPTION
tentative fix for #502 
I checked all the `result_*` in `lwt_unix_unix.h`, and this was the only one I could spot which missed the `lwt_unix_free_job` in one branch.