### PR TITLE
Retain references to buffers while doing blocking I/O

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -793,8 +793,7 @@ external stub_writev :
   Unix.file_descr -> IO_vectors.io_vector list -> int -> int =
   "lwt_unix_writev"
 
-external writev_job :
-  Unix.file_descr -> IO_vectors.io_vector list -> int -> int job =
+external writev_job : Unix.file_descr -> IO_vectors.t -> int -> int job =
   "lwt_unix_writev_job"
 
 let writev fd io_vectors =
@@ -803,7 +802,7 @@ let writev fd io_vectors =
   Lazy.force fd.blocking >>= function
   | true ->
     wait_write fd >>= fun () ->
-    run_job (writev_job fd.fd io_vectors.IO_vectors.prefix count)
+    run_job (writev_job fd.fd io_vectors count)
   | false ->
     wrap_syscall Write fd (fun () ->
       stub_writev fd.fd io_vectors.IO_vectors.prefix count)

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -236,7 +236,22 @@ let self_result job =
   with exn ->
     Result.Error exn
 
+let in_retention_test = ref false
+
+let retained o =
+  let retained = ref true in
+  Gc.finalise (fun _ ->
+    if !in_retention_test then
+      retained := false)
+    o;
+  in_retention_test := true;
+  retained
+
 let run_job ?async_method job =
+  if !in_retention_test then begin
+    Gc.full_major ();
+    in_retention_test := false
+  end;
   let async_method = choose_async_method async_method in
   if async_method = Async_none then
     try

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -774,8 +774,7 @@ external stub_readv :
   Unix.file_descr -> IO_vectors.io_vector list -> int -> int =
   "lwt_unix_readv"
 
-external readv_job :
-  Unix.file_descr -> IO_vectors.io_vector list -> int -> int job =
+external readv_job : Unix.file_descr -> IO_vectors.t -> int -> int job =
   "lwt_unix_readv_job"
 
 let readv fd io_vectors =
@@ -784,7 +783,7 @@ let readv fd io_vectors =
   Lazy.force fd.blocking >>= function
   | true ->
     wait_read fd >>= fun () ->
-    run_job (readv_job fd.fd io_vectors.IO_vectors.prefix count)
+    run_job (readv_job fd.fd io_vectors count)
   | false ->
     wrap_syscall Read fd (fun () ->
       stub_readv fd.fd io_vectors.IO_vectors.prefix count)

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -1535,3 +1535,6 @@ val has_wait4 : bool
 
 val somaxconn : unit -> int
   [@@ocaml.deprecated " This is an internal function."]
+
+val retained : 'a -> bool ref
+  (** @deprecated Used for testing. *)

--- a/src/unix/unix_c/unix_wait_mincore_job.c
+++ b/src/unix/unix_c/unix_wait_mincore_job.c
@@ -8,6 +8,7 @@
 #if !defined(LWT_ON_WINDOWS)
 
 #include <caml/bigarray.h>
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
 #include <string.h>
@@ -19,6 +20,7 @@ LWT_NOT_AVAILABLE2(unix_wait_mincore_job)
 #else
 struct job_wait_mincore {
     struct lwt_unix_job job;
+    value ocaml_buffer;
     char *ptr;
 };
 
@@ -31,6 +33,7 @@ static void worker_wait_mincore(struct job_wait_mincore *job)
 
 static value result_wait_mincore(struct job_wait_mincore *job)
 {
+    caml_remove_generational_global_root(&job->ocaml_buffer);
     lwt_unix_free_job(&job->job);
     return Val_unit;
 }
@@ -39,6 +42,8 @@ CAMLprim value lwt_unix_wait_mincore_job(value val_buffer, value val_offset)
 {
     LWT_UNIX_INIT_JOB(job, wait_mincore, 0);
     job->ptr = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
+    job->ocaml_buffer = val_buffer;
+    caml_register_generational_global_root(&job->ocaml_buffer);
     return lwt_unix_alloc_job(&(job->job));
 }
 #endif

--- a/src/unix/windows_c/windows_bytes_read_job.c
+++ b/src/unix/windows_c/windows_bytes_read_job.c
@@ -8,6 +8,7 @@
 #if defined(LWT_ON_WINDOWS)
 
 #include <caml/bigarray.h>
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
 

--- a/src/unix/windows_c/windows_bytes_read_job.c
+++ b/src/unix/windows_c/windows_bytes_read_job.c
@@ -24,6 +24,7 @@ struct job_bytes_read {
     DWORD length;
     DWORD result;
     DWORD error_code;
+    value ocaml_buffer;
 };
 
 static void worker_bytes_read(struct job_bytes_read *job)
@@ -44,6 +45,7 @@ static value result_bytes_read(struct job_bytes_read *job)
 {
     value result;
     DWORD error = job->error_code;
+    caml_remove_generational_global_root(&job->ocaml_buffer);
     if (error) {
         lwt_unix_free_job(&job->job);
         win32_maperr(error);
@@ -67,6 +69,8 @@ CAMLprim value lwt_unix_bytes_read_job(value val_fd, value val_buffer,
     job->buffer = (char *)Caml_ba_data_val(val_buffer) + Long_val(val_offset);
     job->length = Long_val(val_length);
     job->error_code = 0;
+    job->ocaml_buffer = val_buffer;
+    caml_register_generational_global_root(&job->ocaml_buffer);
     return lwt_unix_alloc_job(&(job->job));
 }
 #endif

--- a/src/unix/windows_c/windows_bytes_write_job.c
+++ b/src/unix/windows_c/windows_bytes_write_job.c
@@ -8,6 +8,7 @@
 #if defined(LWT_ON_WINDOWS)
 
 #include <caml/bigarray.h>
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
 

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -609,7 +609,7 @@ let suite = suite "lwt_bytes" [
       Lwt.return check
     end;
 
-    test "read: buffer retention" begin fun () ->
+    test "read: buffer retention" ~sequential:true begin fun () ->
       let buffer = Lwt_bytes.create 3 in
 
       let read_fd, write_fd = Lwt_unix.pipe () in
@@ -646,7 +646,7 @@ let suite = suite "lwt_bytes" [
       Lwt.return check
     end;
 
-    test "write: buffer retention" begin fun () ->
+    test "write: buffer retention" ~sequential:true begin fun () ->
       let buffer = Lwt_bytes.create 3 in
 
       let read_fd, write_fd = Lwt_unix.pipe () in

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -609,6 +609,23 @@ let suite = suite "lwt_bytes" [
       Lwt.return check
     end;
 
+    test "read: buffer retention" begin fun () ->
+      let buffer = Lwt_bytes.create 3 in
+
+      let read_fd, write_fd = Lwt_unix.pipe () in
+      Lwt_unix.set_blocking read_fd true;
+
+      Lwt_unix.write_string write_fd "foo" 0 3 >>= fun _ ->
+
+      let retained = Lwt_unix.retained buffer in
+      Lwt_bytes.read read_fd buffer 0 3 >>= fun _ ->
+
+      Lwt_unix.close write_fd >>= fun () ->
+      Lwt_unix.close read_fd >|= fun () ->
+
+      !retained
+    end;
+
     test "bytes write" begin fun () ->
       let test_file = "bytes_io_data_write" in
       Lwt_unix.openfile test_file [O_RDWR;O_TRUNC; O_CREAT] 0o666

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -646,6 +646,21 @@ let suite = suite "lwt_bytes" [
       Lwt.return check
     end;
 
+    test "write: buffer retention" begin fun () ->
+      let buffer = Lwt_bytes.create 3 in
+
+      let read_fd, write_fd = Lwt_unix.pipe () in
+      Lwt_unix.set_blocking write_fd true;
+
+      let retained = Lwt_unix.retained buffer in
+      Lwt_bytes.write write_fd buffer 0 3 >>= fun _ ->
+
+      Lwt_unix.close write_fd >>= fun () ->
+      Lwt_unix.close read_fd >|= fun () ->
+
+      !retained
+    end;
+
     test "bytes recv" ~only_if:(fun () -> not Sys.win32) begin fun () ->
       let buf = gen_buf 6 in
       let server_logic socket =


### PR DESCRIPTION
@olafhering, #726 was actually a symptom of a small family of pretty serious bugs in Lwt. Some Lwt APIs were not retaining references to user buffers that were passed in for I/O, and the buffers were occasionally being released too early.

These bugs are fairly difficult to trigger, as they require:

- Doing I/O on a blocking fd (Lwt is primarily used with sockets and pipes in non-blocking mode).
- The user not retaining a reference to the buffer (most programs reuse their buffers, so they retain the references).
- The I/O not completing right away (in most cases, blocking I/O calls do complete right away).
- An intervening GC cycle between when the I/O is scheduled and when it runs.

When triggered, Lwt could access dead (or reallocated) memory when writing, and unexpectedly write to memory of other objects when reading. The buggy APIs were `Lwt_unix.writev`, `Lwt_unix.readv`, `Lwt_bytes.write`, `Lwt_bytes.read`. `Lwt_bytes.wait_mincore` also had the issue, even though it's a different kind of function.

I added a new kind of tests specifically for buffer retention, and reviewed the arguments of all functions in `lwt.unix` for whether they have this bug or not.

I ran the same stress test that I used to reproduce #726 locally, and did not observe the problem with these patches. I'll run it a few more times, and then merge.

@olafhering, thanks again for being thorough and reporting the issue.

Fixes #726.