### PR TITLE
Esy compatibility for libev detection

### DIFF
--- a/src/unix/config/configure.ml
+++ b/src/unix/config/configure.ml
@@ -52,7 +52,7 @@ let main () =
         use_libev := Some false
       | exception Not_found ->
         use_libev := Some false
-      | flags, libs -> ()
+      | _flags, _libs -> ()
   end
   | _ ->
     ()

--- a/src/unix/config/configure.ml
+++ b/src/unix/config/configure.ml
@@ -45,7 +45,14 @@ let main () =
       match input_line ch with
       |"true" -> use_libev := Some true
       |_ -> use_libev := Some false
-    with _ -> use_libev := Some false
+    with _ ->
+      (* Esy users won't have opam installed in the esy sandbox. *)
+      match Sys.getenv "LIBEV_CFLAGS", Sys.getenv "LIBEV_LIBS" with
+      | "", "" ->
+        use_libev := Some false
+      | exception Not_found ->
+        use_libev := Some false
+      | flags, libs -> ()
   end
   | _ ->
     ()


### PR DESCRIPTION
Esy does not have an `opam` binary in the path, and the libev detection introduced in https://github.com/ocsigen/lwt/commit/c1e48e4807c3742bad632dc5905c71a815e5f042 and released in 4.2.0 does not work with esy.

The proposed fix defaults to looking for the environment variables that the libev packages for esy sets (https://github.com/esy-packages/libev/blob/master/package.json#L16-L26)