### PR TITLE
Use `is_blocking` in `dup` and `dup2` to fix `ENOTSOCK` on Windows 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@
 
 ====== Fixes ======
 
+  * Use is_blocking in dup and dup2 to fix ENOTSOCK on Windows.
+    (#869, Antonin Décimo)
+
   * Support IPv6 socketpair on Windows (#870, #876, Antonin Décimo, David Allsopp).
 
   * Lwt_unix.lstat was incorrectly calling Unix.stat on Win32. Fixes

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1242,13 +1242,8 @@ let dup ch =
     set_flags = ch.set_flags;
     blocking =
       if ch.set_flags then
-        lazy(Lazy.force ch.blocking >>= function
-        | true ->
-          Unix.clear_nonblock fd;
-          Lwt.return_true
-        | false ->
-          Unix.set_nonblock fd;
-          Lwt.return_false)
+        lazy(Lazy.force ch.blocking >>= function blocking ->
+               Lazy.force (is_blocking ~blocking fd))
       else
         ch.blocking;
     event_readable = None;
@@ -1263,13 +1258,8 @@ let dup2 ch1 ch2 =
   ch2.set_flags <- ch1.set_flags;
   ch2.blocking <- (
     if ch2.set_flags then
-      lazy(Lazy.force ch1.blocking >>= function
-      | true ->
-        Unix.clear_nonblock ch2.fd;
-        Lwt.return_true
-      | false ->
-        Unix.set_nonblock ch2.fd;
-        Lwt.return_false)
+      lazy(Lazy.force ch1.blocking >>= function blocking ->
+             Lazy.force (is_blocking ~blocking ch2.fd))
     else
       ch1.blocking
   )


### PR DESCRIPTION
On Windows, calling `Unix.clear_non_block` and `Unix.set_non_block` is
only supported on socket file descriptors. The function `is_blocking`
already deals with the corner cases, but the current implementations
of `dup` and `dup2` don't make use of it. Thus, when the `dup` or `dup2`
wrappers are called with file descriptors, `ENOTSOCK` errors are
raised. The fix is to reuse `is_blocking` in the wrappers.