### PR TITLE
Make coverage tests use development versions of lwt and lwt_ppx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ BISECT_FILES_PATTERN := _build/default/test/*/bisect*.out
 
 .PHONY: coverage
 coverage: clean check-config
+	BISECT_ENABLE=yes make build
 	BISECT_ENABLE=yes jbuilder runtest --dev -j 1 --no-buffer
 	bisect-ppx-report \
 	    -I _build/default/ -html _coverage/ \


### PR DESCRIPTION
See the comments starting [here](https://github.com/ocsigen/lwt/issues/492#issuecomment-388961730). 

This PR fixes the Travis builds and gets the coverage tests to run. They currently don't because the tests are looking for the installed version of `lwt`; see e.g. [here](https://travis-ci.org/ocsigen/lwt/jobs/358127721#L799).

To verify, run `make coverage`.