### PR TITLE
Reraise in lwt

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2477,6 +2477,8 @@ sig
   val nchoose_split : 'a t list -> ('a list * 'a t list) t
 end =
 struct
+  external reraise : exn -> 'a = "%reraise"
+
   let async f =
     let p = try f () with exn -> fail exn in
     let Internal p = to_internal_promise p in
@@ -2504,7 +2506,7 @@ struct
     | Fulfilled _ ->
       ()
     | Rejected exn ->
-      raise exn
+      reraise exn
 
     | Pending p_callbacks ->
       let callback result =

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2983,6 +2983,8 @@ struct
     | Fail of exn
     | Sleep
 
+  external reraise : exn -> 'a = "%reraise"
+
   let state p =
     let Internal p = to_internal_promise p in
     match (underlying p).state with
@@ -3003,7 +3005,7 @@ struct
   let poll p =
     let Internal p = to_internal_promise p in
     match (underlying p).state with
-    | Rejected e -> raise e
+    | Rejected e -> reraise e
     | Fulfilled v -> Some v
     | Pending _ -> None
 


### PR DESCRIPTION
Similarly to how #554 uses `reraise` to improve backtraces in lwt_ppx, we can also use `reraise` to improve exceptions reraised by `Lwt.ignore_result` and `Lwt.poll`.