### PR TITLE
Fix O_CLOEXEC tests when compiling to bytecode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - os: linux
       env: COMPILER=4.06.1 LWT_STRESS_TEST=true
     - os: linux
-      env: COMPILER=4.05.0
+      env: COMPILER=4.05.0+bytecode-only
     - os: linux
       env: COMPILER=4.04.2
     - os: linux
@@ -25,7 +25,7 @@ matrix:
     - env: COMPILER=4.08.1+musl+flambda MUSL=yes
     - env: COMPILER=4.07.1 DOCS=yes
     - env: COMPILER=4.06.1 LWT_STRESS_TEST=true
-    - env: COMPILER=4.05.0
+    - env: COMPILER=4.05.0+bytecode-only
     - env: COMPILER=4.04.2
     - env: COMPILER=4.03.0
 

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -51,7 +51,7 @@ let run_test name =
   let fixed_name = name ^ ".fixed" in
   let command =
     Printf.sprintf
-      "OCAMLPATH=%s ocamlfind opt %s -linkpkg -package lwt,lwt_ppx %s > %s 2>&1"
+      "OCAMLPATH=%s ocamlfind c %s -linkpkg -package lwt,lwt_ppx %s > %s 2>&1"
       package_directory "-color=never" ml_name fixed_name
   in
   let ocaml_return_code = _run_int command in

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -3,27 +3,6 @@
 
 
 
-let is_fd_open fd_ =
-  let fd  = (Obj.magic (int_of_string fd_) : Unix.file_descr) in
-  let buf = Bytes.create 42 in
-    try
-      ignore (Unix.read fd buf 0 42);
-      true
-    with Unix.Unix_error(Unix.EBADF, _, _) ->
-      false
-
-let () =
-  try
-    assert (not @@ is_fd_open @@ Unix.getenv Test_lwt_unix.assert_fd_closed);
-    exit 0
-  with Not_found -> ()
-
-let () =
-  try
-    assert (is_fd_open @@ Unix.getenv Test_lwt_unix.assert_fd_open);
-    exit 0
-  with Not_found -> ()
-
 let () =
   Test.concurrent "unix" [
     Test_lwt_unix.suite;

--- a/test/unix/test_lwt_unix.cppo.ml
+++ b/test/unix/test_lwt_unix.cppo.ml
@@ -10,8 +10,6 @@ let assert_fd_closed = "ASSERT_FD_CLOSED"
 let assert_fd_open   = "ASSERT_FD_OPEN"
 
 let test_cloexec assertion flags =
-  if Sys.win32 then Lwt.return true
-  else
     Lwt_unix.openfile "/dev/zero" (Unix.O_RDONLY :: flags) 0o644 >>= fun fd ->
     let fd_ = Lwt_unix.unix_file_descr fd in
     match Lwt_unix.fork () with
@@ -29,20 +27,20 @@ let test_cloexec assertion flags =
                 Lwt.return_false
 
 let openfile_tests = [
-  test "openfile: O_CLOEXEC"
+  test "openfile: O_CLOEXEC" ~only_if:(fun () -> not Sys.win32)
     (fun () -> test_cloexec assert_fd_closed [Unix.O_CLOEXEC]);
 
-  test "openfile: O_CLOEXEC not given"
+  test "openfile: O_CLOEXEC not given" ~only_if:(fun () -> not Sys.win32)
     (fun () -> test_cloexec assert_fd_open []);
 
 #if OCAML_VERSION >= (4, 05, 0)
-  test "openfile: O_KEEPEXEC"
+  test "openfile: O_KEEPEXEC" ~only_if:(fun () -> not Sys.win32)
     (fun () -> test_cloexec assert_fd_open [Unix.O_KEEPEXEC]);
 
-  test "openfile: O_CLOEXEC, O_KEEPEXEC"
+  test "openfile: O_CLOEXEC, O_KEEPEXEC" ~only_if:(fun () -> not Sys.win32)
     (fun () -> test_cloexec assert_fd_closed [Unix.O_CLOEXEC; Unix.O_KEEPEXEC]);
 
-  test "openfile: O_KEEPEXEC, O_CLOEXEC"
+  test "openfile: O_KEEPEXEC, O_CLOEXEC" ~only_if:(fun () -> not Sys.win32)
     (fun () -> test_cloexec assert_fd_closed [Unix.O_KEEPEXEC; Unix.O_CLOEXEC]);
 #endif
 ]

--- a/test/unix/test_lwt_unix.cppo.ml
+++ b/test/unix/test_lwt_unix.cppo.ml
@@ -10,21 +10,21 @@ let assert_fd_closed = "ASSERT_FD_CLOSED"
 let assert_fd_open   = "ASSERT_FD_OPEN"
 
 let test_cloexec assertion flags =
-    Lwt_unix.openfile "/dev/zero" (Unix.O_RDONLY :: flags) 0o644 >>= fun fd ->
-    let fd_ = Lwt_unix.unix_file_descr fd in
-    match Lwt_unix.fork () with
-      | 0 ->
-          Unix.putenv assertion (string_of_int @@ Obj.magic fd_);
-          (* There's no portable way to obtain the executable name (which
-           * may even no longer exist at this point), but argv[0] fortunately
-           * has the right value when the tests are run with "make test". *)
-          Unix.execv Sys.argv.(0) [||]
-      | n ->
-          Lwt_unix.close fd >>= fun () ->
-          Lwt_unix.waitpid [] n >>= function
-            | _, Unix.WEXITED 0 -> Lwt.return_true
-            | _, (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _) ->
-                Lwt.return_false
+  Lwt_unix.openfile "/dev/zero" (Unix.O_RDONLY :: flags) 0o644 >>= fun fd ->
+  let fd_ = Lwt_unix.unix_file_descr fd in
+  match Lwt_unix.fork () with
+  | 0 ->
+    Unix.putenv assertion (string_of_int @@ Obj.magic fd_);
+    (* There's no portable way to obtain the executable name (which
+     * may even no longer exist at this point), but argv[0] fortunately
+     * has the right value when the tests are run with "make test". *)
+    Unix.execv Sys.argv.(0) [||]
+  | n ->
+    Lwt_unix.close fd >>= fun () ->
+    Lwt_unix.waitpid [] n >>= function
+    | _, Unix.WEXITED 0 -> Lwt.return_true
+    | _, (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _) ->
+      Lwt.return_false
 
 let openfile_tests = [
   test "openfile: O_CLOEXEC" ~only_if:(fun () -> not Sys.win32)


### PR DESCRIPTION
@olafhering, could you test this branch, `openfile-tests`, to see if it fixes #729 for you?

The problem was caused by this line:

https://github.com/ocsigen/lwt/blob/fb00be1620197aa9c31f267ede87c678fffaeac8/test/unix/test_lwt_unix.cppo.ml#L23

which does not pass a program name to the child process. When the child process was a native-code OCaml program, it did not try to access that first argument. But, when the child is a bytecode copy of the tester, the bytecode runtime fails if the first argument is not present. It seems to work fine with the empty string as argument, however.

I added a [Travis row](https://travis-ci.org/ocsigen/lwt/jobs/594293751) for testing on a bytecode-only compiler.

Fixes #729.