### PR TITLE
discover.ml: do not pipe ocamlc through ocamlfind

### DIFF
--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -280,7 +280,7 @@ CAMLprim value lwt_test()
    | Compilation                                                     |
    +-----------------------------------------------------------------+ *)
 
-let ocamlc = ref "ocamlfind ocamlc"
+let ocamlc = ref "ocamlc"
 let ocamlc_config = ref ""
 let lwt_config = ref ""
 let ext_obj = ref ".o"


### PR DESCRIPTION
This seems to be the only dependency on ocamlfind left in the codebase, and is (I think) unused. With this patch, I can build Lwt without having ocamlfind installed (which is useful in a Dune monorepo)
