### PR TITLE
Initial implementation of readv, writev on Windows

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -830,13 +830,13 @@ let readv fd io_vectors =
         read_bigarray "Lwt_unix.readv" fd buffer first.offset first.length
 
   else
-  Lazy.force fd.blocking >>= function
-  | true ->
-    wait_read fd >>= fun () ->
-    run_job (readv_job fd.fd io_vectors count)
-  | false ->
-    wrap_syscall Read fd (fun () ->
-      stub_readv fd.fd io_vectors.IO_vectors.prefix count)
+    Lazy.force fd.blocking >>= function
+    | true ->
+      wait_read fd >>= fun () ->
+      run_job (readv_job fd.fd io_vectors count)
+    | false ->
+      wrap_syscall Read fd (fun () ->
+        stub_readv fd.fd io_vectors.IO_vectors.prefix count)
 
 external stub_writev :
   Unix.file_descr -> IO_vectors.io_vector list -> int -> int =
@@ -860,13 +860,13 @@ let writev fd io_vectors =
         write_bigarray "Lwt_unix.writev" fd buffer first.offset first.length
 
   else
-  Lazy.force fd.blocking >>= function
-  | true ->
-    wait_write fd >>= fun () ->
-    run_job (writev_job fd.fd io_vectors count)
-  | false ->
-    wrap_syscall Write fd (fun () ->
-      stub_writev fd.fd io_vectors.IO_vectors.prefix count)
+    Lazy.force fd.blocking >>= function
+    | true ->
+      wait_write fd >>= fun () ->
+      run_job (writev_job fd.fd io_vectors count)
+    | false ->
+      wrap_syscall Write fd (fun () ->
+        stub_writev fd.fd io_vectors.IO_vectors.prefix count)
 
 (* +-----------------------------------------------------------------+
    | Seeking and truncating                                          |

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -1541,3 +1541,11 @@ val somaxconn : unit -> int
 
 val retained : 'a -> bool ref
   (** @deprecated Used for testing. *)
+
+val read_bigarray :
+  string -> file_descr -> IO_vectors._bigarray -> int -> int -> int Lwt.t
+  [@@ocaml.deprecated " This is an internal function."]
+
+val write_bigarray :
+  string -> file_descr -> IO_vectors._bigarray -> int -> int -> int Lwt.t
+  [@@ocaml.deprecated " This is an internal function."]


### PR DESCRIPTION
With this PR, calling `readv` or `writev` on Windows causes the first buffer to be read to or written from using the implementations of the regular `read` and `write`.

Resolves #745.

cc @ulrikstrid, @lessp

I believe this is just about the last thing I wanted to do before the final 4.x.x release, so this should be out very soon.