### PR TITLE
Fix `Lwt_stream.iter_p` to use `bind` and avoid stackoverflow

### DIFF
--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -888,7 +888,9 @@ let rec iter_p_rec node f s =
     match node.data with
     | Some x ->
       consume s node;
-      Lwt.join [f x; iter_p_rec node.next f s]
+      let res = f x in
+      let rest = iter_p_rec node.next f s in
+      res >>= fun () -> rest
     | None ->
       Lwt.return_unit
 


### PR DESCRIPTION
For #432 