### PR TITLE
default_config: work when opam 2.0 is installed

### DIFF
--- a/src/unix/config/dune
+++ b/src/unix/config/dune
@@ -1,6 +1,7 @@
 (executable
  (name configure)
  (modules configure)
+ (libraries unix)
  (flags (:standard)))
 
 (executable

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -136,7 +136,7 @@ else
     LIBEV_FLAG=false
 fi
 
-ocaml src/unix/config/configure.ml -use-libev $LIBEV_FLAG
+dune exec src/unix/config/configure.exe -- -use-libev $LIBEV_FLAG
 make build
 make test
 make coverage

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -147,14 +147,3 @@ make coverage
 make clean
 make install-for-packaging-test
 make packaging-test
-
-
-
-# Some sanity checks.
-if [ "$LIBEV" == no ]
-then
-    ! opam list -i conf-libev
-fi
-
-opam list -i ppx_tools_versioned
-! opam list -i batteries


### PR DESCRIPTION
opam 2.0.0 has different behaviour for `opam list` exit code,
and so always passes. This results in libev being activated
in the default configuration even when conf-libev is not installed.

This PR uses opam config variables instead, which appears to
work on opam 1 and 2.  Since stdout needs to be captured,
it requires the Unix module for configure.exe.

It also works in the case where `opam` is not initialised,
such as in the platform monorepo where opam and lwt are being
built together from the same source tree.

With this changeset, the platform repo builds successfully
on the OS matrix with and without libev installed.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>