### PR TITLE
rfc: disable libev build by default in the discovery scripts

### DIFF
--- a/src/unix/config/configure.ml
+++ b/src/unix/config/configure.ml
@@ -34,20 +34,6 @@ let main () =
 
   let config_file = "lwt_config" in
 
-  begin match !default_configuration with
-  | Some true ->
-    (* Check if we have the opam command and conf-libev is installed. If so,
-       behave as if -use-libev true was passed. *)
-    if not @@ Sys.file_exists config_file then
-      if Sys.command "opam --version > /dev/null" = 0 then
-        if Sys.command "opam list --installed conf-libev > /dev/null" = 0 then
-          use_libev := Some true
-        else
-          use_libev := Some false
-  | _ ->
-    ()
-  end;
-
   let f = open_out config_file in
   let print name var =
     match var with


### PR DESCRIPTION
This simplifies the configure scripts to:

- disable libev build by default unless it is supplied on the configure line.  This does not affect most installations such as via opam (where the flag is explicitly specified depending on the presence of conf-libev) or OS packaging (where libev is typically a concrete dependency specified in the package data). However, this does make the build of Lwt much more portable by default when libev is not available.

- remove writing of setup.data, which seems to be vestigial from the oasis build days. Simplifies the discovery script.

- remove the auto-detection of libev on opam, which is not necessary since the opam package specifies it. Due to an unfortunate bug in opam 2.0.0 (ocaml/opam#3525) this is always true and so has different behaviour on opam1 vs 2.

The overall motivation for this PR is for embedding Lwt in the experimental [ocaml platform](https://github.com/avsm/platform) monorepo, which bootstraps on all supported OCaml platforms with just a C compiler.  It only needs libev for utop, and portability is significantly simpler if libev (and hence pkg-config) are not hard dependencies of this package for that purpose.

I'm opening this PR to discuss other options for out-of-the-box portability as well, in case I'm missing something far simpler!