### PR TITLE
Cancellable

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1550,7 +1550,6 @@ sig
 
   val protected : 'a t -> 'a t
   val no_cancel : 'a t -> 'a t
-  val wrap_in_cancelable : 'a t -> 'a t
 end =
 struct
   let new_pending ~how_to_cancel =
@@ -1685,28 +1684,6 @@ struct
       in
       add_implicitly_removed_callback p_callbacks callback;
 
-      to_public_promise p'
-
-  let wrap_in_cancelable p =
-    let Internal p_internal = to_internal_promise p in
-    let p_underlying = underlying p_internal in
-    match p_underlying.state with
-    | Fulfilled _ -> p
-    | Rejected _ -> p
-    | Pending p_callbacks ->
-      let rec p' = lazy (
-        new_pending
-          ~how_to_cancel:(
-            Propagate_cancel_to_several [p_underlying ; Lazy.force p'])) in
-      let p' = Lazy.force p' in
-      let callback p_result =
-        let State_may_now_be_pending_proxy p' = may_now_be_proxy p' in
-        let p' = underlying p' in
-        let State_may_have_changed p' =
-          resolve ~allow_deferring:false p' p_result in
-        ignore p'
-      in
-      add_implicitly_removed_callback p_callbacks callback;
       to_public_promise p'
 end
 include Pending_promises
@@ -2462,6 +2439,20 @@ struct
 end
 include Sequential_composition
 
+
+(* This belongs with the [protected] and such, but it depends on primitives from
+   [Sequential_composition]. *)
+let wrap_in_cancelable p =
+ let Internal p_internal = to_internal_promise p in
+ let p_underlying = underlying p_internal in
+ match p_underlying.state with
+ | Fulfilled _ -> p
+ | Rejected _ -> p
+ | Pending _ ->
+   let p', r = task () in
+   on_cancel p' (fun () -> cancel p);
+   on_any p (wakeup r) (wakeup_exn r);
+   p'
 
 
 module Concurrent_composition :

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1186,6 +1186,11 @@ val no_cancel : 'a t -> 'a t
     Note that [p'] can still be canceled if [p] is canceled. [Lwt.no_cancel]
     only prevents cancellation of [p] and [p'] through [p']. *)
 
+val wrap_in_cancelable : 'a t -> 'a t
+(** [Lwt.wrap_in_cancelable p] creates a {{: #VALcancel} cancelable} promise
+    [p'] with the same state as [p]. Cancellation carries onto [p], but [p'] is
+    rejected with {!Lwt.Canceled} even if [p] is not cancelable. *)
+
 
 
 (** {2 Convenience} *)

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2777,7 +2777,7 @@ let cancelable_tests = suite "wrap_in_cancelable" [
     Lwt.cancel p';
     Lwt.wakeup r "foo";
     Lwt.return
-      (Lwt.state p = Lwt.Fail Lwt.Canceled && Lwt.state p' = Lwt.Fail Lwt.Canceled)
+      (Lwt.state p = Lwt.Return "foo" && Lwt.state p' = Lwt.Fail Lwt.Canceled)
   end;
 
   test "pending(wait), canceled, fulfilled" begin fun () ->
@@ -2806,7 +2806,7 @@ let cancelable_tests = suite "wrap_in_cancelable" [
     Lwt.return (Lwt.state p2 = Lwt.Return "foo")
   end;
 ]
-let suites = suites @ [protected_tests]
+let suites = suites @ [cancelable_tests]
 
 let no_cancel_tests = suite "no_cancel" [
   test "fulfilled" begin fun () ->

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2,6 +2,8 @@
    details, or visit https://github.com/ocsigen/lwt/blob/master/LICENSE.md. *)
 
 
+CamlinternalLazy.Undefined
+
 
 (* [Lwt_sequence] is deprecated – we don't want users outside Lwt using it.
    However, it is still used internally by Lwt. So, briefly disable warning 3
@@ -2727,7 +2729,7 @@ let cancelable_tests = suite "wrap_in_cancelable" [
   end;
 
   test "rejected" begin fun () ->
-    let p = Lwt.protected (Lwt.fail Exception) in
+    let p = Lwt.wrap_in_cancelable (Lwt.fail Exception) in
     Lwt.return (Lwt.state p = Lwt.Fail Exception)
   end;
 
@@ -2773,16 +2775,16 @@ let cancelable_tests = suite "wrap_in_cancelable" [
 
   test "pending(task), canceled, fulfilled" begin fun () ->
     let p, r = Lwt.task () in
-    let p' = Lwt.protected p in
+    let p' = Lwt.wrap_in_cancelable p in
     Lwt.cancel p';
     Lwt.wakeup r "foo";
     Lwt.return
-      (Lwt.state p = Lwt.Return "foo" && Lwt.state p' = Lwt.Fail Lwt.Canceled)
+      (Lwt.state p = Lwt.Fail Lwt.Canceled && Lwt.state p' = Lwt.Fail Lwt.Canceled)
   end;
 
   test "pending(wait), canceled, fulfilled" begin fun () ->
     let p, r = Lwt.wait () in
-    let p' = Lwt.protected p in
+    let p' = Lwt.wrap_in_cancelable p in
     Lwt.cancel p';
     Lwt.wakeup r "foo";
     Lwt.return

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2770,7 +2770,7 @@ let cancelable_tests = suite "wrap_in_cancelable" [
     let p, _ = Lwt.wait () in
     let p' = Lwt.wrap_in_cancelable p in
     Lwt.cancel p';
-    Lwt.return (Lwt.state p = Lwt.Sleep && Lwt.state p = Lwt.Fail Lwt.Canceled)
+    Lwt.return (Lwt.state p = Lwt.Sleep && Lwt.state p' = Lwt.Fail Lwt.Canceled)
   end;
 
   test "pending(task), canceled, fulfilled" begin fun () ->

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2,8 +2,6 @@
    details, or visit https://github.com/ocsigen/lwt/blob/master/LICENSE.md. *)
 
 
-CamlinternalLazy.Undefined
-
 
 (* [Lwt_sequence] is deprecated – we don't want users outside Lwt using it.
    However, it is still used internally by Lwt. So, briefly disable warning 3

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -2720,6 +2720,94 @@ let protected_tests = suite "protected" [
 ]
 let suites = suites @ [protected_tests]
 
+let cancelable_tests = suite "wrap_in_cancelable" [
+  test "fulfilled" begin fun () ->
+    let p = Lwt.wrap_in_cancelable (Lwt.return ()) in
+    Lwt.return (Lwt.state p = Lwt.Return ())
+  end;
+
+  test "rejected" begin fun () ->
+    let p = Lwt.protected (Lwt.fail Exception) in
+    Lwt.return (Lwt.state p = Lwt.Fail Exception)
+  end;
+
+  test "pending(task)" begin fun () ->
+    let p, _ = Lwt.task () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.return (Lwt.state p = Lwt.Sleep && Lwt.state p' = Lwt.Sleep)
+  end;
+
+  test "pending(task), fulfilled" begin fun () ->
+    let p, r = Lwt.task () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.wakeup r "foo";
+    Lwt.return (Lwt.state p = Lwt.Return "foo" && Lwt.state p' = Lwt.Return "foo")
+  end;
+
+  test "pending(task), canceled" begin fun () ->
+    let p, _ = Lwt.task () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.cancel p';
+    Lwt.return (Lwt.state p = Lwt.Fail Lwt.Canceled && Lwt.state p' = Lwt.Fail Lwt.Canceled)
+  end;
+
+  test "pending(wait)" begin fun () ->
+    let p, _ = Lwt.wait () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.return (Lwt.state p = Lwt.Sleep && Lwt.state p' = Lwt.Sleep)
+  end;
+
+  test "pending(wait), fulfilled" begin fun () ->
+    let p, r = Lwt.wait () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.wakeup r "foo";
+    Lwt.return (Lwt.state p = Lwt.Return "foo" && Lwt.state p' = Lwt.Return "foo")
+  end;
+
+  test "pending(wait), canceled" begin fun () ->
+    let p, _ = Lwt.wait () in
+    let p' = Lwt.wrap_in_cancelable p in
+    Lwt.cancel p';
+    Lwt.return (Lwt.state p = Lwt.Sleep && Lwt.state p = Lwt.Fail Lwt.Canceled)
+  end;
+
+  test "pending(task), canceled, fulfilled" begin fun () ->
+    let p, r = Lwt.task () in
+    let p' = Lwt.protected p in
+    Lwt.cancel p';
+    Lwt.wakeup r "foo";
+    Lwt.return
+      (Lwt.state p = Lwt.Fail Lwt.Canceled && Lwt.state p' = Lwt.Fail Lwt.Canceled)
+  end;
+
+  test "pending(wait), canceled, fulfilled" begin fun () ->
+    let p, r = Lwt.wait () in
+    let p' = Lwt.protected p in
+    Lwt.cancel p';
+    Lwt.wakeup r "foo";
+    Lwt.return
+      (Lwt.state p = Lwt.Return "foo" && Lwt.state p' = Lwt.Fail Lwt.Canceled)
+  end;
+
+  (* Implementation detail: [p' = Lwt.wrap_in_cancelable _] can still be
+     resolved if it becomes a proxy. *)
+  test "pending, proxy" begin fun () ->
+    let p1, r1 = Lwt.task () in
+    let p2 = Lwt.wrap_in_cancelable p1 in
+
+    (* Make p2 a proxy for p4; p3 is just needed to suspend the bind, in order
+       to callback the code that makes p2 a proxy. *)
+    let p3, r3 = Lwt.wait () in
+    let _ = Lwt.bind p3 (fun () -> p2) in
+    Lwt.wakeup r3 ();
+
+    (* It should now be possible to resolve p2 by resolving p1. *)
+    Lwt.wakeup r1 "foo";
+    Lwt.return (Lwt.state p2 = Lwt.Return "foo")
+  end;
+]
+let suites = suites @ [protected_tests]
+
 let no_cancel_tests = suite "no_cancel" [
   test "fulfilled" begin fun () ->
     let p = Lwt.no_cancel (Lwt.return ()) in


### PR DESCRIPTION
Fixes #782 

This PR provides a new `cancelable : 'a t -> 'a t` function such that `cancelable p` is a promise `p'` that is cancelable even if `p` isn't.

I introduced a new constructor in `how_to_cancel`. I'm not 100% sure it is necessary but I couldn't find a way to do without it.