### PR TITLE
[4.0.0] Complete factoring out the PPX

### DIFF
--- a/META.lwt
+++ b/META.lwt
@@ -24,30 +24,6 @@ package "log" (
   exists_if = "lwt_log.cma"
 )
 
-package "ppx" (
-  #directory = "ppx"
-  version = "dev"
-  description = "Lwt PPX syntax extension (deprecated; use lwt_ppx)"
-  requires(ppx_driver) = "lwt.omp"
-  requires(-ppx_driver) = "bytes lwt result"
-  ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
-)
-
-package "omp" (
-  version = "dev"
-  description = "Lwt ocaml-migrate-parsetree PPX (internal)"
-  requires = "compiler-libs
-              compiler-libs.common
-              ocaml-migrate-parsetree
-              ppx_tools_versioned"
-  ppx_runtime_deps = "bytes lwt result"
-  exists_if = "ppx_lwt.cma"
-  archive(byte) = "ppx_lwt.cma"
-  archive(native) = "ppx_lwt.cmxa"
-  plugin(byte) = "ppx_lwt.cma"
-  plugin(native) = "ppx_lwt.cmxs"
-)
-
 package "preemptive" (
   #directory = "preemptive"
   version = "dev"

--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,12 @@ default: build
 # build the usual development packages
 .PHONY: build
 build: check-config
-	jbuilder build --dev --only-packages lwt
-
-# build everything, including additional packages
-.PHONY: build-all
-build-all: check-config
-	jbuilder build --dev --only-packages lwt,lwt_react
+	jbuilder build --dev
 
 # run unit tests for package lwt
 .PHONY: test
 test: build
-	jbuilder runtest --dev --only-packages lwt -j 1 --no-buffer
-
-# run all unit tests
-.PHONY: test-all
-test-all: check-config
-	jbuilder runtest --dev --only-packages lwt,lwt_react
+	jbuilder runtest --dev -j 1 --no-buffer
 
 # configuration
 .PHONY: check-config
@@ -36,6 +26,19 @@ check-config:
 .PHONY: default-config
 default-config:
 	ocaml src/util/configure.ml -use-libev false
+
+# Install dependencies needed during development.
+.PHONY : dev-deps
+dev-deps :
+	opam install --yes --unset-root \
+	  bisect_ppx \
+	  cppo \
+	  jbuilder \
+	  ocaml-migrate-parsetree \
+	  ocamlfind \
+	  ppx_tools_versioned \
+	  react \
+	  result \
 
 # Use jbuilder/odoc to generate static html documentation.
 # Currenty requires ocaml 4.03.0 to install odoc.
@@ -105,7 +108,7 @@ BISECT_FILES_PATTERN := _build/default/test/*/bisect*.out
 
 .PHONY: coverage
 coverage: clean check-config
-	BISECT_ENABLE=yes jbuilder runtest --dev --only-packages lwt,lwt_react
+	BISECT_ENABLE=yes jbuilder runtest --dev -j 1 --no-buffer
 	bisect-ppx-report \
 	    -I _build/default/ -html _coverage/ \
 	    -text - -summary-only \

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -72,15 +72,13 @@ git clone https://github.com/your-user-name/lwt.git
 cd lwt/
 ```
 
-We'll use Lwt's own [`opam`][opam-depends] file to install Lwt's dependencies
-automatically. Before doing that, you may want to switch to a special OPAM
-switch just for Lwt:
+Now, we need to install Lwt's development dependencies. Before doing that, you
+may want to switch to a special OPAM switch for working on Lwt:
 
 ```
-opam switch 4.04.02-lwt --alias-of 4.04.2   # optional
-eval `opam config env`                      # optional
-opam pin add --no-action lwt .
-opam install --deps-only lwt
+opam switch 4.06.1-lwt --alias-of 4.06.1   # optional
+eval `opam config env`                     # optional
+make dev-deps
 ```
 
 [opam-depends]: https://github.com/ocsigen/lwt/blob/8bff603ae6d976e69698fa08e8ce08fe9615489d/opam/opam#L35-L44
@@ -113,6 +111,7 @@ If you want to test your development branch using another OPAM package that
 depends on Lwt, install your development copy of Lwt with:
 
 ```
+opam pin add lwt .
 opam install lwt
 ```
 
@@ -129,14 +128,7 @@ modified code when you run these commands.
 <a id="Testing_with_coverage_analysis"></a>
 #### Testing with coverage analysis
 
-Coverage analysis is only enabled for `src/core/*` for now. To generate coverage
-reports, first pin Bisect_ppx to its development version:
-
-```
-opam pin add --dev-repo bisect_ppx
-```
-
-Then run
+To generate coverage reports, run
 
 ```
 make coverage
@@ -208,19 +200,6 @@ Afterwards, `git push -f` will force the new history into the PR.
 If we do this rewriting, it is usually at the very end, right before merging the
 PR. This is to avoid interfering with reviewers while they are still reviewing
 it.
-
-<a id="Cleaning_up"></a>
-#### Cleaning up
-
-If you don't want a development Lwt installed in your OPAM switch anymore, you
-can do
-
-```
-opam pin remove lwt
-```
-
-However, if you need your change for your purposes, you may want to keep your
-development copy pinned until the next Lwt release.
 
 [travis-ci]: https://travis-ci.org/ocsigen/lwt
 [appveyor-ci]: https://ci.appveyor.com/project/aantron/lwt

--- a/lwt.opam
+++ b/lwt.opam
@@ -37,8 +37,6 @@ depends: [
   # dependency should be converted to a conflict, and package jbuilder should be
   # constrained such that it also includes the error lines fix.
   "ocamlfind" {build & >= "1.7.3-1"}
-  "ocaml-migrate-parsetree"
-  "ppx_tools_versioned" {>= "5.0.1"}
   # result is needed as long as Lwt still supports OCaml 4.02.
   "result"
 ]

--- a/src/ppx/jbuild
+++ b/src/ppx/jbuild
@@ -2,19 +2,6 @@
 
 (library
  ((name ppx_lwt)
-  (public_name lwt.ppx)
-  (synopsis "Lwt PPX syntax extension")
-  (modules (ppx_lwt))
-  (libraries (compiler-libs.common
-              ocaml-migrate-parsetree
-              ppx_tools_versioned))
-  (ppx_runtime_libraries (lwt))
-  (kind ppx_rewriter)
-  (preprocess (pps (ppx_tools_versioned.metaquot_404)))
-  (flags (:standard -w +A-4))))
-
-(library
- ((name ppx_lwt)
   (public_name lwt_ppx)
   (synopsis "Lwt PPX syntax extension")
   (modules (ppx_lwt))

--- a/src/util/appveyor-build.sh
+++ b/src/util/appveyor-build.sh
@@ -1,7 +1,5 @@
 set -e
 set -x
 
-# install packages and run tests
-opam install -y -t --verbose lwt lwt_react
-
-! opam list -i batteries
+make build
+make test

--- a/src/util/appveyor-install.sh
+++ b/src/util/appveyor-install.sh
@@ -9,29 +9,17 @@ DIRECTORY=$(pwd)
 # To get around that, create a tar archive of .opam.
 CACHE=$DIRECTORY/../opam-cache-$SYSTEM-$COMPILER-$LIBEV.tar
 
-pin_extra_package () {
-    PACKAGE=$1
-    opam pin add -y --no-action lwt_$PACKAGE .
-}
-
 if [ ! -f $CACHE ]
 then
     opam init -y --auto-setup
     eval `opam config env`
 
     # Pin Lwt and install its dependencies.
-    opam pin add -y --no-action lwt .
-    opam install -y --deps-only lwt
+    make dev-deps
     if [ "$LIBEV" = yes ]
     then
         opam install -y conf-libev
     fi
-
-    # Generate build systems of extra packages and pin them.
-    pin_extra_package react
-
-    # For the tests, obviously...
-    opam install -y ounit
 
     ( cd ~ ; tar cf $CACHE .opam )
 else

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -119,37 +119,17 @@ fi
 
 
 
-# Pin Lwt, install dependencies, and then install Lwt. Lwt is installed
-# separately because we want to keep the build directory for running the tests.
-opam pin add -y --no-action lwt .
-
-opam install -y --deps-only lwt
+# Install Lwt's development dependencies.
+make dev-deps
 
 if [ "$LIBEV" != no ]
 then
     opam install -y conf-libev
 fi
 
-opam install --keep-build-dir --verbose lwt
 
-# Pin additional packages and install them. There
-# aren't any specific tests for these packages. Installation itself is the only
-# test.
-install_extra_package () {
-    PACKAGE=$1
-    opam pin add -y --no-action lwt_$PACKAGE .
-    opam install -y --verbose lwt_$PACKAGE
-}
-
-install_extra_package ppx
-install_extra_package react
-install_extra_package log
 
 # Build and run the tests.
-opam install -y ounit
-cd `opam config var lib`/../build/lwt.*
-make clean
-
 if [ "$LIBEV" != no ]
 then
     LIBEV_FLAG=true
@@ -158,18 +138,21 @@ else
 fi
 
 ocaml src/util/configure.ml -use-libev $LIBEV_FLAG
-make build-all test-all
+make build
+make test
 make coverage
 
 
 
 # Run the packaging tests.
+make clean
+make install-for-packaging-test
 make packaging-test
 
 
 
 # Some sanity checks.
-if [ "$LIBEV" != yes ]
+if [ "$LIBEV" == no ]
 then
     ! opam list -i conf-libev
 fi

--- a/test/ppx/jbuild
+++ b/test/ppx/jbuild
@@ -3,7 +3,7 @@
 (executable
  ((name main)
   (libraries (lwttester))
-  (preprocess (pps (lwt.ppx)))
+  (preprocess (pps (lwt_ppx)))
   (flags (:standard -warn-error -22))
 ))
 

--- a/test/ppx_expect/jbuild
+++ b/test/ppx_expect/jbuild
@@ -3,7 +3,7 @@
 (executable
  ((name main)
   (libraries (lwttester))
-  (preprocess (pps (lwt.ppx)))))
+  (preprocess (pps (lwt_ppx)))))
 
 ; (alias
 ;  ((name runtest)


### PR DESCRIPTION
The PPX was already fully packaged as `lwt_ppx`. This commit deletes package `lwt.ppx`.

Resolves #338.

I'll fix the CI builds later, as the CI needs a general cleanup anyway.