### PR TITLE
Run Lwt_unix tests concurrently

### DIFF
--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -1466,7 +1466,7 @@ let on_success_tests = suite "on_success" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "fulfilled, f raises" begin fun () ->
+  test ~sequential:true "fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1497,7 +1497,7 @@ let on_success_tests = suite "on_success" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "pending, fulfilled, f raises" begin fun () ->
+  test ~sequential:true "pending, fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_success p (fun () -> raise Exception);
@@ -1532,7 +1532,7 @@ let on_failure_tests = suite "on_failure" [
     later (fun () -> !saw = Some Exception)
   end;
 
-  test "rejected, f raises" begin fun () ->
+  test ~sequential:true "rejected, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1564,7 +1564,7 @@ let on_failure_tests = suite "on_failure" [
     later (fun () -> !saw = Some Exception)
   end;
 
-  test "pending, rejected, f raises" begin fun () ->
+  test ~sequential:true "pending, rejected, f raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_failure p (fun _ -> raise Exception);
@@ -1585,7 +1585,7 @@ let on_termination_tests = suite "on_termination" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "fulfilled, f raises" begin fun () ->
+  test ~sequential:true "fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1601,7 +1601,7 @@ let on_termination_tests = suite "on_termination" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "rejected, f raises" begin fun () ->
+  test ~sequential:true "rejected, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1625,7 +1625,7 @@ let on_termination_tests = suite "on_termination" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "pending, fulfilled, f raises" begin fun () ->
+  test ~sequential:true "pending, fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_termination p (fun () -> raise Exception);
@@ -1645,7 +1645,7 @@ let on_termination_tests = suite "on_termination" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "pending, rejected, f raises" begin fun () ->
+  test ~sequential:true "pending, rejected, f raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_termination p (fun () -> raise Exception);
@@ -1670,7 +1670,7 @@ let on_any_tests = suite "on_any" [
     later (fun () -> !f_ran = true && !g_ran = false)
   end;
 
-  test "fulfilled, f raises" begin fun () ->
+  test ~sequential:true "fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1686,7 +1686,7 @@ let on_any_tests = suite "on_any" [
     later (fun () -> !saw = Some Exception)
   end;
 
-  test "rejected, f raises" begin fun () ->
+  test ~sequential:true "rejected, f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1711,7 +1711,7 @@ let on_any_tests = suite "on_any" [
     later (fun () -> !f_ran = true && !g_ran = false)
   end;
 
-  test "pending, fulfilled, f raises" begin fun () ->
+  test ~sequential:true "pending, fulfilled, f raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_any p (fun () -> raise Exception) ignore;
@@ -1731,7 +1731,7 @@ let on_any_tests = suite "on_any" [
     later (fun () -> !saw = Some Exception)
   end;
 
-  test "pending, rejected, g raises" begin fun () ->
+  test ~sequential:true "pending, rejected, g raises" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.on_any p ignore (fun _ -> raise Exception);
@@ -1758,7 +1758,7 @@ let async_tests = suite "async" [
     later (fun () -> !f_ran = true)
   end;
 
-  test "f raises" begin fun () ->
+  test ~sequential:true "f raises" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1768,7 +1768,7 @@ let async_tests = suite "async" [
       !saw = Some Exception)
   end;
 
-  test "rejected" begin fun () ->
+  test ~sequential:true "rejected" begin fun () ->
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
@@ -1789,7 +1789,7 @@ let async_tests = suite "async" [
     later (fun () -> !resolved = true)
   end;
 
-  test "pending, rejected" begin fun () ->
+  test ~sequential:true "pending, rejected" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.async (fun () -> p);
@@ -1826,7 +1826,7 @@ let ignore_result_tests = suite "ignore_result" [
     Lwt.return true
   end;
 
-  test "pending, rejected" begin fun () ->
+  test ~sequential:true "pending, rejected" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.ignore_result p;

--- a/test/test.ml
+++ b/test/test.ml
@@ -121,7 +121,8 @@ type suite = {
 }
 
 let contains_dup_tests suite tests =
-  let names = List.map (fun t -> "suite:" ^ suite ^ " test:" ^ t.test_name) tests in
+  let names =
+    List.map (fun t -> "suite:" ^ suite ^ " test:" ^ t.test_name) tests in
   let sorted_unique_names = List.sort_uniq String.compare names in
   let counts =
     List.map (fun x ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -194,13 +194,17 @@ let run library_name suites =
 
   Printf.printf "Testing library '%s'...\n" library_name;
 
+  let start_time = Unix.gettimeofday () in
+
   let rec loop_over_suites aggregated_outcomes suites =
     match suites with
     | [] ->
+      let end_time = Unix.gettimeofday () in
       Printf.printf
-        "\nOk. %i tests ran, %i tests skipped\n"
+        "\nOk. %i tests ran, %i tests skipped in %.2f seconds\n"
         (count_ran aggregated_outcomes)
-        (count_skipped aggregated_outcomes);
+        (count_skipped aggregated_outcomes)
+        (end_time -. start_time);
       Lwt.return_unit
 
     | suite::rest ->

--- a/test/test.mli
+++ b/test/test.mli
@@ -24,7 +24,12 @@ val test_direct : string -> ?only_if:(unit -> bool) -> (unit -> bool) -> test
     and [false] otherwise. [only_if] is used to conditionally skip the
     test. *)
 
-val test : string -> ?only_if:(unit -> bool) -> (unit -> bool Lwt.t) -> test
+val test :
+  string ->
+  ?only_if:(unit -> bool) ->
+  ?sequential:bool ->
+  (unit -> bool Lwt.t) ->
+    test
 (** Like [test_direct], but defines a test which runs a thread. *)
 
 val suite : string -> ?only_if:(unit -> bool) -> test list -> suite
@@ -33,6 +38,9 @@ val suite : string -> ?only_if:(unit -> bool) -> test list -> suite
 val run : string -> suite list -> unit
 (** Run all the given tests and exit the program with an exit code
     of [0] if all tests succeeded and with [1] otherwise. *)
+
+val concurrent : string -> suite list -> unit
+(** Same as [run], but runs all the tests concurrently. *)
 
 val with_async_exception_hook : (exn -> unit) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
 (** [Test.with_async_exception_hook hook f] sets [!Lwt.async_exception_hook] to

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -25,7 +25,7 @@ let () =
   with Not_found -> ()
 
 let () =
-  Test.run "unix" [
+  Test.concurrent "unix" [
     Test_lwt_unix.suite;
     Test_lwt_io.suite;
     Test_lwt_io_non_block.suite;

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -66,8 +66,14 @@ let gen_buf n =
  * The main purposes of those functions are not tested.
  * *)
 
+let file_suffix =
+  let last_file_suffix = ref 0 in
+  fun () ->
+    incr last_file_suffix;
+    !last_file_suffix
+
 let test_mincore buff_len offset n_states =
-  let test_file = "bytes_mincore_write" in
+  let test_file = Printf.sprintf "bytes_mincore_write_%i" (file_suffix ()) in
   Lwt_unix.openfile test_file [O_RDWR;O_TRUNC; O_CREAT] 0o666
   >>= fun fd ->
   let buf_write = gen_buf buff_len in
@@ -84,7 +90,7 @@ let test_mincore buff_len offset n_states =
   Lwt.return ()
 
 let test_wait_mincore buff_len offset =
-  let test_file = "bytes_mincore_write" in
+  let test_file = Printf.sprintf "bytes_mincore_write_%i" (file_suffix ()) in
   Lwt_unix.openfile test_file [O_RDWR;O_TRUNC; O_CREAT] 0o666
   >>= fun fd ->
   let buf_write = gen_buf buff_len in

--- a/test/unix/test_lwt_io_non_block.ml
+++ b/test/unix/test_lwt_io_non_block.ml
@@ -10,40 +10,40 @@ let test_file = "Lwt_io_test"
 let file_contents = "test file content"
 
 let suite = suite "lwt_io non blocking io" [
-  test "file does not exist"
+  test ~sequential:true "file does not exist"
     (fun () -> Lwt_unix.file_exists test_file >|= fun r -> not r);
 
-  test "file does not exist (invalid path)"
+  test ~sequential:true "file does not exist (invalid path)"
     (fun () -> Lwt_unix.file_exists (test_file ^ "/foo") >|= fun r -> not r);
 
-  test "file does not exist (LargeFile)"
+  test ~sequential:true "file does not exist (LargeFile)"
     (fun () -> Lwt_unix.LargeFile.file_exists test_file >|= fun r -> not r);
 
-  test "file does not exist (LargeFile, invalid path)"
+  test ~sequential:true "file does not exist (LargeFile, invalid path)"
     (fun () -> Lwt_unix.LargeFile.file_exists (test_file ^ "/foo") >|= fun r -> not r);
 
-  test "create file"
+  test ~sequential:true "create file"
     (fun () ->
       Lwt_io.open_file ~mode:Lwt_io.output test_file >>= fun out_chan ->
       Lwt_io.write out_chan file_contents >>= fun () ->
       Lwt_io.close out_chan >>= fun () ->
       Lwt.return_true);
 
-  test "file exists"
+  test ~sequential:true "file exists"
     (fun () -> Lwt_unix.file_exists test_file);
 
-  test "file exists (LargeFile)"
+  test ~sequential:true "file exists (LargeFile)"
     (fun () -> Lwt_unix.LargeFile.file_exists test_file);
 
 
-  test "read file"
+  test ~sequential:true "read file"
     (fun () ->
       Lwt_io.open_file ~mode:Lwt_io.input test_file >>= fun in_chan ->
       Lwt_io.read in_chan >>= fun s ->
       Lwt_io.close in_chan >>= fun () ->
       Lwt.return (s = file_contents));
 
-  test "remove file"
+  test ~sequential:true "remove file"
     (fun () ->
       Unix.unlink test_file;
       Lwt.return_true);

--- a/test/unix/test_lwt_io_non_block.ml
+++ b/test/unix/test_lwt_io_non_block.ml
@@ -9,13 +9,6 @@ open Lwt.Infix
 let test_file = "Lwt_io_test"
 let file_contents = "test file content"
 
-let open_and_read_filename () =
-  Lwt_io.open_file ~mode:Lwt_io.input test_file >>= fun in_chan ->
-  Lwt_io.read in_chan >>= fun s ->
-  Lwt_io.close in_chan >>= fun () ->
-  assert (s = file_contents);
-  Lwt.return ()
-
 let suite = suite "lwt_io non blocking io" [
   test "file does not exist"
     (fun () -> Lwt_unix.file_exists test_file >|= fun r -> not r);
@@ -49,15 +42,6 @@ let suite = suite "lwt_io non blocking io" [
       Lwt_io.read in_chan >>= fun s ->
       Lwt_io.close in_chan >>= fun () ->
       Lwt.return (s = file_contents));
-
-  test "many read file"
-    (fun () ->
-      let rec loop i =
-        open_and_read_filename () >>= fun () ->
-        if i > 10000 then Lwt.return_true
-        else loop (i + 1)
-      in
-      loop 0);
 
   test "remove file"
     (fun () ->

--- a/test/unix/test_lwt_timeout.ml
+++ b/test/unix/test_lwt_timeout.ml
@@ -122,7 +122,7 @@ let suite = suite "Lwt_timeout" [
     Lwt_timeout.start timeout;
 
     p >|= fun delta ->
-    delta >= 2. && delta < 3.
+    delta >= 1.9 && delta < 3.1
   end;
 
   test "change does not start" begin fun () ->
@@ -155,7 +155,7 @@ let suite = suite "Lwt_timeout" [
     Lwt_timeout.change timeout 1;
 
     p >|= fun delta ->
-    delta >= 2. && delta < 3.
+    delta >= 1.9 && delta < 3.1
   end;
 
   test "change: invalid delay" begin fun () ->
@@ -167,7 +167,7 @@ let suite = suite "Lwt_timeout" [
       Lwt.return true
   end;
 
-  test "exception in action" begin fun () ->
+  test ~sequential:true "exception in action" begin fun () ->
     let p, r = Lwt.wait () in
 
     Test.with_async_exception_hook
@@ -217,7 +217,7 @@ let suite = suite "Lwt_timeout" [
 
     p1 >>= fun delta1 ->
     p2 >>= fun delta2 ->
-    Lwt.return (delta1 >= 2. && delta1 < 3. && delta2 >= 3. && delta2 < 4.)
+    Lwt.return (delta1 >= 1.9 && delta1 < 3. && delta2 >= 2.9 && delta2 < 4.)
   end;
 
   test "simultaneous" begin fun () ->
@@ -238,7 +238,7 @@ let suite = suite "Lwt_timeout" [
 
     p1 >>= fun delta1 ->
     p2 >>= fun delta2 ->
-    Lwt.return (delta1 >= 1. && delta1 < 2. && delta2 >= 1. && delta2 < 2.)
+    Lwt.return (delta1 >= 1. && delta1 < 2.1 && delta2 >= 1. && delta2 < 2.1)
   end;
 
   test "two, first stopped" begin fun () ->
@@ -265,6 +265,6 @@ let suite = suite "Lwt_timeout" [
 
     p1 >>= fun timeout1_not_fired ->
     p2 >>= fun delta2 ->
-    Lwt.return (timeout1_not_fired && delta2 >= 2. && delta2 < 3.)
+    Lwt.return (timeout1_not_fired && delta2 >= 1.9 && delta2 < 3.1)
   end;
 ]

--- a/test/unix/test_lwt_timeout.ml
+++ b/test/unix/test_lwt_timeout.ml
@@ -265,6 +265,6 @@ let suite = suite "Lwt_timeout" [
 
     p1 >>= fun timeout1_not_fired ->
     p2 >>= fun delta2 ->
-    Lwt.return (timeout1_not_fired && delta2 >= 1.9 && delta2 < 3.1)
+    Lwt.return (timeout1_not_fired && delta2 >= 1.5 && delta2 < 3.5)
   end;
 ]

--- a/test/unix/test_lwt_timeout.ml
+++ b/test/unix/test_lwt_timeout.ml
@@ -52,7 +52,7 @@ let suite = suite "Lwt_timeout" [
     Lwt_timeout.start timeout;
     Lwt_timeout.start timeout;
 
-    Lwt_unix.sleep 5. >|= fun () ->
+    Lwt_unix.sleep 3. >|= fun () ->
     !completions = 1
   end;
 

--- a/test/unix/test_mcast.ml
+++ b/test/unix/test_mcast.ml
@@ -8,14 +8,18 @@ open Test
 
 let debug = false
 let hello = Bytes.unsafe_of_string "Hello, World!"
-let mcast_addr = "225.0.0.1"
+let mcast_addr =
+  let last_group = ref 0 in
+  fun () ->
+    incr last_group;
+    Printf.sprintf "225.0.0.%i" !last_group
 let mcast_port =
   let last_port = ref 4421 in
   fun () ->
     incr last_port;
     !last_port
 
-let child join fd =
+let child mcast_addr join fd =
   if join then Lwt_unix.mcast_add_membership fd (Unix.inet_addr_of_string mcast_addr);
   let buf = Bytes.create 50 in
   Lwt_unix.with_timeout 0.1 (fun () -> Lwt_unix.read fd buf 0 (Bytes.length buf)) >>= fun n ->
@@ -26,7 +30,7 @@ let child join fd =
   else
     Lwt.return_unit
 
-let parent mcast_port set_loop fd =
+let parent mcast_addr mcast_port set_loop fd =
   Lwt_unix.mcast_set_loop fd set_loop;
   let addr = Lwt_unix.ADDR_INET (Unix.inet_addr_of_string mcast_addr, mcast_port) in
   Lwt_unix.sendto fd hello 0 (Bytes.length hello) [] addr >>= fun _ ->
@@ -37,6 +41,7 @@ let parent mcast_port set_loop fd =
 
 let test_mcast name join set_loop =
   test name ~only_if:(fun () -> not Sys.win32) begin fun () ->
+    let mcast_addr = mcast_addr () in
     let mcast_port = mcast_port () in
     let should_timeout = not join || not set_loop in
     let fd1 = Lwt_unix.(socket PF_INET SOCK_DGRAM 0) in
@@ -46,8 +51,8 @@ let test_mcast name join set_loop =
         (fun () ->
            Lwt_unix.(bind
              fd1 (ADDR_INET (Unix.inet_addr_any, mcast_port))) >>= fun () ->
-           let t1 = child join fd1 in
-           let t2 = parent mcast_port set_loop fd2 in
+           let t1 = child mcast_addr join fd1 in
+           let t2 = parent mcast_addr mcast_port set_loop fd2 in
            Lwt.join [t1; t2] >>= fun () -> Lwt.return true
         )
         (function


### PR DESCRIPTION
This decreases testing time for `Lwt_unix` from about 47 seconds to about 6 seconds, and the overall testing time is reduced from 53 seconds to 12 seconds (all measurements on my system).

In the remaining 6 seconds:

- 2 seconds are taken up by some tests that must be run sequentially, because they use `Lwt.async_exception_hook`. Actually, most of the 2 seconds is due to only one test, which spends most of that time in `Lwt_unix.sleep`. We can probably refactor or delete it, if we ever really care about these seconds.
- The last concurrent test to finish is started at 3.1 seconds. This is one of the many test that consists mostly of waiting on `Lwt_unix.sleep`, which is the only reason it takes this long.
- The last concurrent test to start also starts around 3.1 seconds.

So, after the 11 sequential tests run for 2 seconds, all the remaining tests, 183 concurrent tests, start and finish within the next 4 seconds. So, the concurrency level is very high.

Resolves #708.

cc @CraigFe this is probably relevant for https://github.com/mirage/alcotest/issues/177 :)

The implementation in this PR is pretty sloppy, because I just coded as fast as possible, and the Lwt tester is private to Lwt. However, it shows what some projects can gain from running tests concurrently.