### PR TITLE
Fix C warning with OCaml 4.10

### DIFF
--- a/src/unix/unix_c/unix_read_job.c
+++ b/src/unix/unix_c/unix_read_job.c
@@ -11,10 +11,15 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
+#include <caml/version.h>
 #include <errno.h>
 #include <string.h>
 
 #include "lwt_unix.h"
+
+#if OCAML_VERSION < 40600
+#define Bytes_val(x) String_val(x)
+#endif
 
 struct job_read {
     struct lwt_unix_job job;
@@ -49,7 +54,7 @@ static value result_read(struct job_read *job)
         lwt_unix_free_job(&job->job);
         unix_error(error_code, "read", Nothing);
     } else {
-        memcpy(String_val(job->string) + job->offset, job->buffer, result);
+        memcpy(Bytes_val(job->string) + job->offset, job->buffer, result);
         caml_remove_generational_global_root(&(job->string));
         lwt_unix_free_job(&job->job);
         return Val_long(result);

--- a/src/unix/windows_c/windows_read_job.c
+++ b/src/unix/windows_c/windows_read_job.c
@@ -10,8 +10,13 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
+#include <caml/version.h>
 
 #include "lwt_unix.h"
+
+#if OCAML_VERSION < 40600
+#define Bytes_val(x) String_val(x)
+#endif
 
 struct job_read {
     struct lwt_unix_job job;
@@ -52,7 +57,7 @@ static value result_read(struct job_read *job)
         win32_maperr(error);
         uerror("read", Nothing);
     }
-    memcpy(String_val(job->string) + job->offset, job->buffer, job->result);
+    memcpy(Bytes_val(job->string) + job->offset, job->buffer, job->result);
     result = Val_long(job->result);
     caml_remove_generational_global_root(&job->string);
     lwt_unix_free_job(&job->job);


### PR DESCRIPTION
OCaml 4.10 comes by default with -force-safe-string enabled which means String_val changes from char* to const char*. Bytes_val should be used instead.

The warning looked like this:
```
+ /home/opam/.opam/4.10.0+trunk/bin/dune "build" "-p" "lwt" "-j" "71" (CWD=/home/opam/.opam/4.10.0+trunk/.opam-switch/build/lwt.4.4.0)
-       ocamlc src/unix/unix_read_job.o
- unix_read_job.c: In function 'result_read':
- unix_read_job.c:52:40: warning: passing argument 1 of 'memcpy' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
-    52 |         memcpy(String_val(job->string) + job->offset, job->buffer, result);
- In file included from unix_read_job.c:15:
- /usr/include/string.h:42:14: note: expected 'void * restrict' but argument is of type 'const char *'
-    42 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
-       |              ^~~~~~
-       ocamlc src/unix/lwt_unix_stubs.o
- lwt_unix_stubs.c: In function 'lwt_unix_blit_to_bytes':
- lwt_unix_stubs.c:134:31: warning: passing argument 1 of 'memcpy' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
-   134 |   memcpy(String_val(val_buf2) + Long_val(val_ofs2),
- In file included from /usr/include/x86_64-linux-gnu/sys/un.h:37,
-                  from /home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/socketaddr.h:22,
-                  from lwt_unix.h:15,
-                  from lwt_unix_stubs.c:35:
- /usr/include/string.h:42:14: note: expected 'void * restrict' but argument is of type 'const char *'
-    42 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
-       |              ^~~~~~
```