### PR TITLE
Fix Lwt_fmt.stderr to actually point to stderr instead of stdout (#850)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
   * Lwt_seq: a Seq-like data-structure with Lwt delayed nodes (#836, Zach Shipko).
 
+====== Bugfixes ======
+
+  * Fix Lwt_fmt.stderr to actually point to stderr (#852, #850, Volker Diels-Grabsch).
+
 ===== 5.4.0 (2020-12-16) =====
 
 ====== Installability ======

--- a/src/unix/lwt_fmt.ml
+++ b/src/unix/lwt_fmt.ml
@@ -76,7 +76,7 @@ let ifprintf ppft fmt =
   ikfprintf (fun _ t -> t) ppft fmt
 
 let stdout = of_channel Lwt_io.stdout
-let stderr = of_channel Lwt_io.stdout
+let stderr = of_channel Lwt_io.stderr
 
 let printf fmt = fprintf stdout fmt
 let eprintf fmt = fprintf stderr fmt


### PR DESCRIPTION
Fix Lwt_fmt.stderr to actually point to stderr instead of stdout.

This fixes #850.