### PR TITLE
unix_termios_conversion.c: Support for higher baud rates.

### DIFF
--- a/src/unix/unix_c/unix_termios_conversion.c
+++ b/src/unix/unix_c/unix_termios_conversion.c
@@ -48,6 +48,9 @@ static struct {
                   {B110, 110},
                   {B134, 134},
                   {B150, 150},
+#ifdef B200
+                  {B200, 200},
+#endif
                   {B300, 300},
                   {B600, 600},
                   {B1200, 1200},
@@ -66,7 +69,68 @@ static struct {
 #ifdef B230400
                   {B230400, 230400},
 #endif
-                  {B0, 0}};
+                  {B0, 0},
+
+                  /* Linux extensions */
+#ifdef B460800
+                  {B460800, 460800},
+#endif
+#ifdef B500000
+                  {B500000, 500000},
+#endif
+#ifdef B576000
+                  {B576000, 576000},
+#endif
+#ifdef B921600
+                  {B921600, 921600},
+#endif
+#ifdef B1000000
+                  {B1000000, 1000000},
+#endif
+#ifdef B1152000
+                  {B1152000, 1152000},
+#endif
+#ifdef B1500000
+                  {B1500000, 1500000},
+#endif
+#ifdef B2000000
+                  {B2000000, 2000000},
+#endif
+#ifdef B2500000
+                  {B2500000, 2500000},
+#endif
+#ifdef B3000000
+                  {B3000000, 3000000},
+#endif
+#ifdef B3500000
+                  {B3500000, 3500000},
+#endif
+#ifdef B4000000
+                  {B4000000, 4000000},
+#endif
+
+                  /* MacOS extensions */
+#ifdef B7200
+                  {B7200, 7200},
+#endif
+#ifdef B14400
+                  {B14400, 14400},
+#endif
+#ifdef B28800
+                  {B28800, 28800},
+#endif
+#ifdef B76800
+                  {B76800, 76800},
+#endif
+
+  /* Cygwin extensions (in addition to the Linux ones) */
+#ifdef B128000
+                  {B128000, 128000},
+#endif
+#ifdef B256000
+                  {B256000, 256000},
+#endif
+};
 
 #define NSPEEDS (sizeof(speedtable) / sizeof(speedtable[0]))
 


### PR DESCRIPTION
This makes Lwt_unix.tcsetattr/tcgetattr functions compatible with the corresponding Unix library functions at higher baudrates.

These extra baudrates are in OCaml's standard library since v.4.02 (see https://github.com/ocaml/ocaml/issues/6781 for details). Code is taken directly from there.