### PR TITLE
OpenBSD no longer has mincore syscall - add required #ifdef dance

### DIFF
--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -19,7 +19,7 @@
 LWT_NOT_AVAILABLE4(unix_mincore)
 #elif defined __OpenBSD__
 #include <sys/param.h>
-#if OpenBSD >= 201811
+#if OpenBSD >= 201805
 LWT_NOT_AVAILABLE4(unix_mincore)
 #endif
 #else

--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -22,7 +22,6 @@ LWT_NOT_AVAILABLE4(unix_mincore)
 #if !defined SYS_mincore
 LWT_NOT_AVAILABLE4(unix_mincore)
 #endif
-#endif
 #else
 
 #ifdef HAVE_BSD_MINCORE

--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -18,9 +18,10 @@
 #ifdef __CYGWIN__
 LWT_NOT_AVAILABLE4(unix_mincore)
 #elif defined __OpenBSD__
-#include <sys/param.h>
-#if OpenBSD >= 201805
+#include <sys/syscall.h>
+#if !defined SYS_mincore
 LWT_NOT_AVAILABLE4(unix_mincore)
+#endif
 #endif
 #else
 

--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -12,10 +12,13 @@
 #include <caml/bigarray.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <sys/param.h>
 
 #include "lwt_unix.h"
 
 #ifdef __CYGWIN__
+LWT_NOT_AVAILABLE4(unix_mincore)
+#elif defined(__OPENBSD__) && OpenBSD >= 201811
 LWT_NOT_AVAILABLE4(unix_mincore)
 #else
 

--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -12,14 +12,16 @@
 #include <caml/bigarray.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <sys/param.h>
 
 #include "lwt_unix.h"
 
 #ifdef __CYGWIN__
 LWT_NOT_AVAILABLE4(unix_mincore)
-#elif defined(__OPENBSD__) && OpenBSD >= 201811
+#elif defined __OpenBSD__
+#include <sys/param.h>
+#if OpenBSD >= 201811
 LWT_NOT_AVAILABLE4(unix_mincore)
+#endif
 #else
 
 #ifdef HAVE_BSD_MINCORE


### PR DESCRIPTION
OpenBSD issued an errata on January 27, 2019 to remove the mincore syscall:

 011: SECURITY FIX: January 27, 2019   All architectures
The mincore() system call can be used to observe memory access patterns of other processes.
A source code patch exists which remedies this problem.

The actual patch for 6.4 is here:

https://ftp.openbsd.org/pub/OpenBSD/patches/6.4/common/011_mincore.patch.sig

This branch allows lwt to compile on OpenBSD -current and 6.4 with the errata applied.

To make lwt compile on patched 6.3, the condition would be OpenBSD >= 201805.

I just run -current so I used >= 201811.