### PR TITLE
Fix compilation with musl-gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       env: COMPILER=4.09.0 LIBEV=no PPX_LET=yes COVERAGE=yes
     - os: linux
-      env: COMPILER=ocaml-variants.4.08.1+flambda
+      env: COMPILER=4.08.1+musl+flambda MUSL=yes
     - os: linux
       env: COMPILER=4.07.1 DOCS=yes
     - os: linux
@@ -22,7 +22,7 @@ matrix:
       env: COMPILER=4.02.3 PACKAGING=yes
 
   allow_failures:
-    - env: COMPILER=ocaml-variants.4.08.1+flambda
+    - env: COMPILER=4.08.1+musl+flambda MUSL=yes
     - env: COMPILER=4.07.1 DOCS=yes
     - env: COMPILER=4.06.1 LWT_STRESS_TEST=true
     - env: COMPILER=4.05.0
@@ -39,8 +39,26 @@ before_install:
   - '[ "$TRAVIS_EVENT_TYPE" != cron ] || rm -rf ~/.opam ./_opam ./_cache'
 
 install:
-  - '[ "$LIBEV" == no ] || sudo apt-get update -qq'
-  - '[ "$LIBEV" == no ] || sudo apt-get install -qq libev-dev'
+  - |
+    if [ "$LIBEV" != no ]
+    then
+      sudo apt-get update -qq
+      if [ "$MUSL" != yes ]
+      then
+        sudo apt-get install -qq libev-dev
+      else
+        sudo apt-get install musl-tools
+        wget http://dist.schmorp.de/libev/Attic/libev-4.27.tar.gz
+        tar xf libev-4.27.tar.gz
+        cd libev-4.27
+        CC=musl-gcc ./configure --prefix `pwd`/install
+        make
+        make install
+        sudo cp install/include/* /usr/include/x86_64-linux-musl
+        sudo cp install/lib/* /usr/lib/x86_64-linux-musl
+        cd ..
+      fi
+    fi
 
   - OS=linux
   - '[ "$TRAVIS_OS_NAME" != osx ] || OS=macos'
@@ -59,6 +77,7 @@ install:
   - opam --version
   - ocaml -version
 
+  - opam pin add --no-action ounit 2.0.8 # 2.1.2 release is broken.
   - CACHED=yes
   - '[ -d _cache/_build ] || CACHED=no'
   - '[ "$CACHED" == yes ] || opam install . --deps-only --yes'

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -439,9 +439,7 @@ struct
         None
       else begin
         skip_if_windows context @@ fun () ->
-        if !Arguments.android_target <> Some true then
-          C_library_flags.detect context ~library:"pthread";
-        compiles context {|
+        let code = {|
           #include <pthread.h>
 
           int main()
@@ -450,6 +448,16 @@ struct
               return 0;
           }
         |}
+        in
+        match compiles context code with
+        | Some true -> Some true
+        | no ->
+          if !Arguments.android_target = Some true then
+            no
+          else begin
+            C_library_flags.detect context ~library:"pthread";
+            compiles context code
+          end
       end
   }
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -325,7 +325,7 @@ let concurrent library_name suites =
     flush stdout;
     outcomes |> List.iter (function
       | (suite, test), Failed ->
-        Printf.eprintf "Test '%s' in suite '%s' produced 'false\n"
+        Printf.eprintf "Test '%s' in suite '%s' produced 'false'\n"
           test.test_name suite.suite_name
       | (suite, test), Exception exn ->
         Printf.eprintf "Test '%s' in suite '%s' raised '%s'\n"

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -497,14 +497,16 @@ let suite = suite "lwt_io" [
     Lwt_bytes.of_string "\x70\x60\x50\x40\x30\x20\xf0\x42"
     |> Lwt_io.(of_bytes ~mode:input)
     |> Lwt_io.LE.read_float64
-    >|= (=) 283686952306183.
+    >|= Int64.bits_of_float
+    >|= (=) 0x42F0203040506070L
   end;
 
   test "NumberIO.BE.read_float64" begin fun () ->
     Lwt_bytes.of_string "\x42\xf0\x20\x30\x40\x50\x60\x70"
     |> Lwt_io.(of_bytes ~mode:input)
     |> Lwt_io.BE.read_float64
-    >|= (=) 283686952306183.
+    >|= Int64.bits_of_float
+    >|= (=) 0x42F0203040506070L
   end;
 
   test "NumberIO.LE.write_int" begin fun () ->
@@ -580,14 +582,14 @@ let suite = suite "lwt_io" [
   test "NumberIO.LE.write_float64" begin fun () ->
     let buffer = Lwt_bytes.create 8 in
     Lwt_io.LE.write_float64 (Lwt_io.(of_bytes ~mode:output) buffer)
-      283686952306183. >>= fun () ->
+      (Int64.float_of_bits 0x42F0203040506070L) >>= fun () ->
     Lwt.return (Lwt_bytes.to_string buffer = "\x70\x60\x50\x40\x30\x20\xf0\x42")
   end;
 
   test "NumberIO.BE.write_float64" begin fun () ->
     let buffer = Lwt_bytes.create 8 in
     Lwt_io.BE.write_float64 (Lwt_io.(of_bytes ~mode:output) buffer)
-      283686952306183. >>= fun () ->
+      (Int64.float_of_bits 0x42F0203040506070L) >>= fun () ->
     Lwt.return (Lwt_bytes.to_string buffer = "\x42\xf0\x20\x30\x40\x50\x60\x70")
   end;
 ]


### PR DESCRIPTION
- [x] Don't add unnecessary flags: rely on `musl-gcc`'s search paths.
- [x] Fix libev search.
- [x] Build with musl in one of the Travis rows to avoid regression.

Fixes #718.

cc @copy