### PR TITLE
Extend lwt_seq

### DIFF
--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -34,7 +34,7 @@ let cons_lwt x t () =
    This is only needed on the first iteration because we are within a callback
    passed to Lwt on the right-hand side of a bind after that.
 
-   Throughout this file we use the same code pattern to acheive this: we
+   Throughout this file we use the same code pattern to achieve this: we
    shadow the recursive traversal function with an identical-but-for-the-apply
    non-recursive copy. *)
 
@@ -262,7 +262,7 @@ let iter_n ?(max_concurrency = 1) f seq =
     | Cons (elt, seq) ->
       loop (f elt :: running) (pred available) seq
   in
-  (* because the recursion is more comolicated here, we apply the seq directly at
+  (* because the recursion is more complicated here, we apply the seq directly at
      the call-site instead *)
   loop [] max_concurrency (fun () -> Lwt.apply seq ())
 

--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -79,6 +79,16 @@ let iter f seq =
   in
   aux seq
 
+let iter_p f seq =
+  let rec aux acc seq =
+    seq () >>= function
+    | Nil -> Lwt.join acc
+    | Cons (x, next) ->
+        let p = f x in
+        aux (p::acc) next
+  in
+  aux [] seq
+
 let rec unfold f u () =
   let* x = f u in
   match x with

--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -277,6 +277,11 @@ let rec unfold_lwt f u () =
   match x with
   | None -> return_nil
   | Some (x, u') -> Lwt.return (Cons (x, unfold_lwt f u'))
+let unfold_lwt f u () =
+  let* x = Lwt.apply f u in
+  match x with
+  | None -> return_nil
+  | Some (x, u') -> Lwt.return (Cons (x, unfold_lwt f u'))
 
 let rec of_list = function
   | [] -> empty

--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -74,6 +74,16 @@ let iter f seq =
     seq () >>= function
     | Nil -> Lwt.return_unit
     | Cons (x, next) ->
+        f x;
+        aux next
+  in
+  aux seq
+
+let iter_s f seq =
+  let rec aux seq =
+    seq () >>= function
+    | Nil -> Lwt.return_unit
+    | Cons (x, next) ->
         let* () = f x in
         aux next
   in

--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -14,9 +14,17 @@ let return_nil = Lwt.return Nil
 
 let empty : 'a t = fun () -> return_nil
 
-let return x : 'a t = fun () -> Lwt.return (Cons (x, empty))
+let return (x : 'a) : 'a t = fun () -> Lwt.return (Cons (x, empty))
+
+let return_lwt (x : 'a Lwt.t) : 'a t = fun () ->
+   let+ x = x in
+   Cons (x, empty)
 
 let cons x t () = Lwt.return (Cons (x, t))
+
+let cons_lwt x t () =
+   let+ x = x in
+   Cons (x, t)
 
 (* A note on recursing through the seqs:
    When traversing a seq, the first time we evaluate a suspended node we are

--- a/src/core/lwt_seq.ml
+++ b/src/core/lwt_seq.ml
@@ -267,10 +267,16 @@ let iter_n ?(max_concurrency = 1) f seq =
   loop [] max_concurrency (fun () -> Lwt.apply seq ())
 
 let rec unfold f u () =
+  match f u with
+  | None -> return_nil
+  | Some (x, u') -> Lwt.return (Cons (x, unfold f u'))
+  | exception exc -> Lwt.fail exc
+
+let rec unfold_lwt f u () =
   let* x = f u in
   match x with
   | None -> return_nil
-  | Some (x, u') -> Lwt.return (Cons (x, unfold f u'))
+  | Some (x, u') -> Lwt.return (Cons (x, unfold_lwt f u'))
 
 let rec of_list = function
   | [] -> empty

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -68,6 +68,15 @@ val iter : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
   The traversal happens immediately and will not terminate (i.e., the promise
   will not resolve) on infinite sequences. *)
 
+val iter_p : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
+(** Iterate on the sequence, calling the (imperative) function on every element.
+
+  The sequence's next node is evaluated as soon as the the previous node is
+  resolved.
+
+  The traversal happens immediately and will not terminate (i.e., the promise
+  will not resolve) on infinite sequences. *)
+
 val unfold : ('b -> ('a * 'b) option Lwt.t) -> 'b -> 'a t
 (** Build a sequence from a step function and an initial value.
   [unfold f u] returns [empty] if the promise [f u] resolves to [None],

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -119,7 +119,7 @@ val of_seq : 'a Seq.t -> 'a t
   This transformation is lazy, it only applies when the result is
   traversed. *)
 
-val of_seq_lwt : 'a Lwt.t Seq.t -> 'a t Lwt.t
+val of_seq_lwt : 'a Lwt.t Seq.t -> 'a t
 (** Convert from ['a Lwt.t Stdlib.Seq.t] to ['a Lwt_seq.t].
   This transformation is lazy, it only applies when the result is
   traversed. *)

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -36,24 +36,42 @@ val append : 'a t -> 'a t -> 'a t
 (** [append xs ys] is the sequence [xs] followed by the sequence [ys] *)
 
 val map : ('a -> 'b) -> 'a t -> 'b t
-val map_s : ('a -> 'b Lwt.t) -> 'a t -> 'b t
 (** [map f seq] returns a new sequence whose elements are the elements of
   [seq], transformed by [f].
   This transformation is lazy, it only applies when the result is traversed. *)
 
+val map_s : ('a -> 'b Lwt.t) -> 'a t -> 'b t
+(** [map_s f seq] is like [map f seq] but [f] is a function that returns a
+  promise.
+
+  Note that there is no concurrency between the promises from the underlying
+  sequence [seq] and the promises from applying the function [f]. In other
+  words, the next promise-element of the underlying sequence ([seq]) is only
+  created when the current promise-element of the returned sequence (as mapped
+  by [f]) has resolved. This scheduling is true for all the [_s] functions of
+  this module. *)
+
 val filter : ('a -> bool) -> 'a t -> 'a t
-val filter_s : ('a -> bool Lwt.t) -> 'a t -> 'a t
 (** Remove from the sequence the elements that do not satisfy the
   given predicate.
   This transformation is lazy, it only applies when the result is
   traversed. *)
 
+val filter_s : ('a -> bool Lwt.t) -> 'a t -> 'a t
+(** [filter_s] is like [filter] but the predicate returns a promise.
+
+  See {!map_s} for additional details about scheduling. *)
+
 val filter_map : ('a -> 'b option) -> 'a t -> 'b t
-val filter_map_s : ('a -> 'b option Lwt.t) -> 'a t -> 'b t
 (** Apply the function to every element; if [f x = None] then [x] is dropped;
   if [f x = Some y] then [y] is returned.
   This transformation is lazy, it only applies when the result is
   traversed. *)
+
+val filter_map_s : ('a -> 'b option Lwt.t) -> 'a t -> 'b t
+(** [filter_map_s] is like [filter] but the predicate returns a promise.
+
+  See {!map_s} for additional details about scheduling. *)
 
 val flat_map : ('a -> 'b t) -> 'a t -> 'b t
 (** Map each element to a subsequence, then return each element of this
@@ -62,14 +80,17 @@ val flat_map : ('a -> 'b t) -> 'a t -> 'b t
   traversed. *)
 
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a Lwt.t
-val fold_left_s : ('a -> 'b -> 'a Lwt.t) -> 'a -> 'b t -> 'a Lwt.t
 (** Traverse the sequence from left to right, combining each element with the
   accumulator using the given function.
   The traversal happens immediately and will not terminate (i.e., the promise
   will not resolve) on infinite sequences. *)
 
+val fold_left_s : ('a -> 'b -> 'a Lwt.t) -> 'a -> 'b t -> 'a Lwt.t
+(** [fold_left_s] is like [fold_left] but the function returns a promise.
+
+  See {!map_s} for additional details about scheduling. *)
+
 val iter : ('a -> unit) -> 'a t -> unit Lwt.t
-val iter_s : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
 (** Iterate on the sequence, calling the (imperative) function on every element.
 
   The sequence's next node is evaluated only once the function has finished
@@ -80,10 +101,15 @@ val iter_s : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
   The traversal happens immediately and will not terminate (i.e., the promise
   will not resolve) on infinite sequences. *)
 
+val iter_s : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
+(** [iter_s] is like [iter] but the function returns a promise.
+
+  See {!map_s} for additional details about scheduling. *)
+
 val iter_p : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
 (** Iterate on the sequence, calling the (imperative) function on every element.
 
-  The sequence's next node is evaluated as soon as the the previous node is
+  The sequence's next node is evaluated as soon as the previous node is
   resolved.
 
   The traversal happens immediately and will not terminate (i.e., the promise
@@ -108,11 +134,13 @@ val iter_n : ?max_concurrency:int -> ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
   @raise Invalid_argument if [max_concurrency < 1]. *)
 
 val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
-val unfold_lwt : ('b -> ('a * 'b) option Lwt.t) -> 'b -> 'a t
 (** Build a sequence from a step function and an initial value.
   [unfold f u] returns [empty] if the promise [f u] resolves to [None],
   or [fun () -> Lwt.return (Cons (x, unfold f y))] if the promise [f u] resolves
   to [Some (x, y)]. *)
+
+val unfold_lwt : ('b -> ('a * 'b) option Lwt.t) -> 'b -> 'a t
+(** [unfold_lwt] is like [unfold] but the step function returns a promise. *)
 
 val to_list : 'a t -> 'a list Lwt.t
 (** Convert a sequence to a list, preserving order.

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -21,9 +21,16 @@ val empty : 'a t
 val return : 'a -> 'a t
 (** The singleton sequence containing only the given element. *)
 
+val return_lwt : 'a Lwt.t -> 'a t
+(** The singleton sequence containing only the given promised element. *)
+
 val cons : 'a -> 'a t -> 'a t
 (** [cons x xs] is the sequence containing the element [x] followed by
   the sequence [xs] *)
+
+val cons_lwt : 'a Lwt.t -> 'a t -> 'a t
+(** [cons x xs] is the sequence containing the element promised by [x] followed
+  by the sequence [xs] *)
 
 val append : 'a t -> 'a t -> 'a t
 (** [append xs ys] is the sequence [xs] followed by the sequence [ys] *)

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -57,7 +57,8 @@ val fold_left : ('a -> 'b -> 'a Lwt.t) -> 'a -> 'b t -> 'a Lwt.t
   The traversal happens immediately and will not terminate (i.e., the promise
   will not resolve) on infinite sequences. *)
 
-val iter : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
+val iter : ('a -> unit) -> 'a t -> unit Lwt.t
+val iter_s : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
 (** Iterate on the sequence, calling the (imperative) function on every element.
 
   The sequence's next node is evaluated only once the function has finished

--- a/src/core/lwt_seq.mli
+++ b/src/core/lwt_seq.mli
@@ -107,7 +107,8 @@ val iter_n : ?max_concurrency:int -> ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
   @param max_concurrency defaults to [1].
   @raise Invalid_argument if [max_concurrency < 1]. *)
 
-val unfold : ('b -> ('a * 'b) option Lwt.t) -> 'b -> 'a t
+val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
+val unfold_lwt : ('b -> ('a * 'b) option Lwt.t) -> 'b -> 'a t
 (** Build a sequence from a step function and an initial value.
   [unfold f u] returns [empty] if the promise [f u] resolves to [None],
   or [fun () -> Lwt.return (Cons (x, unfold f y))] if the promise [f u] resolves

--- a/test/core/main.ml
+++ b/test/core/main.ml
@@ -15,5 +15,6 @@ Test.run "core"
     Test_lwt_condition.suite;
     Test_lwt_pool.suite;
     Test_lwt_sequence.suite;
-    Test_lwt_seq.suite;
+    Test_lwt_seq.suite_base;
+    Test_lwt_seq.suite_fuzzing;
   ])

--- a/test/core/test_lwt_seq.ml
+++ b/test/core/test_lwt_seq.ml
@@ -21,6 +21,7 @@ let rec pause n =
    else
       let* () = Lwt.pause () in
       pause (n - 1)
+let pause n = pause (n mod 5)
 
 let suite_base = suite "lwt_seq" [
   test "fold_left" begin fun () ->
@@ -65,7 +66,7 @@ let suite_base = suite "lwt_seq" [
     let f x =
        incr running;
        assert (!running <= max_concurrency);
-       let* () = pause (x mod 3) in
+       let* () = pause x in
        sum := !sum + x;
        decr running;
        Lwt.return_unit
@@ -84,7 +85,7 @@ let suite_base = suite "lwt_seq" [
     let f x =
        incr running;
        assert (!running <= max_concurrency);
-       let* () = pause (x mod 3) in
+       let* () = pause x in
        sum := !sum + x;
        decr running;
        Lwt.return_unit
@@ -103,7 +104,7 @@ let suite_base = suite "lwt_seq" [
     let f x =
        incr running;
        assert (!running <= max_concurrency);
-       let* () = pause (x mod 3) in
+       let* () = pause x in
        sum := !sum + x;
        decr running;
        Lwt.return_unit

--- a/test/core/test_lwt_seq.ml
+++ b/test/core/test_lwt_seq.ml
@@ -217,7 +217,7 @@ let suite_base = suite "lwt_seq" [
   end;
 ]
 
-let fs = [(+); (-); Fun.const; min; max]
+let fs = [(+); (-); (fun x _ -> x); min; max]
 let ls = [
    [];
    l;

--- a/test/core/test_lwt_seq.ml
+++ b/test/core/test_lwt_seq.ml
@@ -144,7 +144,7 @@ let suite_base = suite "lwt_seq" [
       ([] = b)
   end;
 
-  test "exception" begin fun () ->
+  test "fold-into-exception-from-of-seq" begin fun () ->
     let fail = fun () -> failwith "XXX" in
     let seq = fun () -> Seq.Cons (1, (fun () -> Seq.Cons (2, fail))) in
     let a = Lwt_seq.of_seq seq in
@@ -158,7 +158,7 @@ let suite_base = suite "lwt_seq" [
     n = (-1)
   end;
 
-  test "exception-immediately" begin fun () ->
+  test "fold-into-immediate-exception-from-of-seq" begin fun () ->
     let fail = fun () -> failwith "XXX" in
     let seq = fail in
     let a = Lwt_seq.of_seq seq in
@@ -172,7 +172,7 @@ let suite_base = suite "lwt_seq" [
     n = (-1)
   end;
 
-  test "exception of_seq_lwt" begin fun () ->
+  test "fold-into-exception-from-of-seq-lwt" begin fun () ->
     let fail = fun () -> failwith "XXX" in
     let seq: int Lwt.t Seq.t = fun () ->
       Seq.Cons (Lwt.return 1,
@@ -189,7 +189,7 @@ let suite_base = suite "lwt_seq" [
     n = (-1)
   end;
 
-  test "exception of_seq_lwt immediately" begin fun () ->
+  test "fold-into-immediate-exception-from-of-seq-lwt" begin fun () ->
     let fail = fun () -> failwith "XXX" in
     let seq: int Lwt.t Seq.t = fail in
     let a = Lwt_seq.of_seq_lwt seq in


### PR DESCRIPTION
Adds `iter_p`, renames `iter` into `iter_s`, adds `iter`.

This is meant as a discussion, it should ideally happen before the first release of Lwt that includes `Lwt_seq` to avoid difficulties with the backwards compatibility.

Are the added functions useful?  
Should we also have a similar range of ` `/`_s`for some other traversals? (Note that `_p` doesn't make sense for some of them.)

ping @zshipko @c-cube 