### PR TITLE
lwt_ppx.opam: add ocaml-compiler-libs dependency

### DIFF
--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -20,6 +20,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "lwt"
   "ocaml" {>= "4.02.0"}
+  "ocaml-compiler-libs"
   "ppxlib" {>= "0.16.0"}
 ]
 


### PR DESCRIPTION
This dependency is present in src/ppx/dune, so it explicitly adds an opam dependency as well. Found with opam-dune-lint, and should fix CI