### PR TITLE
Handle an optional IOV_MAX

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -816,11 +816,11 @@ struct
     in
     loop io_vectors.prefix
 
-  external stub_iov_max : unit -> int = "lwt_unix_iov_max"
+  external stub_iov_max : unit -> int option = "lwt_unix_iov_max"
 
   let system_limit =
     if Sys.win32 then None
-    else Some (stub_iov_max ())
+    else stub_iov_max ()
 
   let check tag io_vector =
     let buffer_length =

--- a/src/unix/unix_c/unix_iov_max.c
+++ b/src/unix/unix_c/unix_iov_max.c
@@ -9,8 +9,20 @@
 
 #define _GNU_SOURCE
 
+#include <caml/alloc.h>
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <limits.h>
 
-CAMLprim value lwt_unix_iov_max(value unit) { return Val_int(IOV_MAX); }
+CAMLprim value lwt_unix_iov_max(value unit)
+{
+    CAMLparam1(unit);
+    CAMLlocal1(res);
+
+    res = caml_alloc(1, 0);
+    Store_field(res, 0, Val_int(IOV_MAX));
+
+    CAMLreturn(res);
+}
+
 #endif

--- a/src/unix/unix_c/unix_iov_max.c
+++ b/src/unix/unix_c/unix_iov_max.c
@@ -19,8 +19,12 @@ CAMLprim value lwt_unix_iov_max(value unit)
     CAMLparam1(unit);
     CAMLlocal1(res);
 
+#ifdef IOV_MAX
     res = caml_alloc(1, 0);
     Store_field(res, 0, Val_int(IOV_MAX));
+#else
+    res = Val_int(0);
+#endif
 
     CAMLreturn(res);
 }


### PR DESCRIPTION
`IOV_MAX` is optional in POSIX [1], so it is not defined if the OS does not specify an actual limit. Considering that `Lwt_unix.IO_vectors.system_limit` already returns `int option`, then make the C stub return `int option` directly based on whether `IOV_MAX` is defined.

 [1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html

Potentially now `lwt_unix_iov_max` could be built also on Windows, removing the if in `system_limit`; however I don't have a Windows setup to test this, and it can be deferred as a later change anyway.