### PR TITLE
Some simplifications

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+===== dev =====
+
+  * Avoid double-reversing when traversing lists. This may change the order in
+    which some promises are collected, which may change which of several
+    rejection is arbitrarily selected during concurrent traversal.
+
 ===== 5.3.0 (2020-04-22) =====
 
   * Add let* and and* in Lwt.Syntax and Lwt_result.Syntax (#775, Rahul Kumar).

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -43,8 +43,13 @@ let () = Lwt_main.run (main ())
       [Pervasives.at_exit], use {!Lwt_main.at_exit} instead. *)
 
 val yield : unit -> unit Lwt.t
-  (** [yield ()] is a threads which suspends itself and then resumes
-      as soon as possible and terminates. *)
+  (** [yield ()] is a pending promise that is fulfilled after Lwt finishes
+      calling all currently ready callbacks, i.e. it is fulfilled on the next
+      “tick.”
+
+      [yield] is similar to {!Lwt.pause} which exists for historical reason.
+      Prefer [pause] in order to stay compatible with other execution
+      environments such as js_of_ocaml. *)
 
 
 

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -47,7 +47,7 @@ val yield : unit -> unit Lwt.t
       calling all currently ready callbacks, i.e. it is fulfilled on the next
       “tick.”
 
-      [yield] is similar to {!Lwt.pause} which exists for historical reason.
+      [yield] is similar to {!Lwt.pause} and it exists for historical reason.
       Prefer [pause] in order to stay compatible with other execution
       environments such as js_of_ocaml. *)
 


### PR DESCRIPTION
Two relatively simple modifications. (Albeit one is simple but not trivial.)

The first commit implements `Lwt_main.yield` as a call to `Lwt.pause` and removes all the support code associated with the previous implementation. This is not trivial and may have subtle effects on the scheduling performed in `Lwt_main.run`.

The second commit simply avoids some `List.rev` calls when traversing lists (`iter_p`, `iteri_p`, etc.).