### PR TITLE
mock wait4 on android using waitpid like on win32

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -2242,7 +2242,7 @@ let has_wait4 = not Sys.win32
 external stub_wait4 : Unix.wait_flag list -> int -> int * Unix.process_status * resource_usage = "lwt_unix_wait4"
 
 let do_wait4 flags pid =
-  if Sys.win32 then
+  if Sys.win32 || Lwt_config.android then
     let pid, status = Unix.waitpid flags pid in
     (pid, status, { ru_utime = 0.0; ru_stime = 0.0 })
   else
@@ -2312,7 +2312,7 @@ let waitpid =
 
 let wait4 flags pid =
   install_sigchld_handler ();
-  if Sys.win32 then
+  if Sys.win32 || Lwt_config.android then
     Lwt.return (do_wait4 flags pid)
   else
   if List.mem Unix.WNOHANG flags then


### PR DESCRIPTION
Right now Lwt_process fails when using Android NDK because `wait4` isn't available on every Android device. To solve it this PR implements the same behavior as on win32 it just uses `waitpid` and fills the `rusage` with a mock.

This is important because esy does use Lwt_process and it fails without this patch to work when using an Android device