### PR TITLE
Add Lwt_stream.of_seq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ dev-deps :
 	  ppx_tools_versioned \
 	  react \
 	  result \
+	  seq \
 
 # Use Dune+odoc to generate static html documentation.
 # Currenty requires ocaml 4.03.0 to install odoc.

--- a/lwt.opam
+++ b/lwt.opam
@@ -29,6 +29,8 @@ depends: [
   "dune" {build}
   # result is needed as long as Lwt still supports OCaml 4.02.
   "result"
+  # seq is needed as long as Lwt still supports OCaml < 4.07.0
+  "seq"
 ]
 depopts: [
   "base-threads"

--- a/src/core/dune
+++ b/src/core/dune
@@ -4,5 +4,5 @@
  (synopsis "Monadic promises and concurrent I/O")
  (wrapped false)
  (preprocess (pps bisect_ppx -conditional))
- (libraries bytes result)
+ (libraries bytes result seq)
  (flags (:standard -w +A-29)))

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -187,6 +187,15 @@ let create_with_reference () =
   in
   (t, push, fun x -> source.push_external <- Obj.repr x)
 
+let of_seq s =
+  let s = ref s in
+  let get () =
+    match !s () with
+    | Seq.Nil -> None
+    | Seq.Cons (elt, s') -> s := s'; Some elt
+  in
+  from_direct get
+
 let create () =
   let source, push, _ = create_with_reference () in
   (source, push)

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -122,6 +122,10 @@ val create_bounded : int -> 'a t * 'a bounded_push
 
     It raises [Invalid_argument] if [size < 0]. *)
 
+val of_seq : 'a Seq.t -> 'a t
+(** [of_seq s] creates a stream returning all elements of [s]. The elements are
+    evaluated from [s] and pushed onto the stream as the stream is consumed. *)
+
 val of_list : 'a list -> 'a t
 (** [of_list l] creates a stream returning all elements of [l]. The elements are
     pushed into the stream immediately, resulting in a closed stream (in the

--- a/test/core/test_lwt_stream.ml
+++ b/test/core/test_lwt_stream.ml
@@ -33,13 +33,19 @@ let suite = suite "lwt_stream" [
 
   test "of_seq"
     (fun () ->
-       let seq = fun () -> Seq.Cons (1, Seq.empty) in
+       let x = ref false in
+       let nil = fun () -> x := not !x; Seq.Nil in
+       let seq = fun () -> Seq.Cons (1, nil) in
        let stream = Lwt_stream.of_seq seq in
+       let x_before = !x in
        let closed_before = Lwt_stream.is_closed stream in
        Lwt_stream.get stream >>= fun x1 ->
+       let x_middle = !x in
        Lwt_stream.get stream >>= fun x2 ->
+       let x_after = !x in
        let closed_after = Lwt_stream.is_closed stream in
        return ([closed_before; closed_after] = [false; true]
+               && [x_before; x_middle; x_after] = [false; false; true]
                && [x1; x2] = [Some 1; None]));
 
   test "of_list"

--- a/test/core/test_lwt_stream.ml
+++ b/test/core/test_lwt_stream.ml
@@ -31,6 +31,17 @@ let suite = suite "lwt_stream" [
        t3 >>= fun x3 ->
        return ([x1; x2; x3] = [1; 1; 1]));
 
+  test "of_seq"
+    (fun () ->
+       let seq = fun () -> Seq.Cons (1, Seq.empty) in
+       let stream = Lwt_stream.of_seq seq in
+       let closed_before = Lwt_stream.is_closed stream in
+       Lwt_stream.get stream >>= fun x1 ->
+       Lwt_stream.get stream >>= fun x2 ->
+       let closed_after = Lwt_stream.is_closed stream in
+       return ([closed_before; closed_after] = [false; true]
+               && [x1; x2] = [Some 1; None]));
+
   test "of_list"
     (fun () ->
        let stream = Lwt_stream.of_list [1; 2; 3] in


### PR DESCRIPTION
The Seq module is in stdlib since OCaml 4.07.0 and there is a seq
compatibility package available on opam for older versions of OCaml.

`Lwt_stream.of_seq` gives us a way to lazily traverse a `_ Seq.t` via `Lwt_stream`.