### PR TITLE
Travis: test on 4.08.0+beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
     - os: linux
       env: COMPILER=4.07.1
     - os: linux
-      env: COMPILER=4.07.1 FLAMBDA=yes
+      env: COMPILER=ocaml-variants.4.07.1+flambda
+    - os: linux
+      env: COMPILER=ocaml-variants.4.08.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
     - os: osx
       env: COMPILER=4.07.1
     - os: osx

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -39,15 +39,9 @@ packages
 
 
 
-if [ "$FLAMBDA" = yes ]
-then
-    COMPILER="$COMPILER+flambda"
-fi
-
-
-
 # Initialize opam.
-opam init -y --compiler=$COMPILER --disable-sandboxing --disable-shell-hook
+opam init -y --bare --disable-sandboxing --disable-shell-hook
+opam switch create . $COMPILER $REPOSITORIES --no-install
 eval `opam env`
 opam --version
 ocaml -version


### PR DESCRIPTION
This is currently blocked on ocamlbuild not having a compatible release, see https://github.com/ocaml/ocamlbuild/issues/294. ocamlbuild is an indirect dependency of `lwt_react`, which we test in Travis.