### PR TITLE
Handle uncaught exceptions in Lwt_react.of_stream.

### DIFF
--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -872,8 +872,8 @@ val async_exception_hook : (exn -> unit) ref
 (** Reference to a function, to be called on an "unhandled" exception.
 
     This reference is used by {!Lwt.async}, {!Lwt.on_cancel}, {!Lwt.on_success},
-    {!Lwt.on_failure}, {!Lwt.on_termination}, {!Lwt.on_any}, and the deprecated
-    {!Lwt.ignore_result}.
+    {!Lwt.on_failure}, {!Lwt.on_termination}, {!Lwt.on_any},
+    {!Lwt_react.of_stream}, and the deprecated {!Lwt.ignore_result}.
 
     The initial, default implementation prints the exception, then terminates
     the process with non-zero exit status, as if the exception had reached the

--- a/src/react/lwt_react.cppo.ml
+++ b/src/react/lwt_react.cppo.ml
@@ -101,7 +101,8 @@ module E = struct
   let of_stream stream =
     let event, push = create () in
     let t =
-      Lwt.pause () >>= fun () -> Lwt_stream.iter (fun v -> push v) stream in
+      Lwt.pause () >>= fun () ->
+      Lwt_stream.iter (fun v -> try push v with exn -> !Lwt.async_exception_hook exn) stream in
     with_finaliser (cancel_thread t) event
 
   let delay thread =

--- a/src/react/lwt_react.mli
+++ b/src/react/lwt_react.mli
@@ -63,7 +63,11 @@ module E : sig
 
   val of_stream : 'a Lwt_stream.t -> 'a event
     (** [of_stream stream] creates an event which occurs each time a
-        value is available on the stream. *)
+        value is available on the stream.
+
+        If updating the event causes an exception at any point during the update
+        step, the excpetion is passed to [!]{!Lwt.async_exception_hook}, which
+        terminates the process by default. *)
 
   val delay : 'a event Lwt.t -> 'a event
     (** [delay promise] is an event which does not occur until


### PR DESCRIPTION
Currently exceptions raised during reactive updates set up by `Lwt_react.of_stream` will cause the event to stop without notice. My suggestion is to call `!Lwt.async_exception_hook`.

I ran into this while hunting down a bug in an Eliom application using `Eliom_react.S.Down.of_react` and with this PR I get the needed feedback in the JS console.