### PR TITLE
fix condition in mincore

### DIFF
--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -240,7 +240,8 @@ external stub_mincore : t -> int -> int -> bool array -> unit = "lwt_unix_mincor
 let mincore buffer offset states =
   if (offset mod page_size <> 0
       || offset < 0
-      || offset > length buffer) then
+      || length buffer - offset >= (Array.length states - 1) * page_size + 1)
+  then
     invalid_arg "Lwt_bytes.mincore"
   else
     stub_mincore buffer offset (Array.length states * page_size) states

--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -240,7 +240,7 @@ external stub_mincore : t -> int -> int -> bool array -> unit = "lwt_unix_mincor
 let mincore buffer offset states =
   if (offset mod page_size <> 0
       || offset < 0
-      || length buffer - offset >= (Array.length states - 1) * page_size + 1)
+      || length buffer - offset < (Array.length states - 1) * page_size + 1)
   then
     invalid_arg "Lwt_bytes.mincore"
   else

--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -240,7 +240,7 @@ external stub_mincore : t -> int -> int -> bool array -> unit = "lwt_unix_mincor
 let mincore buffer offset states =
   if (offset mod page_size <> 0
       || offset < 0
-      || offset > length buffer - (Array.length states * page_size)) then
+      || offset > length buffer) then
     invalid_arg "Lwt_bytes.mincore"
   else
     stub_mincore buffer offset (Array.length states * page_size) states


### PR DESCRIPTION
@aantron, 

#625 

I started to try to understand the behavior with different cases : 

when the last condition is : `offset > length buffer - (Array.length states * page_size)`

```ocaml
case where mem_len is > buffer_len

	buff_len = 6 offset = 0  pages = 1
		offset = 0
		mem_len = 1*4096
		offset > (buff_len - mem_len < 0) -> true -> Error

        buff_len = 4096 + 6 offset = 0  pages = 2
		offset = 0
		mem_len = 2*4096
		offset > (buff_len - mem_len < 0) -> true -> Error

	buff_len = 4096 + 6 offset = 4096 pages = 2
		offset = 4096
		mem_len = 2*4096
		offset > (buff_len - mem_len) < 0 -> true ->  Error

case where mem_len is < buffer_len

	buff_len = 4096 + 6 offset = 0 pages = 1
		offset = 0
		mem_len = 1*4096
		offset > buff_len - mem_len = 6  -> false -> ok

	buff_len = 4096 + 6 offset = 4096 pages = 1
		offset = 4096
		mem_len = 1*4096
		offset > (buff_len - mem_len) = 6 -> true ->  Error
```

and instead of *we need to change the check to allow the last page queried to only partially overlap the buffer.* like you said, I thought that we just have to be sure that the offset is not greater than the buffer length.
I have done the tests with the last condition `offset > buffer length` and it works as expected. 

```ocaml
case where mem_len is > buffer_len

	buff_len = 6 offset = 0  pages = 1
		offset = 0
		mem_len = 1*4096
		offset > buff_len -> false -> ok

        buff_len = 4096 + 6 offset = 0  pages = 2
		offset = 0
		mem_len = 2*4096
		offset > buff_len -> false -> ok

	buff_len = 4096 + 6 offset = 4096 pages = 2
		offset = 4096
		mem_len = 2*4096
		offset > buff_len > 0 -> false -> ok

case where mem_len is < buffer_len

	buff_len = 4096 + 6 offset = 0 pages = 1
		offset = 0
		mem_len = 1*4096
		offset > buff_len -> false -> ok

	buff_len = 4096 + 6 offset = 4096 pages = 1
		offset = 4096
		mem_len = 1*4096
		offset > buff_len -> false -> ok
```

I send this PR first for validation, then I will send you another PR with the tests for all the IO part of `Lwt_bytes`.