### PR TITLE
Fix #695 - add more Linux-specific madvise() options

### DIFF
--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -206,6 +206,10 @@ type advice =
   | MADV_SEQUENTIAL
   | MADV_WILLNEED
   | MADV_DONTNEED
+  | MADV_MERGEABLE
+  | MADV_UNMERGEABLE
+  | MADV_HUGEPAGE
+  | MADV_NOHUGEPAGE
 
 external stub_madvise : t -> int -> int -> advice -> unit = "lwt_unix_madvise"
 

--- a/src/unix/lwt_bytes.mli
+++ b/src/unix/lwt_bytes.mli
@@ -154,6 +154,10 @@ type advice =
   | MADV_SEQUENTIAL
   | MADV_WILLNEED
   | MADV_DONTNEED
+  | MADV_MERGEABLE
+  | MADV_UNMERGEABLE
+  | MADV_HUGEPAGE
+  | MADV_NOHUGEPAGE
 
 val madvise : t -> int -> int -> advice -> unit
   (** [madvise buffer pos len advice] advises the kernel how the

--- a/src/unix/unix_c/unix_madvise.c
+++ b/src/unix/unix_c/unix_madvise.c
@@ -14,6 +14,16 @@
 
 static int advise_table[] = {
     MADV_NORMAL, MADV_RANDOM, MADV_SEQUENTIAL, MADV_WILLNEED, MADV_DONTNEED,
+#if defined(MADV_MERGEABLE) && defined(MADV_UNMERGEABLE)
+	MADV_MERGEABLE, MADV_UNMERGEABLE,
+#else
+	0, 0,
+#endif
+#if defined(MADV_HUGEPAGE) && defined(MADV_NOHUGEPAGE)
+	MADV_HUGEPAGE, MADV_NOHUGEPAGE,
+#else
+	0, 0,
+#endif
 };
 
 CAMLprim value lwt_unix_madvise(value val_buffer, value val_offset,

--- a/src/unix/unix_c/unix_madvise.c
+++ b/src/unix/unix_c/unix_madvise.c
@@ -14,15 +14,25 @@
 
 static int advise_table[] = {
     MADV_NORMAL, MADV_RANDOM, MADV_SEQUENTIAL, MADV_WILLNEED, MADV_DONTNEED,
-#if defined(MADV_MERGEABLE) && defined(MADV_UNMERGEABLE)
-	MADV_MERGEABLE, MADV_UNMERGEABLE,
+#if defined(MADV_MERGEABLE)
+	MADV_MERGEABLE,
 #else
-	0, 0,
+	0,
 #endif
-#if defined(MADV_HUGEPAGE) && defined(MADV_NOHUGEPAGE)
-	MADV_HUGEPAGE, MADV_NOHUGEPAGE,
+#if defined(MADV_UNMERGEABLE)
+	MADV_UNMERGEABLE,
 #else
-	0, 0,
+	0,
+#endif
+#if defined(MADV_HUGEPAGE)
+	MADV_HUGEPAGE,
+#else
+	0,
+#endif
+#if defined(MADV_NOHUGEPAGE)
+	MADV_NOHUGEPAGE,
+#else
+	0,
 #endif
 };
 


### PR DESCRIPTION
Since https://github.com/ocsigen/lwt/pull/696 was closed, GitHub doesn't update closed pull requests.
I added the detection for two most important `madvise()` Linux-only options, but the question how to define the `type advice` in `src/unix/lwt_bytes.ml` conditionally? It's not a preprocessor option, right?