### PR TITLE
Issue 395: Add tests that Lwt_list functions run in parallel/series

### DIFF
--- a/test/core/test_lwt_list.ml
+++ b/test/core/test_lwt_list.ml
@@ -119,6 +119,96 @@ let test_map f test_list =
   in
   ()
 
+let test_map_parallelism ?(rev=false) map =
+  let t, w = Lwt.wait () in
+  let g x =
+    Lwt.wakeup_later w ();
+    Lwt.return (x + 1) in
+  let f x =
+    if x = 0 then t >>= (fun _ -> Lwt.return (x + 1))
+    else g x
+  in
+  let p = map f [0; 1] in
+  let expected = if rev then [2; 1] else [1; 2] in
+  p >>= (fun l -> Lwt.return (l = expected))
+
+let test_map_serialism ?(rev=false) map =
+  let m = Lwt_mutex.create () in
+  let g x =
+    Lwt_mutex.unlock m;
+    Lwt.return (x + 1) in
+  let f x =
+    Lwt_mutex.lock m >>= fun _ ->
+    if x = 0 then g x
+    else Lwt.return (x + 1)
+  in
+  let p = map f [0; 1] in
+  let expected = if rev then [2; 1] else [1; 2] in
+  p >>= (fun u -> Lwt.return (u = expected))
+
+let test_iter_parallelism iter =
+  let t, w = Lwt.wait () in
+  let g _ =
+    Lwt.wakeup_later w ();
+    Lwt.return () in
+  let f x =
+    if x = 0 then t >>= (fun _ -> Lwt.return ())
+    else g x
+  in
+  let p = iter f [0; 1] in
+  p >>= (fun _ -> Lwt.return true)
+
+let test_iter_serialism iter =
+  let m = Lwt_mutex.create () in
+  let g _ =
+    Lwt_mutex.unlock m;
+    Lwt.return () in
+  let f x =
+    Lwt_mutex.lock m >>= fun _ ->
+    if x = 0 then g x
+    else Lwt.return ()
+  in
+  let p = iter f [0; 1] in
+  p >>= (fun _ -> Lwt.return_true)
+
+let test_fold_serialism fold =
+  let m = Lwt_mutex.create () in
+  let g x =
+    Lwt_mutex.unlock m;
+    Lwt.return x in
+  let f s x =
+    Lwt_mutex.lock m >>= fun _ ->
+    if x = 0 then g x
+    else Lwt.return (s + x)
+  in
+  let p = fold f 0 [0; 1] in
+  p >>= (fun _ -> Lwt.return_true)
+
+let test_quantifier_parallelism quantifier b =
+  let t, w = Lwt.wait () in
+  let g _ =
+    Lwt.wakeup_later w ();
+    Lwt.return b in
+  let f x =
+    if x = 0 then t >>= (fun _ -> Lwt.return b)
+    else g x
+  in
+  let p = quantifier f [0; 1] in
+  p >>= (fun u -> Lwt.return (u = b))
+
+let test_quantifier_serialism quantifier b =
+  let m = Lwt_mutex.create () in
+  let g _ =
+    Lwt_mutex.unlock m;
+    Lwt.return b in
+  let f x =
+    Lwt_mutex.lock m >>= fun _ ->
+    if x = 0 then g x
+    else Lwt.return b
+  in
+  let p = quantifier f [0; 1] in
+  p >>= (fun u -> Lwt.return (b = u))
+
 let test_for_all_true f =
   let l = [true; true] in
   f (fun x -> Lwt.return (x = true)) l
@@ -408,5 +498,162 @@ let suite = suite "lwt_list" [
     let m f = Lwt_list.partition_s (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
     Lwt.return true;
+  end;
+
+  test "iter_p parallelism" begin fun () ->
+    test_iter_parallelism Lwt_list.iter_p
+  end;
+
+  test "iter_s serialism" begin fun () ->
+    test_iter_serialism Lwt_list.iter_s
+  end;
+
+  test "iteri_p parallelism" begin fun () ->
+    let iter f = Lwt_list.iteri_p (fun _ x -> f x) in
+    test_iter_parallelism iter
+  end;
+
+  test "iteri_s serialism" begin fun () ->
+    let iter f = Lwt_list.iteri_s (fun _ x -> f x) in
+    test_iter_serialism iter
+  end;
+
+  test "map_p parallelism" begin fun () ->
+    test_map_parallelism Lwt_list.map_p
+  end;
+
+  test "map_s serialism" begin fun () ->
+    test_map_serialism Lwt_list.map_s
+  end;
+
+  test "mapi_p parallelism" begin fun () ->
+    let m f = Lwt_list.mapi_p (fun _ x -> f x) in
+    test_map_parallelism m
+  end;
+
+  test "mapi_s serialism" begin fun () ->
+    let m f = Lwt_list.mapi_s (fun _ x -> f x) in
+    test_map_serialism m
+  end;
+
+  test "rev_map_p parallelism" begin fun () ->
+    test_map_parallelism ~rev:true Lwt_list.rev_map_p
+  end;
+
+  test "rev_map_s serialism" begin fun () ->
+    test_map_serialism ~rev:true Lwt_list.rev_map_s
+  end;
+
+  test "fold_left_s serialism" begin fun () ->
+    test_fold_serialism Lwt_list.fold_left_s
+  end;
+
+  test "fold_right_s serialism" begin fun () ->
+    let fold f s l = Lwt_list.fold_right_s f l s in
+    test_fold_serialism fold
+  end;
+
+  test "filter_map_p parallelism" begin fun () ->
+    let m f = Lwt_list.filter_map_p (fun x -> f x >>= fun u -> Lwt.return (Some u)) in
+    test_map_parallelism m
+  end;
+
+  test "filter_map_s serlialism" begin fun () ->
+    let m f = Lwt_list.filter_map_s (fun x -> f x >>= fun u -> Lwt.return (Some u)) in
+    test_map_serialism m
+  end;
+
+  test "for_all_p parallelism" begin fun () ->
+    test_quantifier_parallelism Lwt_list.for_all_p true
+  end;
+
+  test "for_all_s serialism" begin fun () ->
+    test_quantifier_serialism Lwt_list.for_all_s true
+  end;
+
+  test "exists_p parallelism" begin fun () ->
+    test_quantifier_parallelism Lwt_list.exists_p false
+  end;
+
+  test "exists_s serialism" begin fun () ->
+    test_quantifier_serialism Lwt_list.exists_s false
+  end;
+
+  test "find_s serialism" begin fun () ->
+      let m = Lwt_mutex.create () in
+      let g _ =
+        Lwt_mutex.unlock m;
+        Lwt.return false in
+      let f x =
+        Lwt_mutex.lock m >>= fun _ ->
+        if x = 0 then g x
+        else Lwt.return true
+      in
+      let p = Lwt_list.find_s f [0; 1] in
+      p >>= (fun _ -> Lwt.return true)
+  end;
+
+  test "filter_p parallelism" begin fun () ->
+    let t, w = Lwt.wait () in
+    let g _ =
+      Lwt.wakeup_later w ();
+      Lwt.return true in
+    let f x =
+      if x = 0 then t >>= (fun _ -> Lwt.return true)
+      else g x
+    in
+    let p = Lwt_list.filter_p f [0; 1] in
+    p >>= (fun l -> Lwt.return (l = [0; 1]))
+  end;
+
+  test "filter_s serialism" begin fun () ->
+    let m = Lwt_mutex.create () in
+    let g _ =
+      Lwt_mutex.unlock m;
+      Lwt.return_true in
+    let f x =
+      Lwt_mutex.lock m >>= fun _ ->
+      if x = 0 then g x
+      else Lwt.return_true
+    in
+    let p = Lwt_list.filter_s f [0; 1] in
+    p >>= (fun u -> Lwt.return (u = [0; 1]))
+  end;
+
+  test "filter_map_p parallelism" begin fun () ->
+    let map f = Lwt_list.filter_map_p (fun x -> f x >>= fun u -> Lwt.return (Some u)) in
+    test_map_parallelism map
+  end;
+
+  test "filter_map_s parallelism" begin fun () ->
+    let map f = Lwt_list.filter_map_s (fun x -> f x >>= fun u -> Lwt.return (Some u)) in
+    test_map_serialism map
+  end;
+
+  test "partition_p parallelism" begin fun () ->
+    let t, w = Lwt.wait () in
+    let g _ =
+      Lwt.wakeup_later w ();
+      Lwt.return_true in
+    let f x =
+      if x = 0 then t >>= (fun _ -> Lwt.return_true)
+      else g x
+    in
+    let p = Lwt_list.partition_p f [0; 1] in
+    p >>= (fun _ -> Lwt.return_true)
+  end;
+
+  test "partition_s serialism" begin fun () ->
+    let m = Lwt_mutex.create () in
+    let g _ =
+      Lwt_mutex.unlock m;
+      Lwt.return_true in
+    let f x =
+      Lwt_mutex.lock m >>= fun _ ->
+      if x = 0 then g x
+      else Lwt.return_true
+    in
+    let p = Lwt_list.partition_p f [0; 1] in
+    p >>= (fun _ -> Lwt.return_true)
   end;
 ]


### PR DESCRIPTION
This change proposes tests to address the second of the three parts of #395. These tests check that the `Lwt_list` functions ending in `_p` run in parallel and the `_s` tests run in series.

There are a couple of points where I think these tests are potentially dubious.
- As they're currently written, a test that fails will hang. I think this isn't ideal from a CI perspective (it would be preferable to immediately get a pass/fail).
- Based on comments on #395, it seems we'd prefer to have more self-contained tests rather than relying on many "helper functions". I've tried to avoid introducing too many helpers, but it's clear there's a lot of overlap/similarities between the new tests. 