### PR TITLE
Support `Unix.socketpair` using `PF_UNIX` on Windows and OCaml 4.14 

### DIFF
--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1689,7 +1689,11 @@ let shutdown ch shutdown_command =
 external stub_socketpair : socket_domain -> socket_type -> int -> Unix.file_descr * Unix.file_descr = "lwt_unix_socketpair_stub"
 
 let socketpair dom typ proto =
-#if OCAML_VERSION >= (4, 05, 0)
+#if OCAML_VERSION >= (4, 14, 0)
+  let do_socketpair =
+    if Sys.win32 && (dom <> Unix.PF_UNIX) then stub_socketpair
+    else Unix.socketpair ?cloexec:None in
+#elif OCAML_VERSION >= (4, 05, 0)
   let do_socketpair =
     if Sys.win32 then stub_socketpair
     else Unix.socketpair ?cloexec:None in


### PR DESCRIPTION
A few improvements (imho) to the support of `socketpair` under Windows:
- fix the `socket_domain_table` length;
- add support for IPv6 `socketpair` emulation (I'm rooting for the Universal Deployment of IPv6);
- support Unix domain sockets and `socketpair` emulation using Unix domain sockets to be introduced in OCaml 4.14 (PR 10192).

This allows us to use socketpair and Unix domain sockets to perform IO redirection with processes, which isn't possible with current sockets in OCaml under Windows. Sockets have to be created in non-overlapped mode, with `WSASocket(domain, type, protocol, NULL, 0, 0)` rather than `socket(domain, type, protocol)` (overlapped). Unix domain sockets under Windows don't have this limitation.