### PR TITLE
[5.0.0] Lwt.pick, etc raise Invalid_argument on empty list

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2654,6 +2654,9 @@ struct
   let prng = lazy (Random.State.make [||])
 
   let choose ps =
+    if ps = [] then
+      invalid_arg
+        "Lwt.choose [] would return a promise that is pending forever";
     match count_resolved_promises_in ps with
     | 0 ->
       let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
@@ -2676,6 +2679,8 @@ struct
       nth_resolved ps (Random.State.int (Lazy.force prng) n)
 
   let pick ps =
+    if ps = [] then
+      invalid_arg "Lwt.pick [] would return a promise that is pending forever";
     match count_resolved_promises_in ps with
     | 0 ->
       let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
@@ -2732,6 +2737,9 @@ struct
   let nchoose ps =
     (* If at least one promise in [ps] is found fulfilled, this function is
        called to find all such promises. *)
+    if ps = [] then
+      invalid_arg
+        "Lwt.nchoose [] would return a promise that is pending forever";
     let rec collect_already_fulfilled_promises_or_find_rejected acc ps =
       match ps with
       | [] ->
@@ -2789,6 +2797,8 @@ struct
   (* See [nchoose]. This function differs only in having additional calls to
      [cancel]. *)
   let npick ps =
+    if ps = [] then
+      invalid_arg "Lwt.npick [] would return a promise that is pending forever";
     let rec collect_already_fulfilled_promises_or_find_rejected acc ps' =
       match ps' with
       | [] ->
@@ -2848,6 +2858,9 @@ struct
 
   (* Same general pattern as [npick] and [nchoose]. *)
   let nchoose_split ps =
+    if ps = [] then
+      invalid_arg
+        "Lwt.nchoose_split [] would return a promise that is pending forever";
     let rec finish
         (to_resolve : ('a list * 'a t list, underlying, pending) promise)
         (fulfilled : 'a list)

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -970,8 +970,8 @@ let () =
     promise in [ps] to become resolved is rejected, [p] is rejected with the
     same exception.
 
-    If [ps] has no promises (if it is the empty list), [Lwt.pick ps] returns a
-    promise that is pending forever, and cannot be canceled.
+    If [ps] has no promises (if it is the empty list), [Lwt.pick ps] raises
+    [Pervasives.Invalid_argument _].
 
     It's possible for multiple promises in [ps] to become resolved
     simultaneously. This happens most often when some promises [ps] are already

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -1911,9 +1911,13 @@ let suites = suites @ [join_tests]
 
 let choose_tests = suite "choose" [
   test "empty" begin fun () ->
-    let p = Lwt.choose [] in
-    state_is (Lwt.Sleep) p
-  end;
+    try
+      ignore (Lwt.choose []);
+      Lwt.return false
+    with Invalid_argument "Lwt.choose [] would return a \
+                           promise that is pending forever" ->
+      Lwt.return true
+  end [@ocaml.warning "-52"];
 
   test "fulfilled" begin fun () ->
     let p = Lwt.choose [fst (Lwt.wait ()); Lwt.return "foo"] in
@@ -1978,9 +1982,13 @@ let suites = suites @ [choose_tests]
 
 let nchoose_tests = suite "nchoose" [
   test "empty" begin fun () ->
-    let p = Lwt.nchoose [] in
-    Lwt.return (Lwt.state p = Lwt.Sleep)
-  end;
+    try
+      ignore (Lwt.nchoose []);
+      Lwt.return false
+    with Invalid_argument "Lwt.nchoose [] would return a \
+                           promise that is pending forever" ->
+      Lwt.return true
+  end [@ocaml.warning "-52"];
 
   test "all fulfilled" begin fun () ->
     let p = Lwt.nchoose [Lwt.return "foo"; Lwt.return "bar"] in
@@ -2036,9 +2044,13 @@ let suites = suites @ [nchoose_tests]
 
 let nchoose_split_tests = suite "nchoose_split" [
   test "empty" begin fun () ->
-    let p = Lwt.nchoose_split [] in
-    Lwt.return (Lwt.state p = Lwt.Sleep)
-  end;
+    try
+      ignore (Lwt.nchoose_split []);
+      Lwt.return false
+    with Invalid_argument "Lwt.nchoose_split [] would return a \
+                           promise that is pending forever" ->
+      Lwt.return true
+  end [@ocaml.warning "-52"];
 
   test "some fulfilled" begin fun () ->
     let p =
@@ -2514,9 +2526,13 @@ let suites = suites @ [resolve_already_canceled_promise_tests]
 
 let pick_tests = suite "pick" [
   test "empty" begin fun () ->
-    let p = Lwt.pick [] in
-    Lwt.return (Lwt.state p = Lwt.Sleep)
-  end;
+    try
+      ignore (Lwt.pick []);
+      Lwt.return false
+    with Invalid_argument "Lwt.pick [] would return a \
+                           promise that is pending forever" ->
+      Lwt.return true
+  end [@ocaml.warning "-52"];
 
   test "fulfilled" begin fun () ->
     let p1, _ = Lwt.task () in
@@ -2620,9 +2636,13 @@ let suites = suites @ [pick_tests]
 
 let npick_tests = suite "npick" [
   test "empty" begin fun () ->
-    let p = Lwt.npick [] in
-    Lwt.return (Lwt.state p = Lwt.Sleep)
-  end;
+    try
+      ignore (Lwt.npick []);
+      Lwt.return false
+    with Invalid_argument "Lwt.npick [] would return a \
+                           promise that is pending forever" ->
+      Lwt.return true
+  end [@ocaml.warning "-52"];
 
   test "all fulfilled" begin fun () ->
     let p = Lwt.npick [Lwt.return "foo"; Lwt.return "bar"] in


### PR DESCRIPTION
As described in #557, this PR adjusts the behavior of `Lwt.pick`, `Lwt.choose`, `Lwt.npick`, `Lwt.nchoose`, and `Lwt.nchoose_split` raise `Invalid_argument` when passed an invalid list.  The test and docs are updated to reflect the new behavior.