### PR TITLE
Lwt_unix.tcsetattr: Fix segfault on bad arguments (#798)

### DIFF
--- a/src/unix/unix_c/unix_tcsetattr_job.c
+++ b/src/unix/unix_c/unix_tcsetattr_job.c
@@ -34,8 +34,12 @@ static void worker_tcsetattr(struct job_tcsetattr *job)
         job->result = result;
         job->error_code = errno;
     } else {
-        decode_terminal_status(&termios, &(job->termios[0]));
-        job->result = tcsetattr(job->fd, job->when, &termios);
+        int result_decode = decode_terminal_status(&termios, &(job->termios[0]));
+        if (result_decode != 0) {
+            job->result = -1;
+        } else {
+            job->result = tcsetattr(job->fd, job->when, &termios);
+        }
         job->error_code = errno;
     }
 }

--- a/src/unix/unix_c/unix_termios_conversion.c
+++ b/src/unix/unix_c/unix_termios_conversion.c
@@ -207,7 +207,7 @@ void encode_terminal_status(struct termios *terminal_status, value *dst)
     }
 }
 
-void decode_terminal_status(struct termios *terminal_status, value *src)
+int decode_terminal_status(struct termios *terminal_status, value *src)
 {
     long *pc;
     int i;
@@ -232,7 +232,8 @@ void decode_terminal_status(struct termios *terminal_status, value *src)
                 if (i >= 0 && i < num) {
                     *dst = (*dst & ~msk) | pc[i];
                 } else {
-                    unix_error(EINVAL, "tcsetattr", Nothing);
+                    errno = EINVAL;
+                    return EINVAL;
                 }
                 pc += num;
                 break;
@@ -253,11 +254,12 @@ void decode_terminal_status(struct termios *terminal_status, value *src)
                                                   speedtable[i].speed);
                                 break;
                         }
-                        if (res == -1) uerror("tcsetattr", Nothing);
+                        if (res == -1) return res;
                         goto ok;
                     }
                 }
-                unix_error(EINVAL, "tcsetattr", Nothing);
+                errno = EINVAL;
+                return EINVAL;
             ok:
                 break;
             }
@@ -268,5 +270,6 @@ void decode_terminal_status(struct termios *terminal_status, value *src)
             }
         }
     }
+    return 0;
 }
 #endif

--- a/src/unix/unix_c/unix_termios_conversion.h
+++ b/src/unix/unix_c/unix_termios_conversion.h
@@ -25,5 +25,5 @@
 #define NFIELDS 38
 
 void encode_terminal_status(struct termios *terminal_status, value *dst);
-void decode_terminal_status(struct termios *terminal_status, value *src);
+int decode_terminal_status(struct termios *terminal_status, value *src);
 #endif


### PR DESCRIPTION
This MR fixes the segfaults I had in #798  .

A review would be appreciated!

Notably,

* I'm not sure about setting errno in userspace..
* decode_terminal_status() is basically argument validation - would it be better placed in the job creation or do we not care?
* Is the premise that exceptions shouldn't be thrown from worker code correct at all?