### PR TITLE
Better custom configuration

### DIFF
--- a/src/unix/config/configure.ml
+++ b/src/unix/config/configure.ml
@@ -32,10 +32,11 @@ let args = [
 let main () =
   Arg.parse args ignore usage;
 
-  let config_file = "lwt_config" in
+  let config_file = ref "lwt_config" in
 
   begin match !default_configuration with
   | Some true -> begin
+    config_file := "lwt_config.default";
     (* Check if we have the opam command and conf-libev is installed. If so,
        behave as if -use-libev true was passed.
        opam 2.0.0 returns exit code 0 for `opam list` even if the package is not available,
@@ -58,7 +59,7 @@ let main () =
     ()
   end;
 
-  let f = open_out config_file in
+  let f = open_out !config_file in
   let print name var =
     match var with
     | None -> ()

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -31,9 +31,15 @@
  (action (with-stdout-to %{targets} (run %{ocamlc} -config))))
 
 (rule
- (targets lwt_config)
+ (targets lwt_config.default)
  (deps (:exe config/configure.exe))
  (action (run %{exe} -default-configuration true)))
+
+(rule
+ (mode fallback)
+ (targets lwt_config)
+ (deps lwt_config.default)
+ (action (copy %{deps} %{targets})))
 
 ;; note; the call to (and dependency on) ocamlfind is avoided by adding:
 ;; -ocamlc %{ocamlc}

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -66,7 +66,7 @@ else
     LIBEV_FLAG=false
 fi
 
-dune exec src/unix/config/configure.exe -- -use-libev $LIBEV_FLAG
+(cd src/unix && dune exec config/configure.exe -- -use-libev $LIBEV_FLAG)
 make build
 make test
 make coverage


### PR DESCRIPTION
I was tripped up by the example in the travis script when trying to
build lwt with libev without opam.
`dune exec src/unix/configurator.exe -- -use-libev true` doesn't really
do anything since the `lwt_config` file will be generated at the project root
instead of where dune expects it.

Also update the `dune` file to allow proper fallback. Currently dune
gives a warning when a file is both in the source tree and generated by a rule.
This will be an error in future versions of dune.