### PR TITLE
Add {let+,and+} applicative syntax

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -3120,6 +3120,9 @@ module Syntax =
 struct
   let (let*) = bind
   let (and*) = both
+
+  let (let+) x f = map f x
+  let (and+) = both
 end
 
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1400,7 +1400,6 @@ end
 (** {3 Let syntax} *)
 module Syntax :
 sig
-  (**)
 
   (** {1 Monadic syntax} *)
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1402,6 +1402,9 @@ module Syntax :
 sig
   val (let*) : 'a t -> ('a -> 'b t) -> 'b t
   val (and*) : 'a t -> 'b t -> ('a * 'b) t
+
+  val (let+) : 'a t -> ('a -> 'b) -> 'b t
+  val (and+) : 'a t -> 'b t -> ('a * 'b) t
 end
 
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1400,11 +1400,23 @@ end
 (** {3 Let syntax} *)
 module Syntax :
 sig
+  (**)
+
+  (** {1 Monadic syntax} *)
+
   val (let*) : 'a t -> ('a -> 'b t) -> 'b t
+  (** Syntax for {!bind}. *)
+
   val (and*) : 'a t -> 'b t -> ('a * 'b) t
+  (** Syntax for {!both}. *)
+
+  (** {1 Applicative syntax} *)
 
   val (let+) : 'a t -> ('a -> 'b) -> 'b t
+  (** Syntax for {!map}. *)
+
   val (and+) : 'a t -> 'b t -> ('a * 'b) t
+  (** Syntax for {!both}. *)
 end
 
 

--- a/src/core/lwt_result.ml
+++ b/src/core/lwt_result.ml
@@ -93,6 +93,9 @@ end
 module Syntax = struct
   let (let*) = bind
   let (and*) = both
+
+  let (let+) x f = map f x
+  let (and+) = both
 end
 
 include Infix

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -57,7 +57,6 @@ end
 
 (** {3 Let syntax} *)
 module Syntax : sig
-  (**)
 
   (** {1 Monadic syntax} *)
 

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -58,6 +58,9 @@ end
 module Syntax : sig
   val (let*) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
   val (and*) : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
+
+  val (let+) : ('a,'e) t -> ('a -> 'b) -> ('b, 'e) t
+  val (and+) : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
 end
 
 include module type of Infix

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -55,12 +55,25 @@ module Infix : sig
   val (>>=) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
 end
 
+(** {3 Let syntax} *)
 module Syntax : sig
+  (**)
+
+  (** {1 Monadic syntax} *)
+
   val (let*) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
+  (** Syntax for {!bind}. *)
+
   val (and*) : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
+  (** Syntax for {!both}. *)
+
+  (** {1 Applicative syntax} *)
 
   val (let+) : ('a,'e) t -> ('a -> 'b) -> ('b, 'e) t
+  (** Syntax for {!map}. *)
+
   val (and+) : ('a,'e) t -> ('b,'e) t -> ('a * 'b,'e) t
+  (** Syntax for {!both}. *)
 end
 
 include module type of Infix

--- a/test/core/test_lwt_result.ml
+++ b/test/core/test_lwt_result.ml
@@ -215,4 +215,19 @@ let suite =
         Lwt.wakeup r2 (Result.Ok "bar");
         state_is (Lwt.Return (Result.Ok "foobar")) p'
       );
+
+    test "let+/and+"
+      (fun () ->
+        let p1, r1 = Lwt.wait () in
+        let p2, r2 = Lwt.wait () in
+        let p' =
+          let open Lwt_result.Syntax in
+          let+ s1 = p1
+          and+ s2 = p2 in
+          s1 ^ s2
+        in
+        Lwt.wakeup r1 (Result.Ok "foo");
+        Lwt.wakeup r2 (Result.Ok "bar");
+        state_is (Lwt.Return (Result.Ok "foobar")) p'
+      );
   ]


### PR DESCRIPTION
A follow up to https://github.com/ocsigen/lwt/pull/775 proposing `Syntax.(( let+ ), ( and+ ))` operators for the `Lwt` and `Lwt_result` modules.

When working with Lwt, I find myself using `>|=` often enough that a switch to `open Lwt.Syntax` would be frustrating without an equivalent syntactic form. As a sample from the [`mirage/irmin`](https://github.com/mirage/irmin) codebase:

```bash
ᐅ git grep ">>=" | wc -l
1480

ᐅ git grep ">|=" | wc -l
347
```

The proposed `( and+ )` operations behave the same as `( and* )`: I find it convenient / aesthetic to use the corresponding `and<op>` for whichever `let<op>` I'm using. We've been using similar aliases in [OCurrent syntax](https://ocurrent.github.io/ocurrent/current/Current/Syntax/index.html).