### PR TITLE
respect MAKE, properly test for mincore, fdatasync is in <unistd.h>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ doc:
 # Build HTML documentation with ocamldoc
 .PHONY: doc-api-html
 doc-api-html: build-all
-	make -C docs api/html/index.html
+	$(MAKE) -C docs api/html/index.html
 
 # Build wiki documentation with wikidoc
 # requires ocaml 4.03.0 and pinning the repo
 # https://github.com/ocsigen/wikidoc
 .PHONY: doc-api-wiki
 doc-api-wiki: build-all
-	make -C docs api/wiki/index.wiki
+	$(MAKE) -C docs api/wiki/index.wiki
 
 # Packaging tests. These are run with Lwt installed by OPAM, typically during
 # CI. To run locally, run the install-for-packaging-test target first.
@@ -51,7 +51,7 @@ packaging-test:
 	ocamlfind query lwt
 	for TEST in `ls -d test/packaging/*/*` ; \
 	do \
-	    make -wC $$TEST || exit 1 ; \
+	    $(MAKE) -wC $$TEST || exit 1 ; \
 		echo ; \
 		echo ; \
 	done
@@ -78,7 +78,7 @@ clean:
 	rm -f src/jbuild-ignore src/unix/lwt_config
 	for TEST in `ls -d test/packaging/*/*` ; \
 	do \
-	    make -wC $$TEST clean ; \
+	    $(MAKE) -wC $$TEST clean ; \
 	done
 	rm -rf _coverage/
 
@@ -86,7 +86,7 @@ BISECT_FILES_PATTERN := _build/default/test/*/bisect*.out
 
 .PHONY: coverage
 coverage: clean
-	BISECT_ENABLE=yes make build
+	BISECT_ENABLE=yes $(MAKE) build
 	BISECT_ENABLE=yes dune runtest -j 1 --no-buffer
 	bisect-ppx-report \
 	    -I _build/default/ -html _coverage/ \

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -264,14 +264,29 @@ CAMLprim value lwt_test() {
 }
 "
 
-let bsd_mincore_code = "
+let mincore_code =
+"
 #include <unistd.h>
 #include <sys/mman.h>
 #include <caml/mlvalues.h>
 
 CAMLprim value lwt_test()
 {
-    int (*mincore_ptr)(const void*, size_t, char*) = mincore;
+    mincore(NULL, 0, NULL);
+    return Val_unit;
+}
+"
+
+let mincore_type_code =
+Printf.sprintf
+"
+#include <unistd.h>
+#include <sys/mman.h>
+#include <caml/mlvalues.h>
+
+CAMLprim value lwt_test()
+{
+    int (*mincore_ptr)(%s *, size_t, %s *) = mincore;
     return Val_int(mincore_ptr == mincore_ptr);
 }
 "
@@ -725,8 +740,14 @@ Lwt can use pthread or the win32 API.
     "netdb_reentrant" "HAVE_NETDB_REENTRANT" (fun () -> test_code ([], []) netdb_reentrant_code);
   test_feature ~do_check "reentrant gethost*" "HAVE_REENTRANT_HOSTENT" (fun () -> test_code ([], []) hostent_reentrant_code);
   test_nanosecond_stat ();
-  test_feature ~do_check "BSD mincore" "HAVE_BSD_MINCORE" (fun () ->
-    test_code (["-Werror"], []) bsd_mincore_code);
+  test_feature ~do_check "mincore" "HAVE_MINCORE" (fun () ->
+    test_code (["-Werror"], []) mincore_code);
+  test_feature ~do_check "mincore (char array)" "CHAR_MINCORE" (fun () ->
+    test_code (["-Werror"], []) (mincore_type_code "void"       "char") ||
+    test_code (["-Werror"], []) (mincore_type_code "const void" "char"));
+  test_feature ~do_check "mincore (unsigned char array)" "UCHAR_MINCORE" (fun () ->
+    test_code (["-Werror"], []) (mincore_type_code "void"       "unsigned char") ||
+    test_code (["-Werror"], []) (mincore_type_code "const void" "unsigned char"));
 
   let get_cred_vars = [
     "HAVE_GET_CREDENTIALS_LINUX";

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -188,7 +188,7 @@ CAMLprim value lwt_test(value Unit)
 
 let fdatasync_code = "
 #include <caml/mlvalues.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 CAMLprim value lwt_test(value Unit)
 {

--- a/src/unix/unix_c/unix_mincore.c
+++ b/src/unix/unix_c/unix_mincore.c
@@ -15,19 +15,14 @@
 
 #include "lwt_unix.h"
 
-#ifdef __CYGWIN__
-LWT_NOT_AVAILABLE4(unix_mincore)
-#elif defined __OpenBSD__
-#include <sys/syscall.h>
-#if !defined SYS_mincore
-LWT_NOT_AVAILABLE4(unix_mincore)
-#endif
-#else
+#if defined HAVE_MINCORE
 
-#ifdef HAVE_BSD_MINCORE
+#if defined CHAR_MINCORE
 #define MINCORE_VECTOR_TYPE char
-#else
+#elif defined UCHAR_MINCORE
 #define MINCORE_VECTOR_TYPE unsigned char
+#else
+#error "Unknown vector type"
 #endif
 
 CAMLprim value lwt_unix_mincore(value val_buffer, value val_offset,
@@ -43,6 +38,9 @@ CAMLprim value lwt_unix_mincore(value val_buffer, value val_offset,
 }
 
 #undef MINCORE_VECTOR_TYPE
+
+#else
+LWT_NOT_AVAILABLE4(unix_mincore)
 
 #endif
 


### PR DESCRIPTION
* directly calling ``make`` will break on systems where GNU make is called ``gmake`` and ``make`` actually is BSD make.

* ``fdatasync`` is defined in ``<unistd.h>`` on OpenBSD. According to https://linux.die.net/man/2/fdatasync the same is true for linux.

* I found out about d791b9bd only after I adjusted ``discover.ml`` to check for availability of ``mincore``. I'd suggest to rather test for the actual feature than to test for OS. Only tested on OpenBSD, where ``mincore`` is _not_ available. So testing on Linux and maybe some other BSD, maybe Cygwin should still be done.