### PR TITLE
Lwt_stream.of_lwt_seq: 'a Lwt_seq.t -> 'a Lwt_stream.t

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,7 +25,9 @@
 
   * Lwt_stream.return, Lwt_stream.return_lwt: singleton stream constructors (#864, Boning Dong).
 
-  * Add ?to_dir param from Unix.symlink to Lwt_unix.symlink wrapper (#884, Antonin Décimo)
+  * Add ?to_dir param from Unix.symlink to Lwt_unix.symlink wrapper (#884, Antonin Décimo).
+
+  * Lwt_stream.of_lwt_seq to convert an Lwt-sequence into an Lwt-stream (#873)
 
 ====== Misc ======
 

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -213,6 +213,16 @@ let of_seq s =
   in
   from_direct get
 
+let of_lwt_seq s =
+  let s = ref s in
+  let get () =
+    !s () >|= function
+    | Lwt_seq.Nil -> None
+    | Lwt_seq.Cons (elt, s') -> s := s'; Some elt
+  in
+  from get
+
+
 let create () =
   let source, push, _ = create_with_reference () in
   (source, push)

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -137,6 +137,12 @@ val of_seq : 'a Seq.t -> 'a t
 
     @since 4.2.0 *)
 
+val of_lwt_seq : 'a Lwt_seq.t -> 'a t
+(** [of_lwt_seq s] creates a stream returning all elements of [s]. The elements
+    are evaluated from [s] and pushed onto the stream as the stream is consumed.
+
+    @since 5.5.0 *)
+
 val of_list : 'a list -> 'a t
 (** [of_list l] creates a stream returning all elements of [l]. The elements are
     pushed into the stream immediately, resulting in a closed stream (in the

--- a/test/core/test_lwt_stream.ml
+++ b/test/core/test_lwt_stream.ml
@@ -82,6 +82,23 @@ let suite = suite "lwt_stream" [
                && [x_before; x_middle; x_after] = [false; false; true]
                && [x1; x2] = [Some 1; None]));
 
+  test "of_lwt_seq"
+    (fun () ->
+       let x = ref false in
+       let nil = fun () -> Lwt.pause () >|= fun () -> x := not !x; Lwt_seq.Nil in
+       let seq = fun () -> Lwt.pause () >|= fun () -> Lwt_seq.Cons (1, nil) in
+       let stream = Lwt_stream.of_lwt_seq seq in
+       let x_before = !x in
+       let closed_before = Lwt_stream.is_closed stream in
+       Lwt_stream.get stream >>= fun x1 ->
+       let x_middle = !x in
+       Lwt_stream.get stream >>= fun x2 ->
+       let x_after = !x in
+       let closed_after = Lwt_stream.is_closed stream in
+       return ([closed_before; closed_after] = [false; true]
+               && [x_before; x_middle; x_after] = [false; false; true]
+               && [x1; x2] = [Some 1; None]));
+
   test "of_list"
     (fun () ->
        let stream = Lwt_stream.of_list [1; 2; 3] in


### PR DESCRIPTION
Goes along with `Lwt_stream.of_seq` but for `Lwt_seq`. Has the same lazy semantic and the same tests.