### PR TITLE
Begin cleaning up the PPX

### DIFF
--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -274,6 +274,13 @@ let lwt_expression mapper exp attributes =
       else
         [%expr Lwt.catch (fun () -> [%e exp]) Lwt.fail]
     in
+    let warning =
+      attribute_of_warning
+        exp.pexp_loc
+        ("[%lwt ...] is deprecated\n" ^
+         "  See https://github.com/ocsigen/lwt/issues/527")
+    in
+    let pexp_attributes = warning::pexp_attributes in
     mapper.expr mapper { new_exp with pexp_attributes }
 
 let make_loc {Location.loc_start; _} =


### PR DESCRIPTION
This commit deprecates a lot of little-used PPX features, which are probably also somewhat ill-conceived. This includes all PPX options and several bits of syntax:

- `-no-debug`: There is no point in supporting this (#528). In opam, it is used only in `sqlexpr` (cc @mfp).
- `-no-sequence`, `-no-strict-sequence`: We are removing `>>` anyway (#495), so we should remove these options. They have no users in opam.
- `-log`, `-no-log`: We are deprecating Lwt_log, so it's probably worthwhile to remove logging support from the PPX (#520). These options have no users in opam.
- `[%lwt ...]` syntax expanding to `Lwt.catch ...`. This is causing problems (#527), so we don't want to support it. It is used in `eliom` and `sqlexpr` (cc @mfp @balat @jrochel @vouillon @vasilisp).
- `[%finally ...]` should be replaced by `[%lwt.finally ...]`. The bare `[%finally ...]` is used in `devkit`, `gdb`, `gdbprofiler`, `sqlexpr` (cc @cyberhuman @ygrek @copy @mfp).

Some more notes:

- While editing the PPX, I noticed an undocumented feature: a `let%lwt ...` structure item becomes a call to `Lwt_main.run`. It might be impossible to support this on Node.js in a reasonable way. I'm not sure if we want to deprecate it yet, but it's good that it is not documented.
- `-no-sequence` is the most legitimate of the PPX options. Users that want `>>` as a definable operator may be using it to suppress Lwt's `>>`. I'm not sure if the warning will be too noisy for them.
- This PR doesn't check for `[%lwt let ...]`, just `[%lwt ...]` when it would expand to `Lwt.catch ...`. We should probably disable `[%lwt let ...]` and `[%lwt ...]` around all other constructs, by checking the location of the `%lwt` extension point, as is being done in #525 for `;`. This is still being discussed there, so left for future work.
- @kandu, this PR doesn't include your change about inserting spaces into command line argument descriptions. Whichever order this PR and #525 get merged in, I'll be sure to port/cherry-pick that commit and you will get credit for it :)

Some time after deprecating all this, maybe in `lwt_ppx` 2.0.0, we can delete support for all these features from the PPX, making it much simpler than it is now. A side effect of factoring the PPX out into `lwt_ppx` is that it can have its own release cycle, so we could do this without a major release of the main package `lwt`.