### PR TITLE
Tiniest fix in documentation

### DIFF
--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -740,7 +740,7 @@ let () =
       rejected with that exception. Again, no matter how [c ()] finishes, there
       is a promise [p_2] representing the outcome of cleanup.
     - If [p_2] is fulfilled, [p_3] is resolved the same way [p_1] had been
-      resolved. In other words, [p_1] is forwarded to [p_2] when cleanup is
+      resolved. In other words, [p_1] is forwarded to [p_3] when cleanup is
       successful.
     - If [p_2] is rejected, [p_3] is rejected with the same exception. In other
       words, when cleanup fails, [p_3] is rejected. Note this means that if

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -743,9 +743,9 @@ let () =
       resolved. In other words, [p_1] is forwarded to [p_3] when cleanup is
       successful.
     - If [p_2] is rejected, [p_3] is rejected with the same exception. In other
-      words, when cleanup fails, [p_3] is rejected. Note this means that if
-      {e both} the protected code and the cleanup fail, the cleanup exception
-      has precedence. *)
+      words, [p_2] is forwarded to [p_3] when cleanup is unsuccessful. Note this
+      means that if {e both} the protected code and the cleanup fail, the
+      cleanup exception has precedence. *)
 
 val try_bind : (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 (** [Lwt.try_bind f g h] applies [f ()], and then makes it so that:


### PR DESCRIPTION
A tiny fix, a typo fix really, for the documentation of `finalize`.

And because I was there I also reworded a bit for uniformity.