### PR TITLE
Expose Lwt_io.is_closed

### DIFF
--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -191,6 +191,10 @@ val is_busy : 'a channel -> bool
       busy. A channel is busy when there is at least one job using it
       that has not yet terminated. *)
 
+val is_closed : 'a channel -> bool
+  (** [is_closed channel] returns whether the given channel is currently
+      closed. *)
+
 (** {2 Random access} *)
 
 val position : 'a channel -> int64


### PR DESCRIPTION
This PR exposes `Lwt_io.is_closed`. The intent is for this to be analogous to [`Async_unix.Reader.is_closed`](https://ocaml.janestreet.com/ocaml-core/latest/doc/async_unix/Async_unix/Reader/#val-is_closed).