### PR TITLE
check for duplicate test names per suite

### DIFF
--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2060,7 +2060,7 @@ let nchoose_split_tests = suite "nchoose_split" [
     end [@ocaml.warning "-4"]
   end;
 
-  test "pending, rejected" begin fun () ->
+  test "pending, rejected 2" begin fun () ->
     let p, r = Lwt.wait () in
     let p = Lwt.nchoose_split [p; fst (Lwt.wait ())] in
     Lwt.wakeup_exn r Exception;

--- a/test/core/test_lwt_list.ml
+++ b/test/core/test_lwt_list.ml
@@ -221,12 +221,6 @@ let suite_primary = suite "lwt_list" [
   test "for_all_p"
     (fun () -> test_for_all_true Lwt_list.for_all_p);
 
-  test "for_all_s"
-    (fun () -> test_for_all_false Lwt_list.for_all_s);
-
-  test "for_all_p"
-    (fun () -> test_for_all_false Lwt_list.for_all_p);
-
   test "exists_s true"
     (fun () -> test_exists_true Lwt_list.exists_s);
 
@@ -540,11 +534,6 @@ let suite_primary = suite "lwt_list" [
     test_serialization m
   end;
 
-  test "filter_map_p parallelism" begin fun () ->
-    let m f =
-      Lwt_list.filter_map_p (fun x -> f x >>= fun u -> Lwt.return (Some u)) in
-    test_parallelism m
-  end;
 
   test "filter_map_s serialization" begin fun () ->
     let m f =

--- a/test/unix/test_lwt_io_non_block.ml
+++ b/test/unix/test_lwt_io_non_block.ml
@@ -39,14 +39,9 @@ let suite = suite "lwt_io non blocking io" [
   test "file exists"
     (fun () -> Lwt_unix.file_exists test_file);
 
-  test "file does not exist (invalid path)"
-    (fun () -> Lwt_unix.file_exists (test_file ^ "/foo") >|= fun r -> not r);
-
   test "file exists (LargeFile)"
     (fun () -> Lwt_unix.LargeFile.file_exists test_file);
 
-  test "file does not exist (LargeFile, invalid path)"
-    (fun () -> Lwt_unix.LargeFile.file_exists (test_file ^ "/foo") >|= fun r -> not r);
 
   test "read file"
     (fun () ->


### PR DESCRIPTION
Here's some sample output: (with 2 tests modified to use the name `basic take`)

```
$ make test
dune build
dune runtest -j 1 --no-buffer
Done: 890/904 (jobs: 1)Fatal error: exception Test.Duplicate_Test_Names("suite:lwt_mvar test:basic take")
        main alias test/core/runtest (exit 2)
(cd _build/default/test/core && ./main.exe)
Done: 891/904 (jobs: 1)Testing library 'ppx'...
.................
```

### Notes
- I realize that `contains_dup_tests` is Not Very Efficient, but it seemed like a simple implementation so I kept it.
- I removed/renamed a few tests that were flagged as duplicates
- closes #632 