### PR TITLE
String_val returns const char *

### DIFF
--- a/src/unix/windows_c/windows_system_job.c
+++ b/src/unix/windows_c/windows_system_job.c
@@ -40,13 +40,20 @@ static value result_system(struct job_system *job)
 
 CAMLprim value lwt_unix_system_job(value cmdline)
 {
+    size_t count;
+    LPSTR commandLine;
     STARTUPINFO si;
     PROCESS_INFORMATION pi;
+
+    count = caml_string_length(cmdline);
+    commandLine = lwt_unix_malloc(count);
+    memcpy(&commandLine, String_val(cmdline), count);
 
     ZeroMemory(&si, sizeof(si));
     ZeroMemory(&pi, sizeof(pi));
     si.cb = sizeof(si);
-    if (!CreateProcess(NULL, String_val(cmdline), NULL, NULL, TRUE, 0, NULL,
+
+    if (!CreateProcess(NULL, commandLine, NULL, NULL, TRUE, 0, NULL,
                        NULL, &si, &pi)) {
         win32_maperr(GetLastError());
         uerror("CreateProcess", Nothing);


### PR DESCRIPTION
> `String_val(v)` returns a pointer to the first byte of the string
> `v`, with type `char *` or, when OCaml is configured with
> `-force-safe-string`, with type `const char *`.

https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#ss:c-block-access

Safe strings have been the default since OCaml 4.06.

https://caml.inria.fr/pub/docs/manual-ocaml/libref/String.html

The function CreateProcess has two parameters that are non-const:

    LPSTR  lpCommandLine
    LPVOID lpEnvironment

https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa

Passing a const string triggers warnings. One can cast away the const
but that does not seem safe, or duplicate the string. Here, I’m
duplicating the string.