### PR TITLE
Provide for setup and teardown hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lib/
 *.cm*
 *.o
 a.out
+test*.log

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -744,7 +744,6 @@ sig
   val get : 'v key -> 'v option
   val with_value : 'v key -> 'v option -> (unit -> 'b) -> 'b
 
-
   (* Internal interface *)
   val current_storage : storage ref
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1886,17 +1886,9 @@ struct
         | Fulfilled v ->
           current_storage := saved_storage;
           current_setup := saved_setup;
-          let teardown_opt =
-            match saved_setup with
-            | None -> None
-            | Some setup -> Some (setup ())
-          in
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try f v with exn -> fail exn in
-          let _ =
-            match teardown_opt with
-            | None -> None
-            | Some teardown -> Some (teardown ())
-          in
+          let _ = match teardown_opt with | None -> None | Some teardown -> Some (teardown ()) in
           let Internal p' = to_internal_promise p' in
           (* Run the user's function [f]. *)
 
@@ -1953,13 +1945,16 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
         | Fulfilled v ->
           current_storage := saved_storage;
-
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try f v with exn -> fail (add_loc exn) in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2007,13 +2002,16 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
         | Fulfilled v ->
           current_storage := saved_storage;
-
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p''_result = try Fulfilled (f v) with exn -> Rejected exn in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
           let p'' = underlying p'' in
@@ -2063,6 +2061,7 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
@@ -2076,8 +2075,10 @@ struct
 
         | Rejected exn ->
           current_storage := saved_storage;
-
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try h exn with exn -> fail exn in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2118,6 +2119,7 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
@@ -2132,7 +2134,10 @@ struct
         | Rejected exn ->
           current_storage := saved_storage;
 
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try h exn with exn -> fail (add_loc exn) in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2173,13 +2178,16 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
         | Fulfilled v ->
           current_storage := saved_storage;
-
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try f' v with exn -> fail exn in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2191,8 +2199,11 @@ struct
 
         | Rejected exn ->
           current_storage := saved_storage;
-
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try h exn with exn -> fail exn in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
+
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2239,13 +2250,17 @@ struct
       let p'' = new_pending ~how_to_cancel:(Propagate_cancel_to_one p) in
 
       let saved_storage = !current_storage in
+      let saved_setup = !current_setup in
 
       let callback p_result =
         match p_result with
         | Fulfilled v ->
           current_storage := saved_storage;
 
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try f' v with exn -> fail (add_loc exn) in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in
@@ -2258,7 +2273,10 @@ struct
         | Rejected exn ->
           current_storage := saved_storage;
 
+          current_setup := saved_setup;
+          let teardown_opt = match saved_setup with | None -> None | Some setup -> Some (setup ()) in
           let p' = try h exn with exn -> fail (add_loc exn) in
+          let _ = match teardown_opt with | None -> None | Some f -> Some (f ()) in
           let Internal p' = to_internal_promise p' in
 
           let State_may_now_be_pending_proxy p'' = may_now_be_proxy p'' in

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -830,14 +830,14 @@ struct
   let with_setup_teardown setup_teardown f =
       let saved_setup = !current_setup in
       current_setup := Some setup_teardown;
+      let teardown = setup_teardown () in
       try
-        let teardown = setup_teardown () in
-        (* Should we call setup/teardown here ? *)
         let result = f () in
         teardown ();
         current_setup := saved_setup;
         result
       with exn ->
+        teardown ();
         current_setup := saved_setup;
         raise exn
 
@@ -1888,8 +1888,7 @@ struct
           current_setup := saved_setup;
           let teardown_opt =
             match saved_setup with
-            | None -> 
-              None
+            | None -> None
             | Some setup -> Some (setup ())
           in
           let p' = try f v with exn -> fail exn in

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1900,9 +1900,9 @@ struct
           current_storage := saved_storage;
           current_setup := saved_setup;
 
-          let res_teardown = Option.map (fun {setup;teardown} -> setup (),teardown) saved_setup in
+          let res_teardown = match saved_setup with | None -> None | Some {setup;teardown} -> Some (setup (),teardown) in
           let p' = try f v with exn -> fail exn in
-          Option.iter (fun (res,teardown) -> teardown res) res_teardown;
+          let _ = match res_teardown with | None -> None | Some (res,teardown) -> Some (teardown res) in
           let Internal p' = to_internal_promise p' in
           (* Run the user's function [f]. *)
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -750,6 +750,7 @@ sig
   val with_setup_teardown : setup:(unit -> 'a) -> teardown:('a -> unit) -> (unit -> 'c) -> 'c
   type setup_teardown = unit -> (unit -> unit)
   val current_setup : setup_teardown option ref
+
 end =
 struct
   (* The idea behind sequence-associated storage is to preserve some values

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -748,8 +748,8 @@ sig
   (* Internal interface *)
   val current_storage : storage ref
 
+  val with_setup_teardown : setup:(unit -> 'a) -> teardown:('a -> unit) -> (unit -> 'c) -> 'c
   type setup_teardown = unit -> (unit -> unit)
-  val with_setup_teardown : setup_teardown -> (unit -> 'c) -> 'c
   val current_setup : setup_teardown option ref
 end =
 struct
@@ -827,8 +827,9 @@ struct
   type setup_teardown = unit -> (unit -> unit)
   let current_setup : setup_teardown option ref = ref None
 
-  let with_setup_teardown setup_teardown f =
+  let with_setup_teardown ~setup ~teardown f =
       let saved_setup = !current_setup in
+      let setup_teardown = (fun () -> let res = setup () in fun () -> teardown res) in
       current_setup := Some setup_teardown;
       let teardown = setup_teardown () in
       try

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1650,7 +1650,8 @@ val state : 'a t -> 'a state
 
 (** {2 Deprecated} *)
 
-val with_setup_teardown : setup:(unit -> unit) -> teardown:(unit -> unit) -> (unit -> 'c) -> 'c
+type setup_teardown = unit -> (unit -> unit)
+val with_setup_teardown : setup_teardown -> (unit -> 'c) -> 'c
 
 (** {3 Implicit callback arguments}
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1650,6 +1650,8 @@ val state : 'a t -> 'a state
 
 (** {2 Deprecated} *)
 
+val with_setup_teardown : (unit -> 'x) -> ('x -> unit) -> (unit -> 'c) -> 'c
+
 (** {3 Implicit callback arguments}
 
     Using this mechanism is discouraged, because it is non-syntactic, and

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1650,7 +1650,7 @@ val state : 'a t -> 'a state
 
 (** {2 Deprecated} *)
 
-val with_setup_teardown : (unit -> 'x) -> ('x -> unit) -> (unit -> 'c) -> 'c
+val with_setup_teardown : setup:(unit -> unit) -> teardown:(unit -> unit) -> (unit -> 'c) -> 'c
 
 (** {3 Implicit callback arguments}
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1647,11 +1647,9 @@ val state : 'a t -> 'a state
     The constructor names are historical holdovers. *)
 
 
+val with_setup_teardown : setup:(unit -> 'a) -> teardown:('a -> unit) -> (unit -> 'c) -> 'c
 
 (** {2 Deprecated} *)
-
-type setup_teardown = unit -> (unit -> unit)
-val with_setup_teardown : setup_teardown -> (unit -> 'c) -> 'c
 
 (** {3 Implicit callback arguments}
 

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -4462,7 +4462,8 @@ let setup_teardown_tests = suite "setup_teardown" [
     let count = ref 0 in
     let p =
       Lwt.with_setup_teardown
-        (fun () -> fun () -> ())
+        ~setup:(fun () -> ())
+        ~teardown:(fun () -> ())
         (fun () -> Lwt.bind (Lwt.return 0) binder |> Lwt.map (fun _ -> !count))
     in
     state_is (Lwt.Return 0) p
@@ -4484,12 +4485,10 @@ let setup_teardown_tests = suite "setup_teardown" [
           Lwt.bind p2 binder
     in
     let count = ref 0 in
-    let p = 
+    let p =
       Lwt.with_setup_teardown
-        (fun () -> 
-          let counter = !count in
-          fun () -> 
-            count := counter + 1)
+        ~setup:(fun () -> !count)
+        ~teardown:(fun counter -> count := counter + 1)
         (fun () -> Lwt.bind (Lwt.return 0) binder |> Lwt.map (fun _ -> !count))
     in
     state_is (Lwt.Return limit) p
@@ -4529,9 +4528,8 @@ let setup_teardown_tests = suite "setup_teardown" [
     let count = ref 0 in
     let p = 
       Lwt.with_setup_teardown
-        (fun () -> 
-          let counter = !count in
-          fun () -> count := counter + 1)
+        ~setup:(fun () -> !count)
+        ~teardown:(fun counter -> count := counter + 1)
         (fun () -> 
           let p,wake = Lwt.wait () in
           let p = Lwt.bind p binder in


### PR DESCRIPTION
This PR is to evaluate if this is something that would be considered a reasonable addition to Lwt

The goal here is to provide for thread level setup and teardown hooks, which are run everytime the thread becomes 'active'
This is useful where LWT is run in applications where other frameworks (typically within C++) might rely on some global singletons to be active. 

In our usecase, our application relies on some enterprise logging system that runs in C++. The logging system can attach certain 'context' to each log that is emitted, as long as a global singleton is initialized. 

In the past, we have relied on having our own `bind` and `map` wrappers (`Logging.bind`) that would do the setup and teardown for you. It has the unfortunate side effect that even library code that does not care much about the global context needs to start using this specific bind and can't just depend on raw Lwt

The proposal here is to allow for clients to register thread level hooks (similar to implicit values). The hooks are expected to run whenever a thread becomes active and a callback is executed on the thread

**This PR is in draft status right now. If there is enough positive feedback, I can work on cleaning it up to make it ready**


@code-ghalib
