### PR TITLE
Use CAMLnoreturn_{start,end} instead of Noreturn

### DIFF
--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -44,7 +44,9 @@ char *lwt_unix_strdup(char *string);
     (type *)lwt_unix_malloc(sizeof(type) + size)
 
 /* Raise [Lwt_unix.Not_available]. */
-void lwt_unix_not_available(char const *feature) Noreturn;
+CAMLnoreturn_start
+void lwt_unix_not_available(char const *feature)
+CAMLnoreturn_end;
 
 #define LWT_NOT_AVAILABLE_BYTE(prim)             \
     CAMLprim value lwt_##prim(value *a1, int a2) \


### PR DESCRIPTION
This fixes compilation under MSVC, see

https://github.com/ocaml/ocaml/blob/4e9eb755e60d0f0f4e458eb3f7af26bce5d8e2ba/runtime/caml/misc.h#L52-L61