### PR TITLE
lwt_ppx: avoid dependency on compiler-libs

### DIFF
--- a/src/ppx/dune
+++ b/src/ppx/dune
@@ -13,7 +13,7 @@ let () = Jbuild_plugin.V1.send @@ {|
  (public_name lwt_ppx)
  (synopsis "Lwt PPX syntax extension")
  (modules ppx_lwt)
- (libraries ocaml-compiler-libs.common ppxlib)
+ (libraries ppxlib)
  (ppx_runtime_libraries lwt)
  (kind ppx_rewriter)
  (preprocess (pps ppxlib.metaquot|} ^ bisect_ppx ^ {|))


### PR DESCRIPTION
... by replacing uses of `Ast_helper` with `Ast_builder`. Ppxlib provides a stub `Ast_helper` module that [shadows the one from `compiler-libs`](https://ocaml-ppx.github.io/ppxlib/ppxlib/Ppxlib/index.html#module-Ast_helper) and is not intended to be used directly. It's probably best to stick to a single set of AST combinators.

Alternative solution to https://github.com/ocsigen/lwt/pull/834. CC @raphael-proust.