### PR TITLE
Fix Lwt_io.of_bytes

### DIFF
--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -545,30 +545,38 @@ let make :
    | Output -> Outputs.add outputs wrapper);
   wrapper
 
-let of_bytes ~mode bytes =
-  let length = Lwt_bytes.length bytes in
-  let abort_waiter, abort_wakener = Lwt.wait () in
-  let rec ch = {
-    buffer = bytes;
-    length = length;
-    ptr = 0;
-    max = length;
-    close = lazy(Lwt.return_unit);
-    abort_waiter = abort_waiter;
-    abort_wakener = abort_wakener;
-    main = wrapper;
-    (* Auto flush is set to [true] to prevent writing functions from
-       trying to launch the auto-fllushed. *)
-    auto_flushing = true;
-    mode = mode;
-    offset = 0L;
-    typ = Type_bytes;
-  } and wrapper = {
-    state = Idle;
-    channel = ch;
-    queued = Lwt_sequence.create ();
-  } in
-  wrapper
+let of_bytes :
+  type m.
+  mode : m mode ->
+  Lwt_bytes.t ->
+  m channel
+  =
+  fun ~mode bytes ->
+    let length = Lwt_bytes.length bytes in
+    let abort_waiter, abort_wakener = Lwt.wait () in
+    let rec ch = {
+      buffer = bytes;
+      length = length;
+      ptr = 0;
+      max = length;
+      close = lazy(Lwt.return_unit);
+      abort_waiter = abort_waiter;
+      abort_wakener = abort_wakener;
+      main = wrapper;
+      (* Auto flush is set to [true] to prevent writing functions from
+         trying to launch the auto-fllushed. *)
+      auto_flushing = true;
+      mode = mode;
+      offset = (match mode with
+          | Output -> 0L
+          | Input -> Int64.of_int length);
+      typ = Type_bytes;
+    } and wrapper = {
+        state = Idle;
+        channel = ch;
+        queued = Lwt_sequence.create ();
+      } in
+    wrapper
 
 let of_fd :
     type m.

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -366,4 +366,44 @@ let suite = suite "lwt_io" [
         Lwt.return true
       | exn -> Lwt.fail exn)
   end;
+
+  test "input channel of_bytes inital position"
+    (fun () ->
+       let ichan = Lwt_io.of_bytes ~mode:Lwt_io.input @@ Lwt_bytes.of_string "abcd" in
+       Lwt.return (Lwt_io.position ichan = 0L)
+    );
+
+  test "input channel of_bytes position after read"
+    (fun () ->
+       let ichan = Lwt_io.of_bytes ~mode:Lwt_io.input @@ Lwt_bytes.of_string "abcd" in
+       Lwt_io.read_char ichan >|= fun _ ->
+       Lwt_io.position ichan = 1L
+    );
+
+  test "input channel of_bytes position after set_position"
+    (fun () ->
+       let ichan = Lwt_io.of_bytes ~mode:Lwt_io.input @@ Lwt_bytes.of_string "abcd" in
+       Lwt_io.set_position ichan 2L >|= fun () ->
+       Lwt_io.position ichan = 2L
+    );
+
+  test "output channel of_bytes inital position"
+    (fun () ->
+       let ochan = Lwt_io.of_bytes ~mode:Lwt_io.output @@ Lwt_bytes.create 4 in
+       Lwt.return (Lwt_io.position ochan = 0L)
+    );
+
+  test "output channel of_bytes position after read"
+    (fun () ->
+       let ochan = Lwt_io.of_bytes ~mode:Lwt_io.output @@ Lwt_bytes.create 4 in
+       Lwt_io.write_char ochan 'a' >|= fun _ ->
+       Lwt_io.position ochan = 1L
+    );
+
+  test "output channel of_bytes position after set_position"
+    (fun () ->
+       let ochan = Lwt_io.of_bytes ~mode:Lwt_io.output @@ Lwt_bytes.create 4 in
+       Lwt_io.set_position ochan 2L >|= fun _ ->
+       Lwt_io.position ochan = 2L
+    );
 ]


### PR DESCRIPTION
Fixes #636

My understanding is that it's `offset` that's improperly set in `Lwt_io.of_bytes`. Since `Lwt_bytes` based channels just use the `Lwt_bytes` straight as their internal buffer and never actually perform any io, `offset` is never updated. That means we can consider that everything has been already read in case of an input channel since it's already in the internal buffer. In the output channel case, writing to the internal buffer is sufficient and we never need to flush meaning offset should be set to the end of the buffer here as well.

Let me know if that seems right to you!

I'd like to add some tests for this. They should be in `ls test/unix/test_lwt_io.ml` right ?
I was thinking about testing the initial position after creating a channel from bytes. Let me know if you have any brighter ideas for good tests here!