### PR TITLE
Lwt_unix: missing header on Android

### DIFF
--- a/src/unix/unix_c/unix_wait4.c
+++ b/src/unix/unix_c/unix_wait4.c
@@ -90,6 +90,8 @@ value lwt_unix_wait4(value flags, value pid_req)
 
 #else
 
+#include "lwt_unix.h"
+
 LWT_NOT_AVAILABLE2(unix_wait4)
 
 #endif


### PR DESCRIPTION
Building lwt on Android currently fails because the macro `LWT_NOT_AVAILABLE2` from `lwt_unix.h` is not included in `unix_wait4.c`.