### PR TITLE
Deactivate dependency to bisect_ppx

### DIFF
--- a/lwt_luv.opam
+++ b/lwt_luv.opam
@@ -21,7 +21,8 @@ depends: [
   "luv"
   "result" # result is needed as long as Lwt supports OCaml 4.02.
 
-  "bisect_ppx" {dev & >= "2.0.0"}
+  # Until https://github.com/aantron/bisect_ppx/pull/327.
+  # "bisect_ppx" {dev & >= "2.0.0"}
 ]
 
 build: [


### PR DESCRIPTION
Deactivating bisect-ppx dependency until https://github.com/aantron/bisect_ppx/pull/327 is merged.