### PR TITLE
Use max_concurrency rather than max_threads

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -910,12 +910,13 @@ let rec iter_p_rec node f s =
 
 let iter_p f s = iter_p_rec s.node f s
 
-let iter_n ?(max_threads = 1) f stream =
+let iter_n ?(max_concurrency = 1) f stream =
   begin
-    if max_threads <= 0 then
+    if max_concurrency <= 0 then
       let message =
-        Printf.sprintf "Lwt_stream.iter_n: max_threads must be > 0, %d given"
-          max_threads
+        Printf.sprintf
+          "Lwt_stream.iter_n: max_concurrency must be > 0, %d given"
+          max_concurrency
       in
       invalid_arg message
   end;
@@ -935,7 +936,7 @@ let iter_n ?(max_threads = 1) f stream =
     | Some elt ->
       loop (f elt :: running) (pred available)
   in
-  loop [] max_threads
+  loop [] max_concurrency
 
 let rec find_rec node f s =
   if node == !(s.last) then

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -324,12 +324,16 @@ val iter_p : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
 val iter_s : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
 (** [iter f s] iterates over all elements of the stream. *)
 
-val iter_n : ?max_threads:int -> ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
-  (** [iter_n ?max_threads f s] iterates over all elements of the stream [s].
-      Iteration is performed concurrently with up to [max_threads] concurrent
-      instances of [f].
+val iter_n : ?max_concurrency:int -> ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
+(** [iter_n ?max_concurrency f s] iterates over all elements of the stream [s].
+    Iteration is performed concurrently with up to [max_threads] concurrent
+    instances of [f].
 
-      @param max_threads defaults to [1]. *)
+    Iteration is {b not} guaranteed to be in order as this function will
+    attempt to always process [max_concurrency] elements from [s] at once.
+
+    @param max_concurrency defaults to [1].
+    @raise Invalid_argument if [max_concurrency < 1]. *)
 
 val find : ('a -> bool) -> 'a t -> 'a option Lwt.t
 val find_s : ('a -> bool Lwt.t) -> 'a t -> 'a option Lwt.t


### PR DESCRIPTION
Lwt.iter_n's optional max_threads argument incorrectly used the old
terminology.  This new argument name (max_concurrency) hopefully makes
the intent more clear for users.

Fixes #578