### PR TITLE
lwt_ppx: carry explicit dependency from dune to opam

### DIFF
--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -21,6 +21,7 @@ depends: [
   "lwt"
   "ocaml" {>= "4.02.0"}
   "ppxlib" {>= "0.16.0"}
+  "ocaml-compiler-libs" {>= "v0.12.3"}
 ]
 
 build: [

--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -21,7 +21,6 @@ depends: [
   "lwt"
   "ocaml" {>= "4.02.0"}
   "ppxlib" {>= "0.16.0"}
-  "ocaml-compiler-libs" {>= "v0.12.3"}
 ]
 
 build: [

--- a/src/ppx/dune
+++ b/src/ppx/dune
@@ -13,7 +13,7 @@ let () = Jbuild_plugin.V1.send @@ {|
  (public_name lwt_ppx)
  (synopsis "Lwt PPX syntax extension")
  (modules ppx_lwt)
- (libraries ocaml-compiler-libs.common ppxlib)
+ (libraries ppxlib)
  (ppx_runtime_libraries lwt)
  (kind ppx_rewriter)
  (preprocess (pps ppxlib.metaquot|} ^ bisect_ppx ^ {|))


### PR DESCRIPTION
Thanks `opam-dune-lint` for the fix