### PR TITLE
lwt.unix: add `Lwt_unix.send_msgto` that takes a destination address

### DIFF
--- a/src/unix/dune
+++ b/src/unix/dune
@@ -85,6 +85,7 @@ let () = Jbuild_plugin.V1.send @@ {|
   unix_recv_send_utils
   unix_recv_msg
   unix_send_msg
+  unix_send_msg_byte
   unix_get_credentials
   unix_mcast_utils
   unix_mcast_set_loop

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1637,7 +1637,7 @@ let send_msg ~socket ~io_vectors ~fds =
       socket.fd vector_count io_vectors.IO_vectors.prefix fd_count fds None)
 
 let send_msgto ~socket ~io_vectors ~fds ~dest =
-  let vector_count = check_io_vectors "Lwt_unix.send_msg" io_vectors in
+  let vector_count = check_io_vectors "Lwt_unix.send_msgto" io_vectors in
   let fd_count = List.length fds in
   wrap_syscall Write socket (fun () ->
     stub_send_msg

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1626,16 +1626,22 @@ let recv_msg ~socket ~io_vectors =
 external stub_send_msg :
   Unix.file_descr ->
   int -> IO_vectors.io_vector list ->
-  int -> Unix.file_descr list ->
-    int =
-  "lwt_unix_send_msg"
+  int -> Unix.file_descr list -> Unix.sockaddr option ->
+    int = "lwt_unix_send_msg_byte" "lwt_unix_send_msg"
 
 let send_msg ~socket ~io_vectors ~fds =
   let vector_count = check_io_vectors "Lwt_unix.send_msg" io_vectors in
   let fd_count = List.length fds in
   wrap_syscall Write socket (fun () ->
     stub_send_msg
-      socket.fd vector_count io_vectors.IO_vectors.prefix fd_count fds)
+      socket.fd vector_count io_vectors.IO_vectors.prefix fd_count fds None)
+
+let send_msgto ~socket ~io_vectors ~fds ~dest =
+  let vector_count = check_io_vectors "Lwt_unix.send_msg" io_vectors in
+  let fd_count = List.length fds in
+  wrap_syscall Write socket (fun () ->
+    stub_send_msg
+      socket.fd vector_count io_vectors.IO_vectors.prefix fd_count fds (Some dest))
 
 type inet_addr = Unix.inet_addr
 

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -989,8 +989,16 @@ val send_msg :
     @since 5.0.0 *)
 
 val send_msgto :
-  socket:file_descr -> io_vectors:IO_vectors.t -> fds:Unix.file_descr list -> dest:Unix.sockaddr ->
+  socket:file_descr -> io_vectors:IO_vectors.t -> fds:Unix.file_descr list ->
+    dest:Unix.sockaddr ->
     int Lwt.t
+(** [send_msgto ~socket ~io_vectors ~fds ~dest] is similar to [send_msg] but
+    takes an additional [dest] argument to set the address when using a
+    connection-less socket.
+
+    Not implemented on Windows.
+
+    @since 5.4.0 *)
 
 type credentials = {
   cred_pid : int;

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -988,6 +988,10 @@ val send_msg :
 
     @since 5.0.0 *)
 
+val send_msgto :
+  socket:file_descr -> io_vectors:IO_vectors.t -> fds:Unix.file_descr list -> dest:Unix.sockaddr ->
+    int Lwt.t
+
 type credentials = {
   cred_pid : int;
   cred_uid : int;

--- a/src/unix/unix_c/unix_recv_send_utils.c
+++ b/src/unix/unix_c/unix_recv_send_utils.c
@@ -64,7 +64,7 @@ value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs)
 }
 
 value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
-                       value val_n_fds, value val_fds)
+                       value val_n_fds, value val_fds, value dest)
 {
     CAMLparam2(val_n_fds, val_fds);
 
@@ -72,6 +72,16 @@ value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
     memset(&msg, 0, sizeof(msg));
     msg.msg_iov = iovs;
     msg.msg_iovlen = n_iovs;
+
+    /* dest: Unix.sockaddr option */
+    if (Is_block(dest)) {
+      union sock_addr_union addr;
+      socklen_t addr_len;
+      get_sockaddr(Field(dest, 0), &addr, &addr_len);
+
+      msg.msg_name = &addr.s_gen;
+      msg.msg_namelen = addr_len;
+    }
 
     int n_fds = Int_val(val_n_fds);
 #if defined(HAVE_FD_PASSING)

--- a/src/unix/unix_c/unix_recv_send_utils.c
+++ b/src/unix/unix_c/unix_recv_send_utils.c
@@ -66,7 +66,7 @@ value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs)
 value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
                        value val_n_fds, value val_fds, value dest)
 {
-    CAMLparam2(val_n_fds, val_fds);
+    CAMLparam3(val_n_fds, val_fds, dest);
 
     struct msghdr msg;
     memset(&msg, 0, sizeof(msg));

--- a/src/unix/unix_c/unix_recv_send_utils.h
+++ b/src/unix/unix_c/unix_recv_send_utils.h
@@ -37,5 +37,5 @@ extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
                          socklen_t *addr_len /*out*/);
 value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs);
 value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
-                       value val_n_fds, value val_fds);
+                       value val_n_fds, value val_fds, value dest);
 #endif

--- a/src/unix/unix_c/unix_send_msg.c
+++ b/src/unix/unix_c/unix_send_msg.c
@@ -14,11 +14,11 @@
 #include "unix_readv_writev_utils.h"
 
 CAMLprim value lwt_unix_send_msg(value val_fd, value val_n_iovs, value val_iovs,
-                                 value val_n_fds, value val_fds)
+                                 value val_n_fds, value val_fds, value val_dest)
 {
     int n_iovs = Int_val(val_n_iovs);
     struct iovec iovs[n_iovs];
     flatten_io_vectors(iovs, val_iovs, n_iovs, NULL, NULL);
-    return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds);
+    return wrapper_send_msg(Int_val(val_fd), n_iovs, iovs, val_n_fds, val_fds, val_dest);
 }
 #endif

--- a/src/unix/unix_c/unix_send_msg_byte.c
+++ b/src/unix/unix_c/unix_send_msg_byte.c
@@ -1,0 +1,27 @@
+/* This file is part of Lwt, released under the MIT license. See LICENSE.md for
+   details, or visit https://github.com/ocsigen/lwt/blob/master/LICENSE.md. */
+
+
+
+#include "lwt_config.h"
+
+#if !defined(LWT_ON_WINDOWS)
+
+#include <caml/mlvalues.h>
+
+extern value lwt_unix_send_msg(value val_fd, value val_n_iovs, value val_iovs,
+                               value val_n_fds, value val_fds, value val_dest);
+
+CAMLprim value lwt_unix_send_msg_byte(value * argv, int argc)
+{
+  value val_fd = argv[0];
+  value val_n_iovs = argv[1];
+  value val_iovs = argv[2];
+  value val_n_fds = argv[3];
+  value val_fds = argv[4];
+  value val_dest = argv[5];
+
+  return lwt_unix_send_msg(val_fd, val_n_iovs, val_iovs, val_n_fds, val_fds, val_dest);
+}
+
+#endif


### PR DESCRIPTION
This is useful to send IO Vectors over unconnected sockets (e.g. UDP).

