### PR TITLE
Define let*, and*

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.1)
+(lang dune 1.8)

--- a/lwt.opam
+++ b/lwt.opam
@@ -23,6 +23,7 @@ depends: [
   "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
+  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
   "ocplib-endian"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,13 +1,10 @@
 (* -*- tuareg -*- *)
 
 let preprocess =
-  let res =
-    match Sys.getenv "BISECT_ENABLE" with
-    | "yes" -> "(preprocess (pps bisect_ppx))"
-    | _ -> ""
-    | exception _ -> ""
-  in
-  res^"\n(preprocess (future_syntax))"
+   match Sys.getenv "BISECT_ENABLE" with
+   | "yes" -> "(preprocess (pps bisect_ppx) (future_syntax))"
+   | _ -> "(preprocess (future_syntax))"
+   | exception _ -> "(preprocess (future_syntax))"
 
 let () = Jbuild_plugin.V1.send @@ {|
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,10 +1,20 @@
 (* -*- tuareg -*- *)
 
 let preprocess =
-   match Sys.getenv "BISECT_ENABLE" with
-   | "yes" -> "(preprocess (pps bisect_ppx) (future_syntax))"
-   | _ -> "(preprocess (future_syntax))"
-   | exception _ -> "(preprocess (future_syntax))"
+  let older =
+    Scanf.sscanf
+      Sys.ocaml_version
+      "%d.%2d.%s"
+      (fun maj min _ -> maj < 4 || (maj = 4 && min < 8))
+  in
+  let bisect =
+    match Sys.getenv "BISECT_ENABLE" with
+    | "yes" -> "(preprocess (pps bisect_ppx))"
+    | _ -> ""
+    | exception _ -> ""
+  in
+  let future_syntax = "(preprocess (future_syntax))" in
+  if older && bisect = "" then future_syntax else bisect
 
 let () = Jbuild_plugin.V1.send @@ {|
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,13 +1,13 @@
 (* -*- tuareg -*- *)
 
 let preprocess =
-   let res =
-	   match Sys.getenv "BISECT_ENABLE" with
-     | "yes" -> "(preprocess (pps bisect_ppx))"
-     | _ -> ""
-     | exception _ -> ""
-	 in
-	 res^"\n(preprocess (future_syntax))"
+  let res =
+    match Sys.getenv "BISECT_ENABLE" with
+    | "yes" -> "(preprocess (pps bisect_ppx))"
+    | _ -> ""
+    | exception _ -> ""
+  in
+  res^"\n(preprocess (future_syntax))"
 
 let () = Jbuild_plugin.V1.send @@ {|
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,10 +1,13 @@
 (* -*- tuareg -*- *)
 
 let preprocess =
-   match Sys.getenv "BISECT_ENABLE" with
-   | "yes" -> "(preprocess (pps bisect_ppx))"
-   | _ -> ""
-   | exception _ -> ""
+   let res =
+	   match Sys.getenv "BISECT_ENABLE" with
+     | "yes" -> "(preprocess (pps bisect_ppx))"
+     | _ -> ""
+     | exception _ -> ""
+	 in
+	 res^"\n(preprocess (future_syntax))"
 
 let () = Jbuild_plugin.V1.send @@ {|
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -3116,6 +3116,11 @@ struct
 end
 include Infix
 
+module Syntax =
+struct
+  let (let*) = bind
+  let (and*) = both
+end
 
 
 module Lwt_result_type =

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1397,6 +1397,12 @@ let () =
   end
 end
 
+(** {3 Syntax} *)
+module Syntax :
+sig
+  val (let*) : 'a t -> ('a -> 'b t) -> 'b t
+  val (and*) : 'a t -> 'b t -> ('a * 'b) t
+end
 
 
 (** {3 Pre-allocated promises} *)

--- a/src/core/lwt_result.ml
+++ b/src/core/lwt_result.ml
@@ -65,9 +65,21 @@ let bind_lwt_err e f =
       | Error e -> Lwt.bind (f e) fail
       | Ok x -> return x)
 
+let both a b =
+  Lwt.map
+    (function
+      | Ok x, Ok y -> Ok (x,y)
+      | Error e, _ | _, Error e -> Error e)
+    (Lwt.both a b)
+
 module Infix = struct
   let (>>=) = bind
   let (>|=) e f = map f e
+end
+
+module Syntax = struct
+  let (let*) = bind
+  let (and*) = both
 end
 
 include Infix

--- a/src/core/lwt_result.ml
+++ b/src/core/lwt_result.ml
@@ -66,10 +66,20 @@ let bind_lwt_err e f =
       | Ok x -> return x)
 
 let both a b =
+  let s = ref [] in
+  let append e = s := e::(!s) in
+  let (a,b) = map_err append a,map_err append b in
+  let rec last = function
+    | [] -> assert false
+    | e::[] -> Error e
+    | _::es -> last es
+  in
   Lwt.map
     (function
       | Ok x, Ok y -> Ok (x,y)
-      | Error e, _ | _, Error e -> Error e)
+      | Error _, Ok _
+      | Ok _,Error _ 
+      | Error _, Error _ -> last !s)
     (Lwt.both a b)
 
 module Infix = struct

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -41,9 +41,23 @@ val bind_lwt_err : ('a,'e1) t -> ('e1 -> 'e2 Lwt.t) -> ('a,'e2) t
 
 val bind_result : ('a,'e) t -> ('a -> ('b,'e) Result.result) -> ('b,'e) t
 
+val both : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
+(** [Lwt.both p_1 p_2] returns a promise that is pending until {e both} promises
+    [p_1] and [p_2] become {{: #TYPEt} {e resolved}}.
+    If only [p_1] is [Error e], the promise returns [Error e],
+    If only [p_2] is [Error e], the promise returns [Error e],
+    If both [p_1] and [p_2] are errors, the error corresponding to [p_1] is chosen arbitrarily
+    *)
+
+
 module Infix : sig
   val (>|=) : ('a,'e) t -> ('a -> 'b) -> ('b,'e) t
   val (>>=) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
+end
+
+module Syntax : sig
+  val (let*) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
+  val (and*) : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
 end
 
 include module type of Infix

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -46,7 +46,7 @@ val both : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
     [p_1] and [p_2] become {{: #TYPEt} {e resolved}}.
     If only [p_1] is [Error e], the promise returns [Error e],
     If only [p_2] is [Error e], the promise returns [Error e],
-    If both [p_1] and [p_2] are errors, the error corresponding to [p_1] is chosen arbitrarily
+    If both [p_1] and [p_2] are errors, the error corresponding to the promise that resolved first is returned.
     *)
 
 


### PR DESCRIPTION
Proposal to add a syntax module to both `Lwt` and `Lwt_result` now that `let*` and `and*` are available in vanilla OCaml without ppx.

I've made an arbitrary choice while defining `Lwt_result.both` that works for most cases, because I cannot think of a solution that is both general and easy to use. I could avoid the arbitrary choice like so:
```ocaml
val both : ('e -> 'e -> 'e) -> ('a, 'e) Result.t Lwt.t -> ('b, 'e) -> Result.t Lwt.t

let both combine r1 r2 =
  Lwt.map (function
    | Ok p1, Ok p2 -> Ok (p1,p2)
    | Error e1, Error e2 -> Error (combine e1 e2)
    | Error e,_ | _,Error e -> Error e) (Lwt.both a b)

(* In case of string, we would say *)
let (and*) = Lwt_result.both (^)
```

But then defining the syntax module would probably involve a functor which is not that nice to use.

I'm open to suggestions - the main motivation is to not have to redefine these all the time for being able to use monadic syntax.