### PR TITLE
lwt: auto detect Android from the compiler

### DIFF
--- a/lwt.opam
+++ b/lwt.opam
@@ -37,8 +37,6 @@ depopts: [
 ]
 
 build: [
-  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
-    "--use-libev" "%{conf-libev:installed}%"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 


### PR DESCRIPTION
At [reason-mobile](https://github.com/EduardoRFS/reason-mobile/) I try to keep all dune packages simple, by just adding `-x android.arm64` on the CLI they ideally should build.

This implies that the package itself should be able to discover the OS, which is not the case for LWT. Because otherwise we need an external build script to detect which OS should or should not add a flag.

This PR aims to fix that in making so that if no `android-target` is provided on the CLI, it tries to detect from the compiler.