### PR TITLE
Make (Lwt.nchoose_split []) immediately return

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2921,6 +2921,10 @@ struct
 
     let p = check_for_already_resolved_promises [] ps in
     p
+
+  let nchoose_split = function
+    | [] -> return ([], [])
+    | l -> nchoose_split l
 end
 include Concurrent_composition
 

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2037,7 +2037,7 @@ let suites = suites @ [nchoose_tests]
 let nchoose_split_tests = suite "nchoose_split" [
   test "empty" begin fun () ->
     let p = Lwt.nchoose_split [] in
-    Lwt.return (Lwt.state p = Lwt.Sleep)
+    Lwt.return (Lwt.state p = Lwt.Return ([], []))
   end;
 
   test "some fulfilled" begin fun () ->


### PR DESCRIPTION
Fixes #551 

This is a change in (undocumented) behavior.  For the better in my opinion but I'm not sure how others feel.