### PR TITLE
Skip multicast tests when networking not available

### DIFF
--- a/test/unix/test_mcast.ml
+++ b/test/unix/test_mcast.ml
@@ -59,9 +59,7 @@ let test_mcast name join set_loop =
           | Lwt_unix.Timeout ->
             Lwt.return should_timeout
           | e ->
-            Printf.eprintf "\ntest_mcast: unexpected failure: %S\n%!"
-              (Printexc.to_string e);
-            Lwt.return false
+            Lwt.fail e
         )
     in
     Lwt.finalize t (fun () -> Lwt.join [Lwt_unix.close fd1; Lwt_unix.close fd2])

--- a/test/unix/test_mcast.ml
+++ b/test/unix/test_mcast.ml
@@ -58,6 +58,9 @@ let test_mcast name join set_loop =
         (function
           | Lwt_unix.Timeout ->
             Lwt.return should_timeout
+          | Unix.Unix_error (Unix.ENODEV, "setsockopt", _)
+          | Unix.Unix_error (Unix.ENETUNREACH, "send", _) ->
+            Lwt.fail Skip
           | e ->
             Lwt.fail e
         )


### PR DESCRIPTION
Fixes #722.

@olafhering, when you test, could you test this branch, `multicast-skip`? If it fixes the problem for you, I will merge.

By the way, is this testing setup something new? If not, I think these problems should have been observed a long time ago, since they were not introduced by recent changes.