### PR TITLE
fixed race condition in Lwt_react.E.limit

### DIFF
--- a/src/react/lwt_react.ml
+++ b/src/react/lwt_react.ml
@@ -52,7 +52,8 @@ module E = struct
              | None ->
                let cell = ref x in
                delayed := Some cell;
-               Lwt.on_success !limiter (fun () -> let x = !cell in delayed := None; limiter := f (); push x);
+               Lwt.on_success !limiter (fun () ->
+                   if Lwt.is_sleeping !limiter then delayed := None else let x = !cell in delayed := None; limiter := f (); push x);
                None
            end else begin
              (* Set the limiter for future events. *)

--- a/src/react/lwt_react.ml
+++ b/src/react/lwt_react.ml
@@ -53,7 +53,13 @@ module E = struct
                let cell = ref x in
                delayed := Some cell;
                Lwt.on_success !limiter (fun () ->
-                   if Lwt.is_sleeping !limiter then delayed := None else let x = !cell in delayed := None; limiter := f (); push x);
+                  if Lwt.is_sleeping !limiter then
+                    delayed := None
+                  else
+                    let x = !cell in
+                    delayed := None;
+                    limiter := f ();
+                    push x);
                None
            end else begin
              (* Set the limiter for future events. *)

--- a/test/react/test_lwt_event.ml
+++ b/test/react/test_lwt_event.ml
@@ -44,7 +44,7 @@ let suite = suite "lwt_event" [
        push 1;
        return (!l = [1]));
 
- test "limit_race"
+  test "limit_race"
     (fun () ->
        let l = ref [] in
        let event, push = Lwt_react.E.create() in
@@ -65,7 +65,7 @@ let suite = suite "lwt_event" [
        return (!l = [2;2;0]));
 
 
- test "of_stream"
+  test "of_stream"
     (fun () ->
        let stream, push = Lwt_stream.create () in
        let l = ref [] in

--- a/test/react/test_lwt_event.ml
+++ b/test/react/test_lwt_event.ml
@@ -44,7 +44,28 @@ let suite = suite "lwt_event" [
        push 1;
        return (!l = [1]));
 
-  test "of_stream"
+ test "limit_race"
+    (fun () ->
+       let l = ref [] in
+       let event, push = Lwt_react.E.create() in
+       let prepend n = l := n :: !l
+       in
+       event
+       |> Lwt_react.E.limit (fun () ->
+           let p = Lwt_unix.sleep 1. in
+           Lwt.async (fun () ->
+               Lwt_unix.sleep 0.1 >|= fun () ->
+               Lwt.on_success p (fun () -> push 2)); p)
+       |> React.E.map prepend
+       |> ignore;
+       push 0;
+       push 1;
+
+       Lwt_main.run (Lwt_unix.sleep 2.5);
+       return (!l = [2;2;0]));
+
+
+ test "of_stream"
     (fun () ->
        let stream, push = Lwt_stream.create () in
        let l = ref [] in


### PR DESCRIPTION
Now, the function that runs on success ensures that Lwt.is_sleeping is false before pushing the event. 