### PR TITLE
Fix lwt_ppx backtraces with reraise

### DIFF
--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -19,6 +19,8 @@ depends: [
   "ppx_tools_versioned" {>= "5.0.1"}
 ]
 
+available: [ocaml-version >= "4.02.0"]
+
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -477,21 +477,21 @@ let mapper =
         lwt_log mapper fn args pexp_attributes pexp_loc
       | _ ->
         default_mapper.expr mapper expr);
-        structure_item = (fun mapper stri ->
-          default_loc := stri.pstr_loc;
-          match stri with
-          | [%stri let%lwt [%p? var] = [%e? exp]] ->
-            [%stri let [%p var] = Lwt_main.run [%e mapper.expr mapper exp]]
+    structure_item = (fun mapper stri ->
+      default_loc := stri.pstr_loc;
+      match stri with
+      | [%stri let%lwt [%p? var] = [%e? exp]] ->
+        [%stri let [%p var] = Lwt_main.run [%e mapper.expr mapper exp]]
 
-          | {pstr_desc = Pstr_extension (({txt = "lwt"; _}, PStr [
-            {pstr_desc = Pstr_value (Recursive, _); _}]) as content, attrs); pstr_loc} ->
-            {stri with pstr_desc =
-              Pstr_extension (content, warn_let_lwt_rec pstr_loc attrs)}
+      | {pstr_desc = Pstr_extension (({txt = "lwt"; _}, PStr [
+        {pstr_desc = Pstr_value (Recursive, _); _}]) as content, attrs); pstr_loc} ->
+        {stri with pstr_desc =
+          Pstr_extension (content, warn_let_lwt_rec pstr_loc attrs)}
 
-          | {pstr_desc = Pstr_extension (({txt = "lwt"; _}, PStr [
-            {pstr_desc = Pstr_value (Nonrecursive, vbs); _}]), _); _} ->
-            mapper.structure_item mapper (Str.value Nonrecursive (gen_top_binds vbs))
-          | x -> default_mapper.structure_item mapper x);
+      | {pstr_desc = Pstr_extension (({txt = "lwt"; _}, PStr [
+        {pstr_desc = Pstr_value (Nonrecursive, vbs); _}]), _); _} ->
+        mapper.structure_item mapper (Str.value Nonrecursive (gen_top_binds vbs))
+      | x -> default_mapper.structure_item mapper x);
 }
 
 


### PR DESCRIPTION
As others have noted, backtraces with lwt_ppx seem to be broken. I've seen it mentioned in a few places, but https://caml.inria.fr/mantis/print_bug_page.php?bug_id=7375 is the place that inspired me to see if switching from `raise exn` to `reraise exn` would fix the issue.

There were a few small challenges:

1. Putting `external reraise : exn -> 'a = "%reraise"` in `lwt.ml` and passing it into `add_loc` made the re-raise location always show up in `lwt.ml`. So I decided to make ppx_lwt.ml put it into the transformed file
2. The `external` part of the grammar is a little tricky to stick inside of an expression, since it's basically a module item. Sticking it into a local module is kind of a hack, but seems to work.

[The `%reraise` primitive seems to be new to 4.02](https://github.com/ocaml/ocaml/commit/f31325cbaf320e34cf96a40e335456c2df5d6271) so I probably should add `available: [ocaml-version >= "4.02.0"]` to the `lwt_ppx.opam`, right? Would that be ok? I suppose I could also use cppo to decay to `raise` for older versions, if you feel strongly.

Fixes #498 #171 