### PR TITLE
Lwt.dont_wait: a more local, more explicit Lwt.async

### DIFF
--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -824,7 +824,8 @@ val async : (unit -> unit t) -> unit
     [!]{!Lwt.async_exception_hook}.
 
     [!]{!Lwt.async_exception_hook} typically prints an error message and
-    terminates the program.
+    terminates the program. If you need a similar behaviour with a different
+    exception handler, you can use {!Lwt.dont_wait}.
 
     [Lwt.async] is misleadingly named. Itself, it has nothing to do with
     asynchronous execution. It's actually a safety function for making Lwt

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -796,6 +796,25 @@ val try_bind : (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
       performing any operation on one is equivalent to performing it on the
       other. *)
 
+val dont_wait : (unit -> unit t) -> (exn -> unit) -> unit
+(** [Lwt.dont_wait f handler] applies [f ()], which returns a promise, and then
+    makes it so that if the promise is {{: #TYPEt} {e rejected}}, the exception
+    is passed to [handler].
+
+    In addition, if [f ()] raises an exception, it is also passed to [handler].
+
+    As the name implies, [dont_wait (fun () -> <e>) handler] is a way to
+    evaluate the expression [<e>] (which typically has asynchronous
+    side-effects) {e without waiting} for the resolution of the promise [<e>]
+    evaluates to.
+
+    [dont_wait] is meant as an alternative to {!async} with a local, explicit,
+    predictable exception handler.
+
+    Note that [dont_wait f h] causes [f ()] to be evaluated immediately.
+    Consequently, the non-yielding/non-pausing prefix of the body of [f] is
+    evaluated immediately. *)
+
 val async : (unit -> unit t) -> unit
 (** [Lwt.async f] applies [f ()], which returns a promise, and then makes it so
     that if the promise is {{: #TYPEt} {e rejected}}, the exception is passed to

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -1801,6 +1801,8 @@ let async_tests = suite "async" [
       !saw = Some Exception)
   end;
 ]
+let suites = suites @ [async_tests]
+
 let dont_wait_tests = suite "dont_wait" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
@@ -1808,22 +1810,20 @@ let dont_wait_tests = suite "dont_wait" [
     later (fun () -> !f_ran = true)
   end;
 
-  test ~sequential:true "f raises" begin fun () ->
+  test "f raises" begin fun () ->
     let saw = ref None in
     Lwt.dont_wait
       (fun () -> raise Exception)
       (fun exn -> saw := Some exn);
-    later (fun () ->
-      !saw = Some Exception)
+    later (fun () -> !saw = Some Exception)
   end;
 
-  test ~sequential:true "rejected" begin fun () ->
+  test "rejected" begin fun () ->
     let saw = ref None in
     Lwt.dont_wait
       (fun () -> Lwt.fail Exception)
       (fun exn -> saw := Some exn);
-    later (fun () ->
-      !saw = Some Exception)
+    later (fun () -> !saw = Some Exception)
   end;
 
   test "pending, fulfilled" begin fun () ->
@@ -1839,18 +1839,17 @@ let dont_wait_tests = suite "dont_wait" [
     later (fun () -> !resolved = true)
   end;
 
-  test ~sequential:true "pending, rejected" begin fun () ->
+  test "pending, rejected" begin fun () ->
     let saw = ref None in
     let p, r = Lwt.wait () in
     Lwt.dont_wait
       (fun () -> p)
       (fun exn -> saw := Some exn) ;
     Lwt.wakeup_exn r Exception;
-    later (fun () ->
-      !saw = Some Exception)
+    later (fun () -> !saw = Some Exception)
   end;
 ]
-let suites = suites @ [async_tests ; dont_wait_tests]
+let suites = suites @ [dont_wait_tests]
 
 let ignore_result_tests = suite "ignore_result" [
   test "fulfilled" begin fun () ->

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -1801,7 +1801,56 @@ let async_tests = suite "async" [
       !saw = Some Exception)
   end;
 ]
-let suites = suites @ [async_tests]
+let dont_wait_tests = suite "dont_wait" [
+  test "fulfilled" begin fun () ->
+    let f_ran = ref false in
+    Lwt.dont_wait (fun () -> f_ran := true; Lwt.return ()) (fun _ -> ());
+    later (fun () -> !f_ran = true)
+  end;
+
+  test ~sequential:true "f raises" begin fun () ->
+    let saw = ref None in
+    Lwt.dont_wait
+      (fun () -> raise Exception)
+      (fun exn -> saw := Some exn);
+    later (fun () ->
+      !saw = Some Exception)
+  end;
+
+  test ~sequential:true "rejected" begin fun () ->
+    let saw = ref None in
+    Lwt.dont_wait
+      (fun () -> Lwt.fail Exception)
+      (fun exn -> saw := Some exn);
+    later (fun () ->
+      !saw = Some Exception)
+  end;
+
+  test "pending, fulfilled" begin fun () ->
+    let resolved = ref false in
+    let p, r = Lwt.wait () in
+    Lwt.dont_wait
+      (fun () ->
+        Lwt.bind p (fun () ->
+          resolved := true;
+          Lwt.return ()))
+      (fun _ -> ());
+    Lwt.wakeup r ();
+    later (fun () -> !resolved = true)
+  end;
+
+  test ~sequential:true "pending, rejected" begin fun () ->
+    let saw = ref None in
+    let p, r = Lwt.wait () in
+    Lwt.dont_wait
+      (fun () -> p)
+      (fun exn -> saw := Some exn) ;
+    Lwt.wakeup_exn r Exception;
+    later (fun () ->
+      !saw = Some Exception)
+  end;
+]
+let suites = suites @ [async_tests ; dont_wait_tests]
 
 let ignore_result_tests = suite "ignore_result" [
   test "fulfilled" begin fun () ->


### PR DESCRIPTION
Fixes https://github.com/ocsigen/lwt/issues/819

This is an alternative to `async`/`ignore_result` with a more explicit exception handler.