### PR TITLE
Ppx: refuse match cases with only exception cases

### DIFF
--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -186,6 +186,12 @@ let lwt_expression mapper exp attributes =
         | {pc_lhs = [%pat? exception [%p? _]]; _} -> true
         | _ -> false)
     in
+    if cases = [] then
+        raise (Location.Error (
+          Location.errorf
+            ~loc:exp.pexp_loc
+            "match%%lwt must contain at least one non-exception pattern."
+        ));
     let exns =
       exns |> List.map (
         function

--- a/test/ppx_expect/cases/match_5.expect
+++ b/test/ppx_expect/cases/match_5.expect
@@ -1,0 +1,2 @@
+File "match_5.ml", line 2, characters 2-81:
+Error: match%lwt must contain at least one non-exception pattern.

--- a/test/ppx_expect/cases/match_5.ml
+++ b/test/ppx_expect/cases/match_5.ml
@@ -1,0 +1,3 @@
+let _ =
+  match%lwt Lwt.return () with
+  | exception (Invalid_argument _) -> Lwt.return 0

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -73,7 +73,7 @@ let () =
     Sys.cygwin = false && Sys.win32 = false &&
     (* 4.02.3 prints file paths differently *)
     Scanf.sscanf Sys.ocaml_version "%u.%u"
-      (fun major minor -> (major, minor) >= (4, 3))
+      (fun major minor -> (major, minor) >= (4, 4))
   in
   let suite = Test.suite "ppx_expect" (
     List.map (fun test_case ->


### PR DESCRIPTION
Fixes #596 

I guess this technically counts as a breaking change just in case someone was using the behaviour (even though it was incompatible with ocaml's).