### PR TITLE
Lwt.pick and Lwt.choose pick preferentially failed promises

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@
 
   * Fix win32_spawn leaking dev_null fd in the parent process. (#906, Antonin Décimo)
   * Prefer SetHandleInformation to DuplicateHandle in set_close_on_exec for sockets. DuplicateHandle mustn't be used on sockets. (#907, Antonin Décimo)
+  * Lwt.pick and Lwt.choose select preferentially failed promises as per
+  documentation (#856, #874, Raman Varabets)
 
 ===== 5.5.0 =====
 

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2645,7 +2645,7 @@ struct
   let count_resolved_promises_in (ps : 'a t list) =
     let rec count_and_gather_rejected total rejected ps =
        match ps with
-       | [] -> Error (total, rejected)
+       | [] -> Result.Error (total, rejected)
        | p :: ps ->
             let Internal q = to_internal_promise p in
             match (underlying q).state with
@@ -2655,7 +2655,7 @@ struct
     in
     let rec count_fulfilled total ps =
        match ps with
-       | [] -> Ok total
+       | [] -> Result.Ok total
        | p :: ps ->
             let Internal q = to_internal_promise p in
             match (underlying q).state with
@@ -2717,7 +2717,7 @@ struct
       invalid_arg
         "Lwt.choose [] would return a promise that is pending forever";
     match count_resolved_promises_in ps with
-    | Ok 0 ->
+    | Result.Ok 0 ->
       let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
 
       let callback result =
@@ -2731,13 +2731,13 @@ struct
 
       to_public_promise p
 
-    | Ok 1 ->
+    | Result.Ok 1 ->
       nth_resolved ps 0
 
-    | Ok n ->
+    | Result.Ok n ->
       nth_resolved ps (Random.State.int (Lazy.force prng) n)
 
-    | Error (n, ps) ->
+    | Result.Error (n, ps) ->
       nth_resolved ps (Random.State.int (Lazy.force prng) n)
 
   let pick ps =

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -2642,15 +2642,28 @@ struct
      [choose]/[pick] implementation, which may actually be optimal anyway with
      Flambda. *)
 
-  let count_resolved_promises_in (ps : _ t list) =
-    let accumulate total p =
-      let Internal p = to_internal_promise p in
-      match (underlying p).state with
-      | Fulfilled _ -> total + 1
-      | Rejected _ -> total + 1
-      | Pending _ -> total
+  let count_resolved_promises_in (ps : 'a t list) =
+    let rec count_and_gather_rejected total rejected ps =
+       match ps with
+       | [] -> Error (total, rejected)
+       | p :: ps ->
+            let Internal q = to_internal_promise p in
+            match (underlying q).state with
+            | Fulfilled _ -> count_and_gather_rejected total rejected ps
+            | Rejected _ -> count_and_gather_rejected (total + 1) (p :: rejected) ps
+            | Pending _ -> count_and_gather_rejected total rejected ps
     in
-    List.fold_left accumulate 0 ps
+    let rec count_fulfilled total ps =
+       match ps with
+       | [] -> Ok total
+       | p :: ps ->
+            let Internal q = to_internal_promise p in
+            match (underlying q).state with
+            | Fulfilled _ -> count_fulfilled (total + 1) ps
+            | Rejected _ -> count_and_gather_rejected 1 [p] ps
+            | Pending _ -> count_fulfilled total ps
+    in
+    count_fulfilled 0 ps
 
   (* Evaluates to the [n]th promise in [ps], among only those promises in [ps]
      that are resolved. The caller is expected to ensure that there are at
@@ -2704,7 +2717,7 @@ struct
       invalid_arg
         "Lwt.choose [] would return a promise that is pending forever";
     match count_resolved_promises_in ps with
-    | 0 ->
+    | Ok 0 ->
       let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
 
       let callback result =
@@ -2718,17 +2731,20 @@ struct
 
       to_public_promise p
 
-    | 1 ->
+    | Ok 1 ->
       nth_resolved ps 0
 
-    | n ->
+    | Ok n ->
+      nth_resolved ps (Random.State.int (Lazy.force prng) n)
+
+    | Error (n, ps) ->
       nth_resolved ps (Random.State.int (Lazy.force prng) n)
 
   let pick ps =
     if ps = [] then
       invalid_arg "Lwt.pick [] would return a promise that is pending forever";
     match count_resolved_promises_in ps with
-    | 0 ->
+    | Ok 0 ->
       let p = new_pending ~how_to_cancel:(propagate_cancel_to_several ps) in
 
       let callback result =
@@ -2743,12 +2759,16 @@ struct
 
       to_public_promise p
 
-    | 1 ->
+    | Ok 1 ->
       nth_resolved_and_cancel_pending ps 0
 
-    | n ->
+    | Ok n ->
       nth_resolved_and_cancel_pending ps
         (Random.State.int (Lazy.force prng) n)
+
+    | Error (n, qs) ->
+      List.iter cancel ps;
+      nth_resolved qs (Random.State.int (Lazy.force prng) n)
 
 
 


### PR DESCRIPTION
Fix #856 (check for details)

Note that the pick/choose tests were checking for the actual behaviour rather than the documented behaviour. This MR also adapts the tests.