### PR TITLE
Use Windows Unicode API in C stubs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -75,7 +75,7 @@ jobs:
               *.opam
               !lwt_ppx.opam
           - os: windows-latest
-            ocaml-compiler: 4.02.x
+            ocaml-compiler: 4.06.x
             libev: false
             ppx: false
             local-packages: |

--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@
 
   * Code quality improvement: remove an uneeded Obj.magic (#844, Benoit Montagu).
 
+  * On Windows, use the Unicode API in C stubs and functions introduced in OCaml 4.06 to handle Unicode strings. Raise the minimum requirement to OCaml 4.06 (on Windows only). (#843, Antonin Décimo)
 
 ===== 5.4.2 =====
 

--- a/lwt.opam
+++ b/lwt.opam
@@ -22,11 +22,11 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.8.0"}
   "dune-configurator"
-  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
-  "ocaml" {>= "4.02.0"}
+  "mmap" {>= "1.1.0" & "os" != "win32"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0" & "os" != "win32 " | >= "4.06.0"}
   ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
   "ocplib-endian"
-  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "result" {os != "win32"} # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -262,10 +262,11 @@ struct
 
   let ws2_32_lib context =
     if Configurator.ocaml_config_var_exn context "os_type" = "Win32" then
+      let unicode = ["-DUNICODE"; "-D_UNICODE"] in
       if Configurator.ocaml_config_var_exn context "ccomp_type" = "msvc" then
-        extend [] ["ws2_32.lib"]
+        extend unicode ["ws2_32.lib"]
       else
-        extend [] ["-lws2_32"]
+        extend unicode ["-lws2_32"]
 
   let c_flags () =
     !c_flags

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -10,10 +10,15 @@
 #include <lwt_unix.h>
 
 #define CAML_NAME_SPACE
+#include <caml/version.h>
+#if OCAML_VERSION < 41300
+#define CAML_INTERNALS
+#endif
 
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
+#include <caml/osdeps.h>
 
 static HANDLE get_handle(value opt) {
   value fd;
@@ -29,8 +34,6 @@ static HANDLE get_handle(value opt) {
     return INVALID_HANDLE_VALUE;
 }
 
-#define string_option(opt) (Is_block(opt) ? String_val(Field(opt, 0)) : NULL)
-
 CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
                                           value cwd, value fds) {
   CAMLparam5(prog, cmdline, env, cwd, fds);
@@ -38,6 +41,18 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
 
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
+  BOOL ret;
+
+#define string_option(opt) \
+  (Is_block(opt) ? caml_stat_strdup_to_os(String_val(Field(opt, 0))) : NULL)
+
+  char_os
+    *progs = string_option(prog),
+    *cmdlines = caml_stat_strdup_to_os(String_val(cmdline)),
+    *envs = string_option(env),
+    *cwds = string_option(cwd);
+
+#undef string_option
 
   ZeroMemory(&si, sizeof(si));
   ZeroMemory(&pi, sizeof(pi));
@@ -47,9 +62,14 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
   si.hStdOutput = get_handle(Field(fds, 1));
   si.hStdError = get_handle(Field(fds, 2));
 
-  if (!CreateProcess(string_option(prog), (LPSTR)String_val(cmdline), NULL,
-                     NULL, TRUE, 0, (LPVOID)string_option(env),
-                     string_option(cwd), &si, &pi)) {
+  ret = CreateProcess(progs, cmdlines, NULL, NULL, TRUE, 0,
+                      envs, cwds, &si, &pi);
+  caml_stat_free(progs);
+  caml_stat_free(cmdlines);
+  caml_stat_free(envs);
+  caml_stat_free(cwds);
+
+  if (!ret) {
     win32_maperr(GetLastError());
     uerror("CreateProcess", Nothing);
   }

--- a/src/unix/windows_c/windows_system_job.c
+++ b/src/unix/windows_c/windows_system_job.c
@@ -7,8 +7,16 @@
 
 #if defined(LWT_ON_WINDOWS)
 
+#define CAML_NAME_SPACE
+#include <caml/version.h>
+#if OCAML_VERSION < 41300
+#define CAML_INTERNALS
+#endif
+#include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/misc.h>
 #include <caml/unixsupport.h>
+#include <caml/osdeps.h>
 
 #include "lwt_unix.h"
 
@@ -40,23 +48,28 @@ static value result_system(struct job_system *job)
 
 CAMLprim value lwt_unix_system_job(value cmdline)
 {
+    CAMLparam1(cmdline);
     STARTUPINFO si;
     PROCESS_INFORMATION pi;
+    BOOL ret;
+
+    char_os *cmdlines = caml_stat_strdup_to_os(String_val(cmdline));
 
     ZeroMemory(&si, sizeof(si));
     ZeroMemory(&pi, sizeof(pi));
     si.cb = sizeof(si);
-    /* The cast to LPSTR below is only legitimate because we are calling
-       CreateProcessA. See https://github.com/ocsigen/lwt/pull/790. */
-    if (!CreateProcess(NULL, (LPSTR)String_val(cmdline), NULL, NULL, TRUE, 0,
-                       NULL, NULL, &si, &pi)) {
+
+    ret = CreateProcess(NULL, cmdlines, NULL, NULL, TRUE, 0,
+                        NULL, NULL, &si, &pi);
+    caml_stat_free(cmdlines);
+    if (!ret) {
         win32_maperr(GetLastError());
         uerror("CreateProcess", Nothing);
     } else {
         LWT_UNIX_INIT_JOB(job, system, 0);
         CloseHandle(pi.hThread);
         job->handle = pi.hProcess;
-        return lwt_unix_alloc_job(&(job->job));
+        CAMLreturn(lwt_unix_alloc_job(&(job->job)));
     }
 }
 #endif


### PR DESCRIPTION
This was discussed a bit in https://github.com/ocsigen/lwt/pull/790.

I looked for windows functions in `src/unix/{,windows_c}/*.c`.

Two possible changes to this patch:

1. define the macros inside the C files;
2. use the _W_ suffix to `CreateProcess`.