### PR TITLE
Lwt_io.file_length: raise EISDIR when used on directory

### DIFF
--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1508,7 +1508,12 @@ let with_temp_file ?buffer ?flags ?perm ?temp_dir ?prefix f =
       close chan >>= fun () ->
       Lwt_unix.unlink fname)
 
-let file_length filename = with_file ~mode:input filename length
+let file_length filename =
+  Lwt_unix.stat filename >>= fun stat ->
+  if stat.Unix.st_kind = Unix.S_DIR then
+    Lwt.fail (Unix.(Unix_error (EISDIR, "file_length", filename)))
+  else
+    with_file ~mode:input filename length
 
 let close_socket fd =
   Lwt.finalize

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1511,7 +1511,7 @@ let with_temp_file ?buffer ?flags ?perm ?temp_dir ?prefix f =
 let file_length filename =
   Lwt_unix.stat filename >>= fun stat ->
   if stat.Unix.st_kind = Unix.S_DIR then
-    Lwt.fail (Unix.Unix_error (Unix.EISDIR, "file_length", filename))
+    Lwt.fail (Unix.(Unix_error (EISDIR, "file_length", filename)))
   else
     with_file ~mode:input filename length
 

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1511,7 +1511,7 @@ let with_temp_file ?buffer ?flags ?perm ?temp_dir ?prefix f =
 let file_length filename =
   Lwt_unix.stat filename >>= fun stat ->
   if stat.Unix.st_kind = Unix.S_DIR then
-    Lwt.fail (Unix.(Unix_error (EISDIR, "file_length", filename)))
+    Lwt.fail (Unix.Unix_error (Unix.EISDIR, "file_length", filename))
   else
     with_file ~mode:input filename length
 

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -183,7 +183,9 @@ val atomic : ('a channel -> 'b Lwt.t) -> ('a channel -> 'b Lwt.t)
       - [atomic] can be called inside another [atomic] *)
 
 val file_length : string -> int64 Lwt.t
-  (** Returns the length of a file *)
+(** Retrieves the length of the file at the given path. If the path refers to a
+    directory, the returned promise is rejected with
+    [Unix.(Unix_error (EISDIR, _, _))]. *)
 
 val buffered : 'a channel -> int
   (** [buffered oc] returns the number of bytes in the buffer *)

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -385,7 +385,7 @@ let suite = suite "lwt_io" [
         Lwt_io.file_length "." >>= fun _ ->
         Lwt.return false)
       (function
-      | Unix.(Unix_error (EISDIR, "file_length", ".")) ->
+      | Unix.Unix_error (Unix.EISDIR, "file_length", ".") ->
         Lwt.return true
       | exn -> Lwt.fail exn)
   end;

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -378,4 +378,15 @@ let suite = suite "lwt_io" [
          Lwt_io.close chan in
        Lwt_io.with_temp_file f >>= fun _ -> Lwt.return_true;
     );
+
+  test "file_length on directory" begin fun () ->
+    Lwt.catch
+      (fun () ->
+        Lwt_io.file_length "." >>= fun _ ->
+        Lwt.return false)
+      (function
+      | Unix.(Unix_error (EISDIR, "file_length", ".")) ->
+        Lwt.return true
+      | exn -> Lwt.fail exn)
+  end;
 ]


### PR DESCRIPTION
See #563. I don't think `Lwt_io.file_length` can return a meaningful result on a directory, even when that result is not max_int.

Two concerns:

- Maybe we should also fail on other kinds of [non-regular files](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#TYPEfile_kind). However, I am not sure which [error code](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#TYPEerror) to use and which file kinds to fail for. We should probably fix this now, when it is a bugfix, because a second time fixing it could mean a breaking change.
- I implemented the fix by calling `stat` before trying to get the file length, which adds one round trip to the Lwt worker thread pool (i.e., it is slow). If this becomes a performance bottleneck, we can speed up the implementation by using a custom job that does both `stat` and gets the file length in one call out to the thread pool. We can also probably use `Lwt_preemptive` for that, as it is getting merged into `Lwt_unix` very soon.

cc @rixed

Resolves #563.