### PR TITLE
[4.0.0] Finish factoring out Camlp4 syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _build
 src/unix/lwt_config
-src/jbuild-ignore
 *.flag
 
 # OPAM 2.0 local switches.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-config:
 
 .PHONY: default-config
 default-config:
-	ocaml src/util/configure.ml -use-libev false -use-camlp4 false
+	ocaml src/util/configure.ml -use-libev false
 
 # Use jbuilder/odoc to generate static html documentation.
 # Currenty requires ocaml 4.03.0 to install odoc.
@@ -87,8 +87,7 @@ install-for-packaging-test: clean
 	opam pin add --yes --no-action lwt_ppx .
 	opam pin add --yes --no-action lwt_react .
 	opam pin add --yes --no-action lwt_log .
-	opam pin add --yes --no-action lwt_camlp4 .
-	opam reinstall --yes lwt lwt_ppx lwt_react lwt_log lwt_camlp4
+	opam reinstall --yes lwt lwt_ppx lwt_react lwt_log
 
 .PHONY: clean
 clean:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,6 @@ install:
   - 'IF "%LIBEV%"=="yes" (%CYGSETUP% -q -P libev-devel)'
 
   - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/$env:ARCH/ocaml/$env:COMPILER/install.ps1") | PowerShell -Command -'
-  - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/$env:ARCH/camlp4/$env:COMPILER/install.ps1") | PowerShell -Command -'
   - ps: '(new-object net.webclient).DownloadString("https://aantron.github.io/binaries/$env:SYSTEM/$env:ARCH/opam/1.2/install.ps1") | PowerShell -Command -'
 
   - '%CYGSH% "cd /cygdrive/c/projects/lwt ; src/util/appveyor-install.sh"'

--- a/doc/apiref-intro
+++ b/doc/apiref-intro
@@ -95,9 +95,9 @@ Lwt_preemptive
 These extensions are deprecated. Use {!Ppx_lwt} instead.
 
 Lwt is shipped with two Camlp4 syntax extensions. The first one, contained in
-the {e lwt.syntax} package, aims to make coding with Lwt easier, and
+the {e lwt_camlp4} package, aims to make coding with Lwt easier, and
 to make code more readable. The second, contained in the package {e
-lwt.syntax.log}, is a Camlp4 filter which decreases the performance
+lwt_camlp4.log}, is a Camlp4 filter which decreases the performance
 penalty when using logging by inlining level tests.
 
 {!modules:

--- a/lwt.opam
+++ b/lwt.opam
@@ -16,8 +16,7 @@ license: "LGPL with OpenSSL linking exception"
 dev-repo: "https://github.com/ocsigen/lwt.git"
 
 build: [
-  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%"
-                                    "-use-camlp4" "%{camlp4:installed}%" ]
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%" ]
   [ "jbuilder" "build" "-p" name "-j" jobs ]
   [ "ocaml" "src/util/install_filter.ml" ]
 ]
@@ -46,7 +45,6 @@ depends: [
 depopts: [
   "base-threads"
   "base-unix"
-  "camlp4"
   "conf-libev"
 ]
 # In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the

--- a/src/camlp4/jbuild
+++ b/src/camlp4/jbuild
@@ -1,15 +1,6 @@
 (jbuild_version 1)
 
 (library
- ((name lwt_syntax)
-  (public_name lwt.syntax)
-  (synopsis "Camlp4 syntax for Lwt (deprecated; use lwt.ppx)")
-  (optional)
-  (wrapped false)
-  (libraries (camlp4 lwt.syntax.options))
-  (preprocess (action (run camlp4oof ${<})))))
-
-(library
  ((name lwt_camlp4)
   (public_name lwt_camlp4)
   (synopsis "Camlp4 syntax for Lwt (deprecated; use lwt_ppx)")

--- a/src/camlp4/log/jbuild
+++ b/src/camlp4/log/jbuild
@@ -1,16 +1,6 @@
 (jbuild_version 1)
 
 (library
- ((name lwt_syntax_log)
-  (public_name lwt.syntax.log)
-  (synopsis "Camlp4 syntax for Lwt logging (deprecated; use lwt.ppx)")
-  (optional)
-  (wrapped false)
-  (libraries (camlp4 lwt.syntax.options))
-  (flags (:standard -w +A-3-4-58))
-  (preprocess (action (run camlp4oof ${<})))))
-
-(library
  ((name lwt_camlp4_log)
   (public_name lwt_camlp4.log)
   (synopsis "Camlp4 syntax for Lwt logging (deprecated; use lwt_ppx)")

--- a/src/camlp4/options/jbuild
+++ b/src/camlp4/options/jbuild
@@ -1,14 +1,6 @@
 (jbuild_version 1)
 
 (library
- ((name lwt_syntax_options)
-  (public_name lwt.syntax.options)
-  (synopsis "Options for Lwt Camlp4 syntax extension (deprecated; use lwt.ppx)")
-  (optional)
-  (wrapped false)
-  (libraries (camlp4))))
-
-(library
  ((name lwt_camlp4_options)
   (public_name lwt_camlp4.options)
   (synopsis "Options for Lwt Camlp4 syntax extension (deprecated; use lwt_ppx)")

--- a/src/util/appveyor-build.sh
+++ b/src/util/appveyor-build.sh
@@ -2,6 +2,6 @@ set -e
 set -x
 
 # install packages and run tests
-opam install -y -t --verbose lwt lwt_react lwt_camlp4
+opam install -y -t --verbose lwt lwt_react
 
 ! opam list -i batteries

--- a/src/util/appveyor-install.sh
+++ b/src/util/appveyor-install.sh
@@ -29,7 +29,6 @@ then
 
     # Generate build systems of extra packages and pin them.
     pin_extra_package react
-    pin_extra_package camlp4
 
     # For the tests, obviously...
     opam install -y ounit

--- a/src/util/configure.ml
+++ b/src/util/configure.ml
@@ -4,7 +4,6 @@ let use_libev = ref None
 let use_pthread = ref None
 let android_target = ref None
 let libev_default = ref None
-let use_camlp4 = ref None
 
 let arg_bool r =
   Arg.Symbol (["true"; "false"],
@@ -14,7 +13,7 @@ let arg_bool r =
               | _ -> assert false)
 
 let usage =
-  "enable lwt.unix and camlp4 features\noptions are:"
+  "enable lwt.unix features\noptions are:"
 
 let args = [
   "-use-libev", arg_bool use_libev,
@@ -25,8 +24,6 @@ let args = [
     " compile for Android";
   "-libev-default", arg_bool libev_default,
     " whether to use the libev backend by default";
-  "-use-camlp4", arg_bool use_camlp4,
-    " when true enable camlp4 syntax extension";
 ]
 
 let oasis_files = [
@@ -78,17 +75,6 @@ let main () =
   print "use_pthread" !use_pthread;
   print "android_target" !android_target;
   print "libev_default" !libev_default;
-  close_out f;
-
-  (* '-use-camlp4 false' (or none) will write a jbuild-ignore file directing
-                         jbuilder to ignore the camlp4 directory.
-     '-use-camlp4 true' will write an empty file which does nothing.
-
-     This is a workaround required to overcome some weird camlp4 packaging
-     behaviour where ocamlfind sometimes installs a dummy META file for it even
-     though it's not actually installed. *)
-  let f = open_out "src/jbuild-ignore" in
-  (if !use_camlp4 = Some true then () else Printf.fprintf f "camlp4");
   close_out f;
 
   (* Compilers starting from 4.03.0 support the -O3 flag. *)

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -36,10 +36,6 @@ packages_homebrew () {
     if [ "$COMPILER" = system ]
     then
         brew install ocaml
-        # The system compiler on Homebrew is now 4.06 or higher, and there is no
-        # system Camlp4 package compatible with that (at least not yet). See:
-        #   https://github.com/ocaml/opam-repository/pull/10455
-        HAVE_CAMLP4=no
     else
         DO_SWITCH=yes
     fi
@@ -66,7 +62,6 @@ packages_macports () {
 
     wget -q -O - https://aantron.github.io/binaries/macports/x86_64/opam/1.2/install.sh | bash
     wget -q -O - https://aantron.github.io/binaries/macports/x86_64/ocaml/$COMPILER/install.sh | bash
-    wget -q -O - https://aantron.github.io/binaries/macports/x86_64/camlp4/$COMPILER/install.sh | bash
 }
 
 packages_osx () {
@@ -130,11 +125,6 @@ opam pin add -y --no-action lwt .
 
 opam install -y --deps-only lwt
 
-if [ "$HAVE_CAMLP4" != no ]
-then
-    opam install -y camlp4
-fi
-
 if [ "$LIBEV" != no ]
 then
     opam install -y conf-libev
@@ -155,11 +145,6 @@ install_extra_package ppx
 install_extra_package react
 install_extra_package log
 
-if [ "$HAVE_CAMLP4" != no ]
-then
-    install_extra_package camlp4
-fi
-
 # Build and run the tests.
 opam install -y ounit
 cd `opam config var lib`/../build/lwt.*
@@ -172,17 +157,14 @@ else
     LIBEV_FLAG=false
 fi
 
-ocaml src/util/configure.ml -use-libev $LIBEV_FLAG -use-camlp4 false
+ocaml src/util/configure.ml -use-libev $LIBEV_FLAG
 make build-all test-all
 make coverage
 
 
 
 # Run the packaging tests.
-if [ "$HAVE_CAMLP4" != no ]
-then
-    make packaging-test
-fi
+make packaging-test
 
 
 

--- a/test/packaging/ocamlfind/camlp4/Makefile
+++ b/test/packaging/ocamlfind/camlp4/Makefile
@@ -1,9 +1,0 @@
-.PHONY : test
-test : clean
-	ocamlfind opt -syntax camlp4o -package lwt,lwt_camlp4 -c user.ml
-	ocamlfind opt -package lwt -linkpkg user.cmx
-	./a.out
-
-.PHONY : clean
-clean :
-	rm -f *.cm* *.o a.out

--- a/test/packaging/ocamlfind/camlp4/user.ml
+++ b/test/packaging/ocamlfind/camlp4/user.ml
@@ -1,6 +1,0 @@
-let () =
-  let p =
-    lwt () = Lwt.return () in
-    Lwt.return ()
-  in
-  ignore p


### PR DESCRIPTION
The Camlp4 syntax was already fully packaged as `lwt_camlp4`. This commit deletes package `lwt.syntax`.

Resolves #370.

After this PR, the code of the Camlp4 extension will be removed from the repo (#511).