### PR TITLE
Lwt_io.establish_server (TCP servers): expose client socket to connection-handling callback

### DIFF
--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1659,24 +1659,6 @@ let establish_server_generic
 
   server, server_has_started
 
-(* Old, deprecated version of [establish_server]. This function has to persist
-   for a while, in some form, until it is no longer exposed as
-   [Lwt_io.Versioned.establish_server_1]. *)
-let establish_server_deprecated ?fd ?buffer_size ?backlog sockaddr f =
-  let blocking_bind fd addr =
-    Lwt.return (Lwt_unix.Versioned.bind_1 fd addr) [@ocaml.warning "-3"]
-  in
-  let f _addr c = f c in
-
-  let server, server_started =
-    establish_server_generic blocking_bind ?fd ?buffer_size ?backlog sockaddr f
-  in
-
-  (* Poll for exceptions in server startup that may have occurred synchronously.
-     This emulates an old, deprecated behavior. *)
-  Lwt.ignore_result server_started;
-  server
-
 let establish_server_with_client_address
     ?fd ?buffer_size ?backlog ?(no_close = false) sockaddr f =
   let best_effort_close channel =
@@ -1725,6 +1707,24 @@ let establish_server ?fd ?buffer_size ?backlog ?no_close sockaddr f =
   let f _addr c = f c in
   establish_server_with_client_address
     ?fd ?buffer_size ?backlog ?no_close sockaddr f
+
+(* Old, deprecated version of [establish_server]. This function has to persist
+   for a while, in some form, until it is no longer exposed as
+   [Lwt_io.Versioned.establish_server_1]. *)
+let establish_server_deprecated ?fd ?buffer_size ?backlog sockaddr f =
+  let blocking_bind fd addr =
+    Lwt.return (Lwt_unix.Versioned.bind_1 fd addr) [@ocaml.warning "-3"]
+  in
+  let f _addr c = f c in
+
+  let server, server_started =
+    establish_server_generic blocking_bind ?fd ?buffer_size ?backlog sockaddr f
+  in
+
+  (* Poll for exceptions in server startup that may have occurred synchronously.
+     This emulates an old, deprecated behavior. *)
+  Lwt.ignore_result server_started;
+  server
 
 let ignore_close ch =
   ignore (close ch)

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -512,35 +512,33 @@ val with_close_connection :
 type server
   (** Type of a server *)
 
-val establish_server_with_client_address :
-  ?fd : Lwt_unix.file_descr ->
-  ?buffer_size : int ->
-  ?backlog : int ->
-  ?no_close : bool ->
+val establish_server_with_client_socket :
+  ?server_fd:Lwt_unix.file_descr ->
+  ?backlog:int ->
+  ?no_close:bool ->
   Unix.sockaddr ->
-  (Lwt_unix.sockaddr -> input_channel * output_channel -> unit Lwt.t) ->
+  (Lwt_unix.sockaddr -> Lwt_unix.file_descr -> unit Lwt.t) ->
     server Lwt.t
-(** [establish_server_with_client_address listen_address f] creates a server
+(** [establish_server_with_client_socket listen_address f] creates a server
     which listens for incoming connections on [listen_address]. When a client
     makes a new connection, it is passed to [f]: more precisely, the server
     calls
 
 {[
-f client_address (in_channel, out_channel)
+f client_address client_socket
 ]}
 
     where [client_address] is the address (peer name) of the new client, and
-    [in_channel] and [out_channel] are two channels wrapping the socket for
-    communicating with that client.
+    [client_socket] is the socket connected to the client.
 
     The server does not block waiting for [f] to complete: it concurrently tries
     to accept more client connections while [f] is handling the client.
 
     When the promise returned by [f] completes (i.e., [f] is done handling the
-    client), [establish_server_with_client_address] automatically closes
-    [in_channel] and [out_channel]. This is a default behavior that is useful
-    for simple cases, but for a robust application you should explicitly close
-    these channels yourself, and handle any exceptions. If the channels are
+    client), [establish_server_with_client_socket] automatically closes
+    [client_socket]. This is a default behavior that is useful for simple cases,
+    but for a robust application you should explicitly close these channels
+    yourself, and handle any exceptions as appropriate. If the channels are
     still open when [f] completes, and their automatic closing raises an
     exception, [establish_server_with_client_address] treats it as an unhandled
     exception reaching the top level of the application: it passes that
@@ -553,14 +551,33 @@ f client_address (in_channel, out_channel)
     an exception), [establish_server_with_client_address] can do nothing with
     that exception, except pass it to {!Lwt.async_exception_hook}.
 
-    [~fd] can be specified to use an existing file descriptor for listening.
-    Otherwise, a fresh socket is created internally.
+    [~server_fd] can be specified to use an existing file descriptor for
+    listening. Otherwise, a fresh socket is created internally. In either case,
+    [establish_server_with_client_socket] will internally assign
+    [listen_address] to the server socket.
 
     [~backlog] is the argument passed to {!Lwt_unix.listen}.
 
     The returned promise (a [server Lwt.t]) resolves when the server has just
     started listening on [listen_address]: right after the internal call to
     [listen], and right before the first internal call to [accept].
+
+    @since 4.1.0 *)
+
+val establish_server_with_client_address :
+  ?fd:Lwt_unix.file_descr ->
+  ?buffer_size:int ->
+  ?backlog:int ->
+  ?no_close:bool ->
+  Unix.sockaddr ->
+  (Lwt_unix.sockaddr -> input_channel * output_channel -> unit Lwt.t) ->
+    server Lwt.t
+(** Like {!Lwt_io.establish_server_with_client_socket}, but passes two buffered
+    channels to the connection handler [f]. These channels wrap the client
+    socket.
+
+    The channels are closed automatically when the promise returned by [f]
+    resolves. To avoid this behavior, pass [~no_close:true].
 
     @since 3.1.0 *)
 
@@ -696,7 +713,7 @@ val establish_server :
   [@@ocaml.deprecated
 "  Since Lwt 3.1.0, use Lwt_io.establish_server_with_client_address"]
 (** Like [establish_server_with_client_address], but does not pass the client
-    address to the callback [f].
+    address or fd to the callback [f].
 
     @deprecated Use {!establish_server_with_client_address}.
     @since 3.0.0 *)


### PR DESCRIPTION
This is a follow-on to #323/#346 (cc @rgrinberg). It adds a function like:

```ocaml
val establish_server_with_client_socket :
  Unix.sockaddr ->
  (Unix.sockaddr -> Lwt_unix.file_descr -> (input_channel * output_channel) -> unit Lwt.t) ->
    server Lwt.t
```

...whereas existing versions of this function didn't pass the `Lwt_unix.file_descr` to the client-handling function, and only passed the `sockaddr` and the two channels.

I'm still not sure if this is the right API, but starting with this.

The PR also includes a pretty thorough cleanup of the existing code, so it should be easier to keep working on.