### PR TITLE
Issue 452: Add a test for the interaction of Lwt.finalize and Lwt.cancel.

### DIFF
--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2838,6 +2838,17 @@ let cancel_finalize_tests = suite "cancel finalize" [
        Lwt.state p' = Lwt.Fail Lwt.Canceled)
   end;
 
+  test "task, canceled, cancel exception replaced" begin fun () ->
+    let p, _ = Lwt.task () in
+    let p' =
+      Lwt.finalize
+        (fun () -> p)
+        (fun () -> Lwt.fail Exception)
+    in
+    Lwt.cancel p;
+    Lwt.return (Lwt.state p' = Lwt.Fail Exception)
+  end;
+
   test "pending, wait, canceled" begin fun () ->
     let p1, r = Lwt.wait () in
     let p2, _ = Lwt.wait () in


### PR DESCRIPTION
This change addresses #452 by introducing a test verifying the following property:

When running `Lwt.finalize f g`, if `f` is terminated by `Lwt.cancel` (a particular type of exception), and running `g` produces a second exception `e`, then the return value of `Lwt.finalize f g ` is `e`.