### PR TITLE
[4.0.0] Mark resolvers contravariant

### DIFF
--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -416,7 +416,7 @@ type +'a t
     There is one exception to this: most promises can be {e canceled} by calling
     {!Lwt.cancel}, without going through a resolver. *)
 
-type 'a u
+type -'a u
 (** Resolvers for promises of type ['a ]{!Lwt.t}.
 
     Each resolver can be thought of as the {b write end} of one promise. It can


### PR DESCRIPTION
Resolves #458.

Contravariant resolvers are unsound if `Lwt.waiter_of_wakener` is used, but we've deprecated that function exactly for this reason.