### PR TITLE
Deprecate Lwt_main.yield in favor of Lwt.pause.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,13 @@
 ===== dev =====
 
+====== Deprecations ======
+
+  * Lwt_main.yield and Lwt_unix.yield are deprecated in favor of the generic Lwt.pause, and Lwt_unix.auto_yield is deprecated in favor of the new Lwt_unix.auto_pause (#855, #858, Favonia). Currently, Lwt.main resolves paused promises more frequently than yielded promises. The difference is unintended but existing applications could depend on it. Once the migration has been completed, Lwt_main.abandon_yielded_and_paused will also be deprecated in favor of Lwt.abandon_paused.
+
 ====== Additions ======
 
   * Lwt_seq: a Seq-like data-structure with Lwt delayed nodes (#836, #842, Zach Shipko).
+  * Lwt_unix.auto_pause: the replacement of Lwt_unix.auto_yield that uses Lwt.pause instead of Lwt_unix.yield (#855, #858, Favonia).
 
 ====== Misc ======
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,11 +2,12 @@
 
 ====== Deprecations ======
 
-  * Lwt_main.yield and Lwt_unix.yield are deprecated in favor of the generic Lwt.pause, and Lwt_unix.auto_yield is deprecated in favor of the new Lwt_unix.auto_pause (#855, #858, Favonia). Currently, Lwt.main resolves paused promises more frequently than yielded promises. The difference is unintended but existing applications could depend on it. Once the migration has been completed, Lwt_main.abandon_yielded_and_paused will also be deprecated in favor of Lwt.abandon_paused.
+  * Lwt_main.yield and Lwt_unix.yield are deprecated in favor of the generic Lwt.pause, and Lwt_unix.auto_yield is deprecated in favor of the new Lwt_unix.auto_pause. Currently, Lwt_main.run resolves paused promises more frequently than yielded promises; the difference is unintended but existing applications could unintentionally depend on it (#855, #858, Favonia).
 
 ====== Additions ======
 
   * Lwt_seq: a Seq-like data-structure with Lwt delayed nodes (#836, #842, Zach Shipko).
+
   * Lwt_unix.auto_pause: the replacement of Lwt_unix.auto_yield that uses Lwt.pause instead of Lwt_unix.yield (#855, #858, Favonia).
 
 ====== Misc ======

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -298,8 +298,8 @@ let () =
     underlying I/O operations complete.
 
     In case your callback is just using the CPU for a really long time, you can
-    insert a few calls to {!Lwt_main.yield} into it, and resume your computation
-    in callbacks of [yield]. This is basically the same as
+    insert a few calls to {!Lwt.pause} into it, and resume your computation
+    in callbacks of [pause]. This is basically the same as
     {!Lwt_unix.sleep}[ 0.] – it's a promise that will be resolved by
     {!Lwt_main.run} {e after} any other I/O resolutions that are already in its
     queue.
@@ -1927,7 +1927,7 @@ val register_pause_notifier : (int -> unit) -> unit
 
 val abandon_paused : unit -> unit
 (** Causes promises created with {!Lwt.pause} to remain forever pending. See
-    {!Lwt_main.abandon_yielded_and_paused}.
+    {!Lwt_main.abandon_yielded_and_paused} before {!Lwt_main.yield} is phased out.
 
     This function is intended for internal use by Lwt. *)
 

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -47,14 +47,21 @@ val yield : unit -> unit Lwt.t [@@deprecated "Use Lwt.pause instead"]
       calling all currently ready callbacks, i.e. it is fulfilled on the next
       “tick.”
 
-      [yield] is similar to {!Lwt.pause} and it exists for historical reason.
-      Prefer [pause] in order to stay compatible with other execution
-      environments such as js_of_ocaml. *)
+      [yield] is now deprecated in favor of the more general {!Lwt.pause}
+      in order to avoid discrepancies in resolution (see below) and stay
+      compatible with other execution environments such as js_of_ocaml.
+
+      Currently, paused promises are resolved more frequently than yielded promises.
+      The difference is unintended but existing applications could depend on it.
+      Unifying the two pools of promises into one in the future would eliminate
+      possible discrepancies and simplify the code. *)
 
 val abandon_yielded_and_paused : unit -> unit
 (** Causes promises created with {!Lwt.pause} and {!Lwt_main.yield} to remain
-    forever pending. Once [yield] is phased out, this function will be deprecated
-    as well.
+    forever pending.
+
+    [yield] is now deprecated in favor of the more general {!Lwt.pause}.
+    Once [yield] is phased out, this function will be deprecated as well.
 
     This is meant for use with {!Lwt.fork}, as a way to "abandon" more promise
     chains that are pending in your process. *)

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -42,7 +42,7 @@ let () = Lwt_main.run (main ())
       It is not safe to call [Lwt_main.run] in a function registered with
       [Pervasives.at_exit], use {!Lwt_main.at_exit} instead. *)
 
-val yield : unit -> unit Lwt.t
+val yield : unit -> unit Lwt.t [@@deprecated "Use Lwt.pause instead"]
   (** [yield ()] is a pending promise that is fulfilled after Lwt finishes
       calling all currently ready callbacks, i.e. it is fulfilled on the next
       “tick.”
@@ -53,7 +53,8 @@ val yield : unit -> unit Lwt.t
 
 val abandon_yielded_and_paused : unit -> unit
 (** Causes promises created with {!Lwt.pause} and {!Lwt_main.yield} to remain
-    forever pending.
+    forever pending. Once [yield] is phased out, this function will be deprecated
+    as well.
 
     This is meant for use with {!Lwt.fork}, as a way to "abandon" more promise
     chains that are pending in your process. *)

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -124,7 +124,7 @@ let sleep delay =
   Lwt.on_cancel waiter (fun () -> Lwt_engine.stop_event ev);
   waiter
 
-let[@warning "-3"] yield = Lwt_main.yield
+let yield = (Lwt_main.yield [@warning "-3"])
 
 let auto_yield timeout =
   let limit = ref (Unix.gettimeofday () +. timeout) in

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -51,16 +51,18 @@ val sleep : float -> unit Lwt.t
   (** [sleep d] is a promise that remains in a pending state for [d] seconds
       and after which it is resolved with value [()]. *)
 
-val yield : unit -> unit Lwt.t
+val yield : unit -> unit Lwt.t [@@deprecated "Use Lwt.pause instead"]
   (** [yield ()] is a promise in a pending state. It resumes itself as soon as
       possible and resolves with value [()]. *)
 
-val auto_yield : float -> (unit -> unit Lwt.t)
-  (** [auto_yield timeout] returns a function [f], and [f ()] has the following
+val auto_yield : float -> (unit -> unit Lwt.t) [@@deprecated "Use Lwt.auto_pause instead"]
+
+val auto_pause : float -> (unit -> unit Lwt.t)
+  (** [auto_pause timeout] returns a function [f], and [f ()] has the following
       behavior:
 
       - If it has been more than [timeout] seconds since the last time [f ()]
-        behaved like {!Lwt_unix.yield}, [f ()] calls {!Lwt_unix.yield}.
+        behaved like {!Lwt.pause}, [f ()] calls {!Lwt.pause}.
       - Otherwise, if it has been less than [timeout] seconds, [f ()] behaves
         like {!Lwt.return_unit}, i.e. it does not yield. *)
 

--- a/test/unix/test_lwt_engine.ml
+++ b/test/unix/test_lwt_engine.ml
@@ -66,7 +66,7 @@ let run_tests = [
 
     (* Make sure we are running in a callback called by Lwt_main.run, not
        synchronously when the testing executable is loaded. *)
-    Lwt_main.yield () >>= fun () ->
+    Lwt.pause () >>= fun () ->
 
     try
       Lwt_main.run (Lwt.return ());

--- a/test/unix/test_sleep_and_timeout.ml
+++ b/test/unix/test_sleep_and_timeout.ml
@@ -41,7 +41,7 @@ let suite = suite "Lwt_unix sleep and timeout" [
 
     test "with_timeout : no timeout" begin fun () ->
       let duration = 1.0 in
-      Lwt_unix.with_timeout duration Lwt_unix.yield
+      Lwt_unix.with_timeout duration Lwt.pause
       >>= fun () -> Lwt.return_true
     end;
 
@@ -65,32 +65,32 @@ let suite = suite "Lwt_unix sleep and timeout" [
         )
     end;
 
-    test "yield" begin fun () ->
+    test "pause" begin fun () ->
       let bind_callback_ran = ref false in
       Lwt.async (fun () -> Lwt.return () >|= fun () -> bind_callback_ran := true);
       let bind_is_immediate = !bind_callback_ran in
-      let yield_callback_ran = ref false in
-      Lwt.async (fun () -> Lwt_unix.yield () >|= fun () -> yield_callback_ran := true);
-      let yield_is_immediate = !yield_callback_ran in
-      Lwt.return (bind_is_immediate && not yield_is_immediate)
+      let pause_callback_ran = ref false in
+      Lwt.async (fun () -> Lwt.pause () >|= fun () -> pause_callback_ran := true);
+      let pause_is_immediate = !pause_callback_ran in
+      Lwt.return (bind_is_immediate && not pause_is_immediate)
     end;
 
-    test "auto_yield" begin fun () ->
-      let f = Lwt_unix.auto_yield 1.0 in
-      let run_auto_yield () =
+    test "auto_pause" begin fun () ->
+      let f = Lwt_unix.auto_pause 1.0 in
+      let run_auto_pause () =
         let callback_ran = ref false in
         Lwt.async (fun () -> f () >|= fun () -> callback_ran := true);
         !callback_ran;
       in
-      let check1 = run_auto_yield () in
-      let check2 = run_auto_yield () in
+      let check1 = run_auto_pause () in
+      let check2 = run_auto_pause () in
       Lwt_unix.sleep 1.0
       >|= fun () ->
-      let check3 = run_auto_yield () in
-      let check4 = run_auto_yield () in
-      let check5 = run_auto_yield () in
+      let check3 = run_auto_pause () in
+      let check4 = run_auto_pause () in
+      let check5 = run_auto_pause () in
       let check = check1 && check2 && not check3 && check4 && check5 in
-      instrument check "Lwt_unix sleep and timeout: auto_yield: %b %b %b %b %b"
+      instrument check "Lwt_unix sleep and timeout: auto_pause: %b %b %b %b %b"
         check1 check2 check3 check4 check5
     end;
   ]


### PR DESCRIPTION
This partially addresses #855. The eventual goal is to remove the second pool completely.

`Lwt_unix.auto_pause` was added to replace `Lwt_unix.auto_yield`.