### PR TITLE
Don't extend library flags if the library isn't found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,13 +135,13 @@ scripts:
     script:
       - esy install
       - esy build
-      - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep lev'
+      - 'cat _build/default/src/unix/unix_c_library_flags.sexp | grep lev'
       - |
         sed -i 's#"@opam/conf-libev": "\*",##g' esy.json
       - esy install
       - esy build
       # Check `lev` isn't detected
-      - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep -v lev'
+      - 'cat _build/default/src/unix/unix_c_library_flags.sexp | grep -v lev'
 
     cache:
       directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,13 +135,13 @@ scripts:
     script:
       - esy install
       - esy build
-      - 'cat _build/default/src/unix/unix_c_library_flags.sexp | grep lev'
+      - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep lev'
       - |
         sed -i 's#"@opam/conf-libev": "\*",##g' esy.json
       - esy install
       - esy build
       # Check `lev` isn't detected
-      - 'cat _build/default/src/unix/unix_c_library_flags.sexp | grep -v lev'
+      - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep -v lev'
 
     cache:
       directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,8 @@ scripts:
       - esy install
       - esy build
       - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep lev'
-      - sed -i 's#"@opam/conf-libev": "\*",##g' esy.json
+      - |
+        sed -i 's#"@opam/conf-libev": "\*",##g' esy.json
       - esy install
       - esy build
       # Check `lev` isn't detected

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,11 @@ scripts:
       - esy install
       - esy build
       - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep lev'
+      - sed -i 's#"@opam/conf-libev": "\*",##g' esy.json
+      - esy install
+      - esy build
+      # Check `lev` isn't detected
+      - 'esy sh -c "cat #{self.target_dir}/_build/default/src/unix/unix_c_library_flags.sexp"  | grep -v lev'
 
     cache:
       directories:

--- a/esy.json
+++ b/esy.json
@@ -10,6 +10,7 @@
     "resolutions": {
       "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb66",
       "@opam/bisect_ppx": "aantron/bisect_ppx:bisect_ppx.opam#02dfb10"
-    }
+    },
+    "buildsInSource": "unsafe"
   }
 }

--- a/esy.json
+++ b/esy.json
@@ -10,7 +10,6 @@
     "resolutions": {
       "@opam/conf-libev": "esy-packages/libev:package.json#0b5eb66",
       "@opam/bisect_ppx": "aantron/bisect_ppx:bisect_ppx.opam#02dfb10"
-    },
-    "buildsInSource": "unsafe"
+    }
   }
 }

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -254,8 +254,7 @@ struct
           extend
             ["-I" ^ (path // "include")]
             ["-L" ^ (path // "lib"); "-l" ^ library]
-        with Not_found ->
-          extend [] ["-l" ^ library]
+        with Not_found -> ()
 
   let ws2_32_lib context =
     if Configurator.ocaml_config_var_exn context "os_type" = "Win32" then


### PR DESCRIPTION
This fixes an issue where after #755 Esy would _only_ work if libev was
available in the sandbox.