### PR TITLE
Fixing typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -682,7 +682,7 @@ See #453 for details and instructions about planned breakage in Lwt 4.0.0.
   * Allow to use {{{select}}} on arbitrary high file descriptors
   * More commands and features in {{{Lwt_read_line}}}:
     ** Handle "undo" command
-    ** New controlable read-lines instances
+    ** New controllable read-lines instances
     ** More edition commands
     ** Completion as you type
     ** Backward search

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -96,12 +96,12 @@
    "aspects," which are *not* necessary to understand the main mechanism
    promises, but they are still there:
 
-   - promise cancelation
+   - promise cancellation
    - sequence-associated storage
 
-   If you are not interested in cancelation or storage, you can ignore these two
+   If you are not interested in cancellation or storage, you can ignore these two
    complications, and still get a pretty good understanding of the code. To
-   help, all identifiers related to cancelation contain the string "cancel," and
+   help, all identifiers related to cancellation contain the string "cancel," and
    all identifiers related to storage contain "storage."
 
 
@@ -145,13 +145,13 @@
 
        For example, [Lwt.bind]. These promises only are only resolved when the
        preceding sequence of promises resolves. The user cannot resolve these
-       promises directly (but see the section on cancelation below).
+       promises directly (but see the section on cancellation below).
 
      - Concurrent composition
 
        For example, [Lwt.join] or [Lwt.choose]. These promises are only resolved
        when all or one of a set of "preceding" promises resolve. The user cannot
-       resolve these promises directly (but see the section on cancelation
+       resolve these promises directly (but see the section on cancellation
        below).
 
 
@@ -183,8 +183,8 @@
    - all cancel callbacks of a promise are called before any regular callback
      is called.
 
-   Cancelation is a special case of resolution, in particular, a special case of
-   rejection, but see the section on cancelation later below.
+   Cancellation is a special case of resolution, in particular, a special case of
+   rejection, but see the section on cancellation later below.
 
 
    4. Resolution loop
@@ -207,23 +207,23 @@
    callback to resolve another initial promise. All the explicit dependencies
    are created by Lwt's own sequential and concurrent composition functions
    (so, [Lwt.bind], [Lwt.join], etc). Whether dependencies are explicit or not
-   is relevant only to cancelation.
+   is relevant only to cancellation.
 
 
-   5. Cancelation
+   5. Cancellation
 
    As described above, ordinary promise resolution proceeds from an initial
    promise, forward along callbacks through the dependency graph. Since it
    starts from an initial promise, it can only be triggered using a resolver.
 
-   Cancelation is a sort of dual to ordinary resolution. Instead of starting at
-   an initial promise/resolver, cancelation starts at *any* promise. It then
+   Cancellation is a sort of dual to ordinary resolution. Instead of starting at
+   an initial promise/resolver, cancellation starts at *any* promise. It then
    goes *backwards* through the explicit dependency graph, looking for
    cancelable initial promises to cancel -- those that were created by
-   [Lwt.task]. After finding them, cancelation resolves them normally with
+   [Lwt.task]. After finding them, cancellation resolves them normally with
    [Rejected Lwt.Canceled], causing an ordinary promise resolution process.
 
-   To summarize, cancelation is a way to trigger an *ordinary* resolution of
+   To summarize, cancellation is a way to trigger an *ordinary* resolution of
    promises created with [Lwt.task], by first searching for them in the promise
    dependency graph (which is assembled by [Lwt.bind], [Lwt.join], etc).
 
@@ -244,7 +244,7 @@
    susceptible to being canceled by [Lwt.cancel], but the user can manually
    cancel initial promises created by both [Lwt.task] and [Lwt.wait].
 
-   Due to [Lwt.cancel], promise cancelation, and therefore resolution, can be
+   Due to [Lwt.cancel], promise cancellation, and therefore resolution, can be
    initiated by the user without access to a resolver. This is important for
    reasoning about state changes in the implementation of Lwt, and is referenced
    in some implementation detail comments.
@@ -493,7 +493,7 @@ struct
        memory representation.
 
      - As per the Overview, there are regular callbacks and cancel callbacks.
-       Cancel callbacks are called only on cancelation, and, then, before any
+       Cancel callbacks are called only on cancellation, and, then, before any
        regular callbacks are called.
 
        Despite the different types for the two kinds of callbacks, they are
@@ -698,7 +698,7 @@ struct
      They do not return a corresponding resolver. That means that only the
      function itself (typically, a callback registered by it) can resolve [p].
      The only thing the user can do directly is try to cancel [p], but, since
-     [p] is not an initial promise, the cancelation attempt simply propagates
+     [p] is not an initial promise, the cancellation attempt simply propagates
      past [p] to [p]'s predecessors. If that eventually results in canceling
      [p], it will be through the normal mechanisms of the function (e.g.
      [Lwt.bind]'s callback).
@@ -1435,8 +1435,8 @@ struct
        through the promise dependency graph.
 
        The callbacks of these initial promises are then run, in a separate
-       phase. These callbacks propagate cancelation forwards to any dependent
-       promises. See "Cancelation" in the Overview. *)
+       phase. These callbacks propagate cancellation forwards to any dependent
+       promises. See "Cancellation" in the Overview. *)
     let propagate_cancel : (_, _, _) promise -> packed_callbacks list =
         fun p ->
       let rec cancel_and_collect_callbacks :
@@ -1763,7 +1763,7 @@ struct
      becomes resolved probably are:
 
      - Promises have more behaviors than resolution. One would have to add a
-       cancelation handler to [~outer_promise] to propagate the cancelation back
+       cancellation handler to [~outer_promise] to propagate the cancellation back
        to [~user_provided_promise], for example. It may be easier to just think
        of them as the same promise.
      - If using callbacks, resolving [~user_provided_promise] would not
@@ -1849,7 +1849,7 @@ struct
       (* The result promise is a fresh pending promise.
 
          Initially, trying to cancel this fresh pending promise [p''] will
-         propagate the cancelation attempt to [p] (backwards through the promise
+         propagate the cancellation attempt to [p] (backwards through the promise
          dependency graph). If/when [p] is fulfilled, Lwt will call the user's
          callback [f] below, which will provide a new promise [p'], and [p']
          will become a proxy of [p'']. At that point, trying to cancel [p'']

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -99,10 +99,10 @@
    - promise cancellation
    - sequence-associated storage
 
-   If you are not interested in cancellation or storage, you can ignore these two
-   complications, and still get a pretty good understanding of the code. To
-   help, all identifiers related to cancellation contain the string "cancel," and
-   all identifiers related to storage contain "storage."
+   If you are not interested in cancellation or storage, you can ignore these
+   two complications, and still get a pretty good understanding of the code. To
+   help, all identifiers related to cancellation contain the string "cancel,"
+   and all identifiers related to storage contain "storage."
 
 
    1. Promises
@@ -183,8 +183,8 @@
    - all cancel callbacks of a promise are called before any regular callback
      is called.
 
-   Cancellation is a special case of resolution, in particular, a special case of
-   rejection, but see the section on cancellation later below.
+   Cancellation is a special case of resolution, in particular, a special case
+   of rejection, but see the section on cancellation later below.
 
 
    4. Resolution loop
@@ -1763,9 +1763,9 @@ struct
      becomes resolved probably are:
 
      - Promises have more behaviors than resolution. One would have to add a
-       cancellation handler to [~outer_promise] to propagate the cancellation back
-       to [~user_provided_promise], for example. It may be easier to just think
-       of them as the same promise.
+       cancellation handler to [~outer_promise] to propagate the cancellation
+       back to [~user_provided_promise], for example. It may be easier to just
+       think of them as the same promise.
      - If using callbacks, resolving [~user_provided_promise] would not
        immediately resolve [~outer_promise]. Another callback added to
        [~user_provided_promise] might see [~user_provided_promise] resolved,
@@ -1849,11 +1849,11 @@ struct
       (* The result promise is a fresh pending promise.
 
          Initially, trying to cancel this fresh pending promise [p''] will
-         propagate the cancellation attempt to [p] (backwards through the promise
-         dependency graph). If/when [p] is fulfilled, Lwt will call the user's
-         callback [f] below, which will provide a new promise [p'], and [p']
-         will become a proxy of [p'']. At that point, trying to cancel [p'']
-         will be equivalent to trying to cancel [p'], so the behavior will
+         propagate the cancellation attempt to [p] (backwards through the
+         promise dependency graph). If/when [p] is fulfilled, Lwt will call the
+         user's callback [f] below, which will provide a new promise [p'], and
+         [p'] will become a proxy of [p'']. At that point, trying to cancel
+         [p''] will be equivalent to trying to cancel [p'], so the behavior will
          depend on how the user obtained [p']. *)
 
       let saved_storage = !current_storage in

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -323,7 +323,7 @@ let () =
       ways: {e fulfilled} with a value, or {e rejected} with an exception. There
       is nothing conceptually special about rejection – it's just that you can
       ask for callbacks to run only on fulfillment, only on rejection, etc.
-    - {{: #2_Cancelation} Cancelation}. This is a special case of rejection,
+    - {{: #2_Cancelation} Cancellation}. This is a special case of rejection,
       specifically with exception {!Lwt.Canceled}. It has extra helpers in the
       Lwt API.
     - {{: #2_Concurrency} Concurrency helpers}. All of these could be
@@ -1017,7 +1017,7 @@ val nchoose_split : ('a t) list -> ('a list * ('a t) list) t
 
 
 
-(** {2 Cancelation} *)
+(** {2 Cancellation} *)
 
 exception Canceled
 (** Canceled promises are those rejected with this exception, [Lwt.Canceled].
@@ -1043,7 +1043,7 @@ val cancel : _ t -> unit
     propagated “forwards” by {!Lwt.bind}, {!Lwt.join}, etc., as described in the
     documentation of those functions.
 
-    {b Cancelation} is a separate phase, triggered only by {!Lwt.cancel}, that
+    {b Cancellation} is a separate phase, triggered only by {!Lwt.cancel}, that
     searches {e backwards}, strating from [p], for promises to reject with
     {!Lwt.Canceled}. Once those promises are found, they are canceled, and then
     ordinary, forwards rejection propagation takes over.
@@ -1103,7 +1103,7 @@ let () =
       rejection.
     - Suppose [p] was returned by {!Lwt.join}, {!Lwt.pick}, or similar function,
       which was applied to the promise list [ps]. {!Lwt.cancel} then recursively
-      tries to cancel each promise in [ps]. If one of those cancelations
+      tries to cancel each promise in [ps]. If one of those cancellations
       succeeds, [p] {e may} be canceled later by the normal propagation of
       rejection. *)
 
@@ -1115,7 +1115,7 @@ val on_cancel : _ t -> (unit -> unit) -> unit
     callbacks that are triggered by rejection, such as those added by
     {!Lwt.catch}.
 
-    Note that this does not interact directly with the {e cancelation}
+    Note that this does not interact directly with the {e cancellation}
     mechanism, the backwards search described in {!Lwt.cancel}. For example,
     manually rejecting a promise with {!Lwt.Canceled} is sufficient to trigger
     [f].
@@ -1125,16 +1125,16 @@ val on_cancel : _ t -> (unit -> unit) -> unit
 
 val protected : 'a t -> 'a t
 (** [Lwt.protected p] creates a {{: #VALcancel} cancelable} promise [p'] with
-    the same state as [p]. However, cancelation, the backwards search described
+    the same state as [p]. However, cancellation, the backwards search described
     in {!Lwt.cancel}, stops at [p'], and does not continue to [p]. *)
 
 val no_cancel : 'a t -> 'a t
 (** [Lwt.no_cancel p] creates a non-{{: #VALcancel}cancelable} promise [p'],
-    with the same state as [p]. Cancelation, the backwards search described in
+    with the same state as [p]. Cancellation, the backwards search described in
     {!Lwt.cancel}, stops at [p'], and does not continue to [p].
 
     Note that [p'] can still be canceled if [p] is canceled. [Lwt.no_cancel]
-    only prevents cancelation of [p] and [p'] through [p']. *)
+    only prevents cancellation of [p] and [p'] through [p']. *)
 
 val wait : unit -> ('a t * 'a u)
 (** [Lwt.wait] is the same as {!Lwt.task}, except the resulting promise [p] is

--- a/src/unix/lwt_preemptive.ml
+++ b/src/unix/lwt_preemptive.ml
@@ -88,7 +88,7 @@ type thread = {
   (* The worker thread. *)
 
   mutable reuse : bool;
-  (* Whether the thread must be read to the pool when the work is
+  (* Whether the thread must be re-added to the pool when the work is
      done. *)
 }
 

--- a/src/unix/lwt_preemptive.ml
+++ b/src/unix/lwt_preemptive.ml
@@ -88,7 +88,7 @@ type thread = {
   (* The worker thread. *)
 
   mutable reuse : bool;
-  (* Whether the thread must be readded to the pool when the work is
+  (* Whether the thread must be read to the pool when the work is
      done. *)
 }
 

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -113,7 +113,7 @@ let suites = suites @ [trivial_promise_tests]
 
 
 (* Tests for promises created with [Lwt.wait] and [Lwt.task], not including
-   tests for cancelation of the latter. Tests for double use of [Lwt.wakeup]
+   tests for cancellation of the latter. Tests for double use of [Lwt.wakeup]
    and related functions are in a separated suite. So are tests for
    [Lwt.wakeup_later] and related functions. *)
 
@@ -237,7 +237,7 @@ let suites = suites @ [double_resolve_tests]
 
 
 (* Tests for sequential composition functions, such as [Lwt.bind], but not
-   including testing for interaction with cancelation and sequence-associated
+   including testing for interaction with cancellation and sequence-associated
    storage. Those tests come later. *)
 
 let bind_tests = suite "bind" [
@@ -1747,9 +1747,9 @@ let suites = suites @ [on_any_tests]
 
 
 
-(* Concurrent composition tests, not including cancelation and
+(* Concurrent composition tests, not including cancellation and
    sequence-associated storage. Also not including [Lwt.pick] and [Lwt.npick],
-   as those interact with cancelation. *)
+   as those interact with cancellation. *)
 
 let async_tests = suite "async" [
   test "fulfilled" begin fun () ->
@@ -2473,7 +2473,7 @@ let suites = suites @ [wakeup_later_tests]
 
 
 
-(* Cancelation and its interaction with the rest of the API. *)
+(* Cancellation and its interaction with the rest of the API. *)
 
 let cancel_tests = suite "cancel" [
   test "fulfilled" begin fun () ->
@@ -3046,7 +3046,7 @@ let cancel_catch_tests = suite "cancel catch" [
   end;
 
   (* In [p' = Lwt.catch (fun () -> p) f], if [p] is cancelable, canceling [p']
-     propagates to [p], and then the cancelation exception can be "intercepted"
+     propagates to [p], and then the cancellation exception can be "intercepted"
      by [f], which can resolve [p'] in an arbitrary way. *)
   test "task, pending, canceled" begin fun () ->
     let saw = ref None in
@@ -3086,7 +3086,7 @@ let cancel_catch_tests = suite "cancel catch" [
        !on_cancel_2_ran = false)
   end;
 
-  (* Same as above, except this time, cancelation is passed on to the outer
+  (* Same as above, except this time, cancellation is passed on to the outer
      promise, so we can expect both cancel callbacks to run. *)
   test "task, pending, canceled, on_cancel, forwarded" begin fun () ->
     let on_cancel_2_ran = ref false in
@@ -3374,7 +3374,7 @@ let cancel_join_tests = suite "cancel join" [
 
   (* In [p' = Lwt.join [p; p]], if [p'] is canceled, the cancel handler on [p]
      is called only once, even though it is reachable by two paths in the
-     cancelation graph. *)
+     cancellation graph. *)
   test "cancel diamond" begin fun () ->
     let ran = ref 0 in
     let p, _ = Lwt.task () in


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

A ton of "cancelation->cancellation" 

but, there is only one correct spelling of the word cancellation, no matter where you are. :=)