### PR TITLE
add ppx_let support for Lwt_result

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -3133,6 +3133,17 @@ struct
   let (<&>) p p' = join [p; p']
   let (<?>) p p' = choose [p; p']
 
+  module Let_syntax =
+  struct
+    let return = return
+    let map t ~f = map f t
+    let bind t ~f = bind t f
+    let both = both
+
+    module Open_on_rhs =
+    struct
+    end
+  end
 end
 include Infix
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -3133,6 +3133,11 @@ struct
   let (<&>) p p' = join [p; p']
   let (<?>) p p' = choose [p; p']
 
+end
+include Infix
+
+module Let_syntax =
+struct
   module Let_syntax =
   struct
     let return = return
@@ -3145,7 +3150,6 @@ struct
     end
   end
 end
-include Infix
 
 module Syntax =
 struct

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -3122,31 +3122,6 @@ struct
 end
 include Miscellaneous
 
-
-
-module Infix =
-struct
-  let (>>=) = bind
-  let (=<<) f p = bind p f
-  let (>|=) p f = map f p
-  let (=|<) = map
-  let (<&>) p p' = join [p; p']
-  let (<?>) p p' = choose [p; p']
-
-  module Let_syntax =
-  struct
-    let return = return
-    let map t ~f = map f t
-    let bind t ~f = bind t f
-    let both = both
-
-    module Open_on_rhs =
-    struct
-    end
-  end
-end
-include Infix
-
 module Let_syntax =
 struct
   module Let_syntax =
@@ -3161,6 +3136,19 @@ struct
     end
   end
 end
+
+module Infix =
+struct
+  let (>>=) = bind
+  let (=<<) f p = bind p f
+  let (>|=) p f = map f p
+  let (=|<) = map
+  let (<&>) p p' = join [p; p']
+  let (<?>) p p' = choose [p; p']
+
+  include Let_syntax
+end
+include ( Infix : module type of Infix with module Let_syntax := Let_syntax.Let_syntax )
 
 module Syntax =
 struct

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1377,12 +1377,30 @@ let () =
       This operator is obscure and its use is discouraged. It is the same as
       [p >|= f]. *)
 
+  (** This module provides support for {{:https://github.com/janestreet/ppx_let}
+      ppx_let}.
+
+      @since 4.2.0 *)
+  module Let_syntax :
+  sig
+    val return : 'a -> 'a t
+    (** See {!Lwt.return}. *)
+
+    val map : 'a t -> f:('a -> 'b) -> 'b t
+    (** See {!Lwt.map}. *)
+
+    val bind : 'a t -> f:('a -> 'b t) -> 'b t
+    (** See {!Lwt.bind}. *)
+
+    val both : 'a t -> 'b t -> ('a * 'b) t
+    (** See {!Lwt.both}. *)
+
+    module Open_on_rhs :
+    sig
+    end
+  end
 end
 
-(** This module provides support for {{:https://github.com/janestreet/ppx_let}
-    ppx_let}.
-
-    @since 4.2.0 *)
 module Let_syntax :
 sig
   module Let_syntax :

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1377,10 +1377,14 @@ let () =
       This operator is obscure and its use is discouraged. It is the same as
       [p >|= f]. *)
 
-  (** This module provides support for {{:https://github.com/janestreet/ppx_let}
-      ppx_let}.
+end
 
-      @since 4.2.0 *)
+(** This module provides support for {{:https://github.com/janestreet/ppx_let}
+    ppx_let}.
+
+    @since 4.2.0 *)
+module Let_syntax :
+sig
   module Let_syntax :
   sig
     val return : 'a -> 'a t

--- a/src/core/lwt_result.ml
+++ b/src/core/lwt_result.ml
@@ -90,6 +90,17 @@ module Infix = struct
   let (>|=) e f = map f e
 end
 
+module Let_syntax = struct
+  module Let_syntax = struct
+    let return = return
+    let map t ~f = map f t
+    let bind t ~f = bind t f
+    let both = both
+    module Open_on_rhs = struct
+    end
+  end
+end
+
 module Syntax = struct
   let (let*) = bind
   let (and*) = both

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -55,6 +55,25 @@ module Infix : sig
   val (>>=) : ('a,'e) t -> ('a -> ('b,'e) t) -> ('b,'e) t
 end
 
+module Let_syntax : sig
+  module Let_syntax : sig
+    val return : 'a -> ('a, _) t
+    (** See {!Lwt_result.return}. *)
+
+    val map : ('a, 'e) t -> f:('a -> 'b) -> ('b, 'e) t
+    (** See {!Lwt_result.map}. *)
+
+    val bind : ('a, 'e) t -> f:('a -> ('b, 'e) t) -> ('b, 'e) t
+    (** See {!Lwt_result.bind}. *)
+
+    val both : ('a, 'e) t -> ('b, 'e) t -> ('a * 'b, 'e) t
+    (** See {!Lwt_result.both}. *)
+
+    module Open_on_rhs : sig
+    end
+  end
+end
+
 (** {3 Let syntax} *)
 module Syntax : sig
 

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -3999,18 +3999,18 @@ let suites = suites @ [infix_operator_tests]
    testing the full syntax to avoid large dependencies for the test suite. *)
 let ppx_let_tests = suite "ppx_let" [
   test "return" begin fun () ->
-    let p = Lwt.Infix.Let_syntax.return () in
+    let p = Lwt.Let_syntax.Let_syntax.return () in
     state_is (Lwt.Return ()) p
   end;
 
   test "map" begin fun () ->
-    let p = Lwt.Infix.Let_syntax.map (Lwt.return 1) ~f:(fun x -> x + 1) in
+    let p = Lwt.Let_syntax.Let_syntax.map (Lwt.return 1) ~f:(fun x -> x + 1) in
     state_is (Lwt.Return 2) p
   end;
 
   test "bind" begin fun () ->
     let p =
-      Lwt.Infix.Let_syntax.bind
+      Lwt.Let_syntax.Let_syntax.bind
         (Lwt.return 1) ~f:(fun x -> Lwt.return (x + 1))
     in
     state_is (Lwt.Return 2) p
@@ -4029,7 +4029,7 @@ let ppx_let_tests = suite "ppx_let" [
         end
       end
     in
-    let x : (module Local.Empty) = (module Lwt.Infix.Let_syntax.Open_on_rhs) in
+    let x : (module Local.Empty) = (module Lwt.Let_syntax.Let_syntax.Open_on_rhs) in
     ignore x;
     Lwt.return true
   end;

--- a/test/ppx_let/test.ml
+++ b/test/ppx_let/test.ml
@@ -1,15 +1,27 @@
 let () =
-  let open Lwt.Infix in
-
-  let p =
+  let p1 =
+    let open Lwt.Let_syntax in
     let%bind x = Lwt.return 1 in
     let%map y = Lwt.return (x + 1) in
     y + 1
   in
 
+  let p2 =
+    let open Lwt_result.Let_syntax in
+    let%bind x = Lwt_result.return 2 in
+    let%map y = Lwt_result.return (x + 3) in
+    x + y
+  in
+
+  let p =
+    let%bind.Lwt p1 = p1 in
+    let%map.Lwt_result p2 = p2 in
+    p1 + p2
+  in
+
   let x = Lwt_main.run p in
 
-  if x = 3 then
+  if x = Ok 10 then
     exit 0
   else
     exit 1


### PR DESCRIPTION
This adds the module needed for ppx_let to work for Lwt_result.
Similar module already exists for the regular `Lwt` module.
In addition, this change also enables support for using `ppx_let`
while using module qualifier to the `bind/map` operation, ex:
`let%bind.Lwt` or `let%map.Lwt_result`.