### PR TITLE
Lwt_sequence: remove check for active node in length function

### DIFF
--- a/src/core/lwt_sequence.ml
+++ b/src/core/lwt_sequence.ml
@@ -69,11 +69,7 @@ let length seq =
     if curr == seq then
       len
     else
-      let node = node_of_seq curr in
-      if node.node_active then
-        loop node.node_next (len + 1)
-      else
-        loop node.node_next len
+      let node = node_of_seq curr in loop node.node_next (len + 1)
   in
   loop seq.next 0
 


### PR DESCRIPTION
@aantron,

while I was removing the check, I was asking myself if when a sequence is shared/used in two threads, how can I be sure that the `Lwt_sequence.length` is "atomic". For example, it is hard in the test to : 

* create a sequence
* create a thread that use `Lwt_sequence.length` on this sequence
* create another thread that remove one or more node in this sequence
* use Lwt.join on the 2 threads

but we can imagine that it could happen? 

or is there some kind of Lwt "magic" that sets some "mutex" or something like that in order to garantee that operation like `Lwt_sequence.length` is atomic.