### PR TITLE
Lwt_react.limit: fix redundant event occurrences according to documented semantics

### DIFF
--- a/src/react/lwt_react.ml
+++ b/src/react/lwt_react.ml
@@ -45,7 +45,7 @@ module E = struct
     let iter =
       fmap
         (fun x ->
-           if Lwt.state !limiter = Lwt.Sleep then begin
+           if Lwt.is_sleeping !limiter then begin
              (* The limiter is sleeping, we queue the event for later
                 delivering. *)
              match !delayed with
@@ -56,7 +56,7 @@ module E = struct
              | None ->
                let cell = ref x in
                delayed := Some cell;
-               Lwt.on_success !limiter (fun () -> let x = !cell in delayed := None; push x);
+               Lwt.on_success !limiter (fun () -> let x = !cell in delayed := None; limiter := f (); push x);
                None
            end else begin
              (* Set the limiter for future events. *)
@@ -279,7 +279,7 @@ module S = struct
     let iter =
       E.fmap
         (fun x ->
-           if Lwt.state !limiter = Lwt.Sleep then begin
+           if Lwt.is_sleeping !limiter then begin
              (* The limiter is sleeping, we queue the event for later
                 delivering. *)
              match !delayed with
@@ -290,7 +290,7 @@ module S = struct
              | None ->
                let cell = ref x in
                delayed := Some cell;
-               Lwt.on_success !limiter (fun () -> let x = !cell in delayed := None; push x);
+               Lwt.on_success !limiter (fun () -> let x = !cell in delayed := None; limiter := f (); push x);
                None
            end else begin
              (* Set the limiter for future events. *)

--- a/test/react/test_lwt_event.ml
+++ b/test/react/test_lwt_event.ml
@@ -86,6 +86,7 @@ let suite = suite "lwt_event" [
          push 2; (* overwrites previous 0 *)
          Lwt_condition.signal cond ();
          push 3;
+         Lwt_condition.signal cond ();
          push 4;
          Lwt_condition.signal cond ();
          return (!l = [4; 3; 2; 1]));

--- a/test/react/test_lwt_signal.ml
+++ b/test/react/test_lwt_signal.ml
@@ -37,6 +37,7 @@ let suite = suite "lwt_signal" [
          push 2; (* overwrites previous 0 *)
          Lwt_condition.signal cond ();
          push 3;
+         Lwt_condition.signal cond ();
          push 4;
          Lwt_condition.signal cond ();
          return (!l = [4; 3; 2; 1]));


### PR DESCRIPTION
possible fix for #565