### PR TITLE
Deprecate let%lwt at the module item level

### DIFF
--- a/src/ppx/dune
+++ b/src/ppx/dune
@@ -6,5 +6,5 @@
  (libraries compiler-libs.common ocaml-migrate-parsetree ppx_tools_versioned)
  (ppx_runtime_libraries lwt)
  (kind ppx_rewriter)
- (preprocess (pps ppx_tools_versioned.metaquot_409))
+ (preprocess (pps ppx_tools_versioned.metaquot_409 bisect_ppx --conditional))
  (flags (:standard -w +A-4)))

--- a/src/ppx/ppx_lwt.ml
+++ b/src/ppx/ppx_lwt.ml
@@ -465,7 +465,15 @@ let mapper =
       default_loc := stri.pstr_loc;
       match stri with
       | [%stri let%lwt [%p? var] = [%e? exp]] ->
-        [%stri let [%p var] = Lwt_main.run [%e mapper.expr mapper exp]]
+        let warning =
+          str
+            ("let%lwt should not be used at the module item level.\n" ^
+             "Replace let%lwt x = e by let x = Lwt_main.run (e)")
+        in
+        [%stri
+          let [%p var] =
+            (Lwt_main.run [@ocaml.ppwarning [%e warning]])
+              [%e mapper.expr mapper exp]]
           [@metaloc !default_loc]
 
       | x -> default_mapper.structure_item mapper x);

--- a/test/ppx_expect/cases/match_5.expect
+++ b/test/ppx_expect/cases/match_5.expect
@@ -1,2 +1,2 @@
-File "match_5.ml", line 2, characters 2-81:
+File "match_5.ml", line 3, characters 2-61:
 Error: match%lwt must contain at least one non-exception pattern.

--- a/test/ppx_expect/cases/match_5.ml
+++ b/test/ppx_expect/cases/match_5.ml
@@ -1,3 +1,3 @@
 let _ =
-  match%lwt Lwt.return () with
-  | exception (Invalid_argument _) -> Lwt.return 0
+  (* The ugly one-line match is for error message compatibility with 4.09. *)
+  match%lwt Lwt.return () with exception Exit -> Lwt.return 0

--- a/test/ppx_expect/cases/run_1.expect
+++ b/test/ppx_expect/cases/run_1.expect
@@ -1,0 +1,3 @@
+File "run_1.ml", line 2, characters 0-26:
+Warning 22: let%lwt should not be used at the module item level.
+Replace let%lwt x = e by let x = Lwt_main.run (e)

--- a/test/ppx_expect/cases/run_1.ml
+++ b/test/ppx_expect/cases/run_1.ml
@@ -1,2 +1,2 @@
-let%lwt () =
-  Lwt.return ()
+(* On one line for error message compatibility with 4.09. *)
+let%lwt () = Lwt.return ()

--- a/test/ppx_expect/cases/run_1.ml
+++ b/test/ppx_expect/cases/run_1.ml
@@ -1,0 +1,2 @@
+let%lwt () =
+  Lwt.return ()

--- a/test/ppx_expect/cases/run_2.expect
+++ b/test/ppx_expect/cases/run_2.expect
@@ -1,0 +1,2 @@
+File "run_2.ml", line 1, characters 4-7:
+Error: Uninterpreted extension 'lwt'.

--- a/test/ppx_expect/cases/run_2.ml
+++ b/test/ppx_expect/cases/run_2.ml
@@ -1,0 +1,2 @@
+let%lwt rec () = Lwt.return ()
+and () = Lwt.return ()

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -51,15 +51,11 @@ let run_test name =
   let fixed_name = name ^ ".fixed" in
   let command =
     Printf.sprintf
-      "%s %s ocamlfind c %s -linkpkg -package lwt,lwt_ppx %s > %s 2>&1"
+      "%s %s ocamlfind c %s -linkpkg -thread -package %s %s > %s 2>&1"
       ("OCAMLPATH=" ^ package_directory) "OCAML_ERROR_STYLE=short"
-      "-color=never" ml_name fixed_name
+      "-color=never" "lwt.unix,lwt_ppx" ml_name fixed_name
   in
-  let ocaml_return_code = _run_int command in
-  begin if ocaml_return_code = 0 then
-    failwith
-      (Printf.sprintf "Unexpected compiler return code: %d" ocaml_return_code)
-  end;
+  ignore (_run_int command);
   diff expect_name fixed_name
 
 let () =

--- a/test/ppx_expect/main.ml
+++ b/test/ppx_expect/main.ml
@@ -51,8 +51,9 @@ let run_test name =
   let fixed_name = name ^ ".fixed" in
   let command =
     Printf.sprintf
-      "OCAMLPATH=%s ocamlfind c %s -linkpkg -package lwt,lwt_ppx %s > %s 2>&1"
-      package_directory "-color=never" ml_name fixed_name
+      "%s %s ocamlfind c %s -linkpkg -package lwt,lwt_ppx %s > %s 2>&1"
+      ("OCAMLPATH=" ^ package_directory) "OCAML_ERROR_STYLE=short"
+      "-color=never" ml_name fixed_name
   in
   let ocaml_return_code = _run_int command in
   begin if ocaml_return_code = 0 then
@@ -62,15 +63,6 @@ let run_test name =
   diff expect_name fixed_name
 
 let () =
-  (* Don't run on 4.08, due to different error and warning output. *)
-  let ocaml_version =
-    Scanf.sscanf Sys.ocaml_version "%u.%u%[.]%[0-9]"
-      (fun major minor _periods patchlevel ->
-        major, minor, try Some (int_of_string patchlevel) with _ -> None)
-  in
-  if ocaml_version >= (4, 8, None) then
-    exit 0;
-
   let test_cases =
     Sys.readdir test_directory
     |> Array.to_list


### PR DESCRIPTION
Using `let%lwt` as a module item now produces a warning like this:

```
File "test/ppx/main.ml", line 162, characters 9-41:
162 |          let%lwt result = Lwt.return_true
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning 22: let%lwt should not be used at the module item level.
Replace let%lwt x = e by let x = Lwt_main.run (e)
```

Resolves #728.

<br/>

I completely removed support for `let%lwt ... and ...`, because it was broken. This line

https://github.com/ocsigen/lwt/blob/18e990e5b8875e654c165e2fdfa834340f36108d/src/ppx/ppx_lwt.ml#L140

was accidentally inserting the identifier `gen_exp` into the output AST, because it is missing an `[%e ...]` antiquotation, resulting in errors like

```
File "run_2.ml", line 1, characters 0-49:
Error: Unbound value gen_exp
```

This means that nobody has ever used `let%lwt ... and ...` successfully.

I removed the warning that we were trying to print on `let%lwt rec ... and ...`, because, in this case, the warning seems to be ignored, and the output is simply

```
File "run_2.ml", line 1, characters 4-7:
Error: Uninterpreted extension 'lwt'.
```

whether we try to add the warning or not. Given that we will already be discouraging `let%lwt` at structure item level without `and`, I think it's fine to have just this uglier message.

The result of these two changes is that we never try to interpret `let%lwt ... and ...` at all, simplifying the PPX a bit.