### PR TITLE
Travis speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
     - env: COMPILER=ocaml-variants.4.08.1+flambda
-    - env: COMPILER=4.07.1
+    - env: COMPILER=4.07.1 LWT_STRESS_TEST=true
     - env: COMPILER=4.06.1
     - env: COMPILER=4.05.0
     - env: COMPILER=4.04.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - os: linux
       env: COMPILER=4.08.1 COVERAGE=yes
     - os: linux
-      env: COMPILER=ocaml-variants.4.07.1+flambda
+      env: COMPILER=ocaml-variants.4.08.1+flambda
     - os: linux
       env: COMPILER=4.07.1
     - os: linux
@@ -25,7 +25,7 @@ matrix:
 
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
-    - env: COMPILER=ocaml-variants.4.07.1+flambda
+    - env: COMPILER=ocaml-variants.4.08.1+flambda
     - env: COMPILER=4.07.1
     - env: COMPILER=4.06.1
     - env: COMPILER=4.05.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - os: linux
       env: COMPILER=ocaml-variants.4.08.1+flambda
     - os: linux
-      env: COMPILER=4.07.1
+      env: COMPILER=4.07.1 LWT_STRESS_TEST=true
     - os: linux
       env: COMPILER=4.06.1
     - os: linux
@@ -37,7 +37,6 @@ matrix:
 env:
   global:
     - LWT_FORCE_LIBEV_BY_DEFAULT=yes
-    - LWT_STRESS_TEST=true
 
 script: bash -e src/util/travis.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
     - os: linux
-      env: COMPILER=4.08.1 LIBEV=no COVERAGE=yes
+      env: COMPILER=4.08.1 LIBEV=no PPX_LET=yes COVERAGE=yes
     - os: linux
       env: COMPILER=ocaml-variants.4.08.1+flambda
     - os: linux
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       env: COMPILER=4.03.0
     - os: linux
-      env: COMPILER=4.02.3
+      env: COMPILER=4.02.3 PACKAGING=yes
 
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
     - os: linux
-      env: COMPILER=4.08.1 COVERAGE=yes
+      env: COMPILER=4.08.1 LIBEV=no COVERAGE=yes
     - os: linux
       env: COMPILER=ocaml-variants.4.08.1+flambda
     - os: linux
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       env: COMPILER=4.03.0
     - os: linux
-      env: COMPILER=4.02.3 LIBEV=no
+      env: COMPILER=4.02.3
 
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ matrix:
 
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+    - env: COMPILER=ocaml-variants.4.07.1+flambda
+    - env: COMPILER=4.07.1
+    - env: COMPILER=4.06.1
+    - env: COMPILER=4.05.0
+    - env: COMPILER=4.04.2
+    - env: COMPILER=4.03.0
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ cache:
   directories:
     - $HOME/.opam
     - ./_opam
+    - ./_cache
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,23 @@ matrix:
     - os: osx
       env: COMPILER=4.08.1 LIBEV=no
     - os: linux
+      env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+    - os: linux
       env: COMPILER=4.08.1 COVERAGE=yes
-    - os: linux
-      env: COMPILER=4.02.3 LIBEV=no
-    - os: linux
-      env: COMPILER=4.03.0
-    - os: linux
-      env: COMPILER=4.04.2
-    - os: linux
-      env: COMPILER=4.05.0
-    - os: linux
-      env: COMPILER=4.06.1
-    - os: linux
-      env: COMPILER=4.07.1
     - os: linux
       env: COMPILER=ocaml-variants.4.07.1+flambda
     - os: linux
-      env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+      env: COMPILER=4.07.1
+    - os: linux
+      env: COMPILER=4.06.1
+    - os: linux
+      env: COMPILER=4.05.0
+    - os: linux
+      env: COMPILER=4.04.2
+    - os: linux
+      env: COMPILER=4.03.0
+    - os: linux
+      env: COMPILER=4.02.3 LIBEV=no
 
   allow_failures:
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,12 @@ EXPECTED_FILES := \
     --do-not-expect src/unix/unix_c/
 
 .PHONY: coverage
-coverage: clean
+coverage: clean coverage-only
+
+.PHONY : coverage-only
+coverage-only :
 	BISECT_ENABLE=yes $(MAKE) build
-	BISECT_ENABLE=yes dune runtest -j 1 --no-buffer
+	BISECT_ENABLE=yes dune runtest -j 1 --no-buffer --force
 	bisect-ppx-report html $(EXPECTED_FILES)
 	bisect-ppx-report summary
 	@echo See _coverage/index.html

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -2,6 +2,8 @@ set -x
 
 
 
+date
+
 # Install libev, if requested.
 if [ "$LIBEV" != no ]
 then
@@ -16,6 +18,8 @@ then
 fi
 
 
+
+date
 
 # Install opam.
 case $TRAVIS_OS_NAME in
@@ -33,6 +37,8 @@ sudo chmod a+x /usr/local/bin/opam
 
 
 
+date
+
 # Initialize opam.
 opam init -y --bare --disable-sandboxing --disable-shell-hook
 if [ ! -d _opam/bin ]
@@ -46,6 +52,8 @@ ocaml -version
 
 
 
+date
+
 # Install Lwt's development dependencies.
 make dev-deps
 
@@ -55,6 +63,8 @@ then
 fi
 
 
+
+date
 
 # Build and run the tests.
 if [ "$LIBEV" != no ]
@@ -67,6 +77,8 @@ export LWT_DISCOVER_ARGUMENTS
 
 make build
 
+date
+
 if [ "$COVERAGE" != yes ]
 then
     make test
@@ -77,6 +89,8 @@ fi
 
 
 
+date
+
 # Run the packaging tests.
 make clean
 make install-for-packaging-test
@@ -85,9 +99,13 @@ make uninstall-after-packaging-test
 
 
 
+date
+
 # Run the ppx_let integratio test.
 if [ "$COMPILER" != "4.02.3" ]
 then
     make ppx_let-test-deps
     make ppx_let-test
 fi
+
+date

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -55,11 +55,16 @@ ocaml -version
 date
 
 # Install Lwt's development dependencies.
-make dev-deps
-
-if [ "$LIBEV" != no ]
+if [ ! -d _cache/_build ]
 then
-    opam install -y conf-libev
+    make dev-deps
+
+    if [ "$LIBEV" != no ]
+    then
+        opam install -y conf-libev
+    fi
+else
+    cp -r _cache/_build .
 fi
 
 
@@ -75,16 +80,21 @@ else
 fi
 export LWT_DISCOVER_ARGUMENTS
 
-make build
-
 date
 
 if [ "$COVERAGE" != yes ]
 then
-    make test
+    make build
+    dune runtest -j 1 --no-buffer --force
 else
-    make coverage
+    make coverage-only
     bisect-ppx-report send-to Coveralls
+fi
+
+if [ ! -d _cache/_build ]
+then
+    mkdir -p _cache
+    cp -r _build _cache
 fi
 
 

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -110,4 +110,11 @@ then
     make ppx_let-test
 fi
 
+
+
+date
+
+# Clean up the opam switch for better caching.
+opam clean
+
 date

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -1,5 +1,12 @@
 set -x
 
+if [ "$TRAVIS_EVENT_TYPE" == cron ]
+then
+    rm -rf ~/.opam
+    rm -rf ./_opam
+    rm -rf ./_cache
+fi
+
 
 
 date

--- a/src/util/travis.sh
+++ b/src/util/travis.sh
@@ -92,17 +92,19 @@ fi
 date
 
 # Run the packaging tests.
-make clean
-make install-for-packaging-test
-make packaging-test
-make uninstall-after-packaging-test
+if [ "$PACKAGING" == yes ]
+then
+    make install-for-packaging-test
+    make packaging-test
+    make uninstall-after-packaging-test
+fi
 
 
 
 date
 
 # Run the ppx_let integratio test.
-if [ "$COMPILER" != "4.02.3" ]
+if [ "$PPX_LET" == yes ]
 then
     make ppx_let-test-deps
     make ppx_let-test


### PR DESCRIPTION
Resolves #705.

The critical path consists of just the one macOS build row. Before this PR, a Mac build using the cache (containing the compiler and opam deps) took 5 minutes and 5 seconds. It now takes 1 minute and 53 seconds, and still makes up the critical path (all the other builds were also sped up by the changes).

37% of the remaining time is spent restoring and checking the cache, so this likely can't be optimized.

47% of the remaining time is spent running the test suite, which can probably be greatly optimized by taking advantage of Lwt concurrency, and also by parallelizing it. So, speeding up the test suite is the next step.