### PR TITLE
Add Lwt_bytes.{unsafe_,}blit_from_string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
 
 ====== Additions ======
 
+  * Lwt_bytes.blit_from_string: string complement of Lwt_bytes.blit (#882, Hugo Heuzard).
+
   * Lwt_seq: a Seq-like data-structure with Lwt delayed nodes (#836, #842, Zach Shipko).
 
   * Lwt_unix.auto_pause: the replacement of Lwt_unix.auto_yield that uses Lwt.pause instead of Lwt_unix.yield (#855, #858, Favonia).

--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -41,7 +41,7 @@ let blit_from_string src_buf src_ofs dst_buf dst_ofs len =
   if (len < 0
       || src_ofs < 0 || src_ofs > String.length src_buf - len
       || dst_ofs < 0 || dst_ofs > length dst_buf - len) then
-    invalid_arg "Lwt_bytes.blit_from_bytes"
+    invalid_arg "Lwt_bytes.blit_from_string"
   else
     unsafe_blit_from_string src_buf src_ofs dst_buf dst_ofs len
 

--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -32,9 +32,18 @@ let fill bytes ofs len ch =
 
 [@@@ocaml.warning "-3"]
 external unsafe_blit_from_bytes : Bytes.t -> int -> t -> int -> int -> unit = "lwt_unix_blit_from_bytes" "noalloc"
+external unsafe_blit_from_string : string -> int -> t -> int -> int -> unit = "lwt_unix_blit_from_string" "noalloc"
 external unsafe_blit_to_bytes : t -> int -> Bytes.t -> int -> int -> unit = "lwt_unix_blit_to_bytes" "noalloc"
 external unsafe_blit : t -> int -> t -> int -> int -> unit = "lwt_unix_blit" "noalloc"
 [@@@ocaml.warning "+3"]
+
+let blit_from_string src_buf src_ofs dst_buf dst_ofs len =
+  if (len < 0
+      || src_ofs < 0 || src_ofs > String.length src_buf - len
+      || dst_ofs < 0 || dst_ofs > length dst_buf - len) then
+    invalid_arg "Lwt_bytes.blit_from_bytes"
+  else
+    unsafe_blit_from_string src_buf src_ofs dst_buf dst_ofs len
 
 let blit_from_bytes src_buf src_ofs dst_buf dst_ofs len =
   if (len < 0

--- a/src/unix/lwt_bytes.mli
+++ b/src/unix/lwt_bytes.mli
@@ -54,12 +54,16 @@ val blit : t -> int -> t -> int -> int -> unit
   (** [blit buf1 ofs1 buf2 ofs2 len] copies [len] bytes from [buf1]
       starting at offset [ofs1] to [buf2] starting at offset [ofs2]. *)
 
+val blit_from_string : string -> int -> t -> int -> int -> unit
+  (** Same as {!blit} but the first buffer is a [String.t] instead of a byte
+      array. *)
+
 val blit_from_bytes : bytes -> int -> t -> int -> int -> unit
-  (** Same as {!blit} but the first buffer is a string instead of a byte
+  (** Same as {!blit} but the first buffer is a [Bytes.t] instead of a byte
       array. *)
 
 val blit_to_bytes : t -> int -> bytes -> int -> int -> unit
-  (** Same as {!blit} but the second buffer is a string instead of a byte
+  (** Same as {!blit} but the second buffer is a [Bytes.t] instead of a byte
       array. *)
 
 val unsafe_blit : t -> int -> t -> int -> int -> unit
@@ -67,6 +71,9 @@ val unsafe_blit : t -> int -> t -> int -> int -> unit
 
 val unsafe_blit_from_bytes : bytes -> int -> t -> int -> int -> unit
   (** Same as {!Lwt_bytes.blit_from_bytes} but without bounds checking. *)
+
+val unsafe_blit_from_string : string -> int -> t -> int -> int -> unit
+(** Same as {!Lwt_bytes.blit_from_string} but without bounds checking. *)
 
 val unsafe_blit_to_bytes : t -> int -> bytes -> int -> int -> unit
   (** Same as {!Lwt_bytes.blit_to_bytes} but without bounds checking. *)

--- a/src/unix/lwt_bytes.mli
+++ b/src/unix/lwt_bytes.mli
@@ -104,7 +104,7 @@ external unsafe_fill : t -> int -> int -> char -> unit = "lwt_unix_fill_bytes" "
 (** {2 IOs} *)
 
 (** The following functions behave similarly to the ones in {!Lwt_unix}, except
-    they use byte arrays instead of strings, and they never perform extra copies
+    they use byte arrays instead of [Bytes.t], and they never perform extra copies
     of the data. *)
 
 val read : Lwt_unix.file_descr -> t -> int -> int -> int Lwt.t

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -105,6 +105,13 @@ void lwt_unix_not_available(char const *feature) {
    | Operation on bigarrays                                          |
    +-----------------------------------------------------------------+ */
 
+/* Needed while Lwt supports OCaml < 4.06. */
+#ifdef Bytes_val
+#define Lwt_bytes_val(v) Bytes_val(v)
+#else
+#define Lwt_bytes_val(v) String_val(v)
+#endif
+
 CAMLprim value lwt_unix_blit(value val_buf1, value val_ofs1, value val_buf2,
                              value val_ofs2, value val_len) {
   memmove((char *)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
@@ -117,16 +124,18 @@ CAMLprim value lwt_unix_blit_from_bytes(value val_buf1, value val_ofs1,
                                         value val_buf2, value val_ofs2,
                                         value val_len) {
   memcpy((char *)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+         Lwt_bytes_val(val_buf1) + Long_val(val_ofs1), Long_val(val_len));
+  return Val_unit;
+}
+
+CAMLprim value lwt_unix_blit_from_string(value val_buf1, value val_ofs1,
+                                        value val_buf2, value val_ofs2,
+                                        value val_len) {
+  memcpy((char *)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
          String_val(val_buf1) + Long_val(val_ofs1), Long_val(val_len));
   return Val_unit;
 }
 
-/* Needed while Lwt supports OCaml < 4.06. */
-#ifdef Bytes_val
-#define Lwt_bytes_val(v) Bytes_val(v)
-#else
-#define Lwt_bytes_val(v) String_val(v)
-#endif
 
 CAMLprim value lwt_unix_blit_to_bytes(value val_buf1, value val_ofs1,
                                       value val_buf2, value val_ofs2,

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -125,42 +125,30 @@ let suite = suite "lwt_bytes" [
 
     test "get out of bounds : lower limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
-      try
-        let _ = Lwt_bytes.get buff (-1) in
-        Lwt.return false
-      with
-      | Invalid_argument _ -> Lwt.return true
+      match Lwt_bytes.get buff (-1) with
+      | exception Invalid_argument _ -> Lwt.return true
       | _ -> Lwt.return false
     end;
 
     test "get out of bounds : upper limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
-      try
-        let _ = Lwt_bytes.get buff 3 in
-        Lwt.return false
-      with
-      | Invalid_argument _ -> Lwt.return true
+      match Lwt_bytes.get buff 3 with
+      | exception Invalid_argument _ -> Lwt.return true
       | _ -> Lwt.return false
     end;
 
     test "set out of bounds : lower limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
-      try
-        let () = Lwt_bytes.set buff (-1) 'a' in
-        Lwt.return true
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.set buff (-1) 'a' with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "set out of bounds : upper limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
-      try
-        let () = Lwt_bytes.set buff 3 'a' in
-        Lwt.return true
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.set buff 3 'a' with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "unsafe_get/unsafe_set" begin fun () ->
@@ -222,12 +210,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let() = Lwt_bytes.blit buf1 (-1) buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.blit buf1 (-1) buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "blit source out of bounds: upper limit" begin fun () ->
@@ -235,12 +220,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let() = Lwt_bytes.blit buf1 1 buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.blit buf1 1 buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "blit destination out of bounds: lower limit" begin fun () ->
@@ -248,12 +230,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let() = Lwt_bytes.blit buf1 0 buf2 (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.blit buf1 0 buf2 (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "blit destination out of bounds: upper limit" begin fun () ->
@@ -261,12 +240,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let() = Lwt_bytes.blit buf1 0 buf2 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.blit buf1 0 buf2 4 3 with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "blit length out of bounds: lower limit" begin fun () ->
@@ -274,12 +250,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let() = Lwt_bytes.blit buf1 0 buf2 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      match Lwt_bytes.blit buf1 0 buf2 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return true
+      | () -> Lwt.return false
     end;
 
     test "blit from bytes" begin fun () ->
@@ -295,60 +268,45 @@ let suite = suite "lwt_bytes" [
       let bytes1 = Bytes.of_string "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_bytes bytes1 (-1) buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_bytes bytes1 (-1) buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from bytes source out of bounds: upper limit" begin fun () ->
       let bytes1 = Bytes.of_string "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_bytes bytes1 1 buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_bytes bytes1 1 buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from bytes destination out of bounds: lower limit" begin fun () ->
       let bytes1 = Bytes.of_string "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_bytes bytes1 0 buf2 (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_bytes bytes1 0 buf2 (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from bytes destination out of bounds: upper limit" begin fun () ->
       let bytes1 = Bytes.of_string "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_bytes bytes1 0 buf2 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_bytes bytes1 0 buf2 4 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from bytes length out of bounds: lower limit" begin fun () ->
       let bytes1 = Bytes.of_string "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_bytes bytes1 0 buf2 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_bytes bytes1 0 buf2 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
       end;
 
     test "blit from string" begin fun () ->
@@ -364,62 +322,55 @@ let suite = suite "lwt_bytes" [
       let string1 = "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_string string1 (-1) buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_string string1 (-1) buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from string source out of bounds: upper limit" begin fun () ->
       let string1 = "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_string string1 1 buf2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_string string1 1 buf2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from string destination out of bounds: lower limit" begin fun () ->
       let string1 = "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_string string1 0 buf2 (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_string string1 0 buf2 (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from string destination out of bounds: upper limit" begin fun () ->
       let string1 = "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_string string1 0 buf2 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_string string1 0 buf2 4 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from string length out of bounds: lower limit" begin fun () ->
       let string1 = "abc" in
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_from_string string1 0 buf2 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_from_string string1 0 buf2 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
+    test "blit from string length out of bounds: upper limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      match Lwt_bytes.blit_from_string string1 0 buf2 3 10 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
+    end;
 
     test "blit to bytes" begin fun () ->
       let str1 = "abc" in
@@ -436,12 +387,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let bytes2 = Bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_to_bytes buf1 (-1) bytes2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_to_bytes buf1 (-1) bytes2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit to bytes source out of bounds: upper limit" begin fun () ->
@@ -449,12 +397,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let bytes2 = Bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_to_bytes buf1 1 bytes2 3 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_to_bytes buf1 1 bytes2 3 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit to bytes destination out of bounds: lower limit" begin fun () ->
@@ -462,12 +407,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let bytes2 = Bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_to_bytes buf1 0 bytes2 (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_to_bytes buf1 0 bytes2 (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit to bytes destination out of bounds: upper limit" begin fun () ->
@@ -475,12 +417,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let bytes2 = Bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_to_bytes buf1 0 bytes2 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_to_bytes buf1 0 bytes2 4 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit to bytes length out of bounds: lower limit" begin fun () ->
@@ -488,12 +427,9 @@ let suite = suite "lwt_bytes" [
       let buf1 = Lwt_bytes.of_string str1 in
       let str2 = "abcdef" in
       let bytes2 = Bytes.of_string str2 in
-      try
-        let () = Lwt_bytes.blit_to_bytes buf1 0 bytes2 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.blit_to_bytes buf1 0 bytes2 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "unsafe blit" begin fun () ->
@@ -547,33 +483,24 @@ let suite = suite "lwt_bytes" [
     test "proxy offset out of bounds: lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.proxy buf (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.proxy buf (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
     test "proxy offset out of bounds: upper limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.proxy buf 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.proxy buf 4 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
     test "proxy length out of bounds: lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.proxy buf 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.proxy buf 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
@@ -588,33 +515,24 @@ let suite = suite "lwt_bytes" [
     test "extract offset out of bounds: lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.extract buf (-1) 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.extract buf (-1) 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
     test "extract offset out of bounds: upper limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.extract buf 4 3 in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.extract buf 4 3 with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
     test "extract length out of bounds: lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let _ = Lwt_bytes.extract buf 3 (-1) in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
+      match Lwt_bytes.extract buf 3 (-1) with
+      | exception Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
     end;
 
@@ -637,34 +555,25 @@ let suite = suite "lwt_bytes" [
     test "fill offset out of bounds: lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let () = Lwt_bytes.fill buf (-1) 3 'a' in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.fill buf (-1) 3 'a' with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "fill offset out of bounds: upper limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let () = Lwt_bytes.fill buf 4 3 'a' in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.fill buf 4 3 'a' with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "fill length out of bounds lower limit" begin fun () ->
       let str = "abcdef" in
       let buf = Lwt_bytes.of_string str in
-      try
-        let () = Lwt_bytes.fill buf 3 (-1) 'a' in
-        Lwt.return_false
-      with
-      | Invalid_argument _ -> Lwt.return_true
-      | _ -> Lwt.return_false
+      match Lwt_bytes.fill buf 3 (-1) 'a' with
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "unsafe fill" begin fun () ->

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -349,7 +349,77 @@ let suite = suite "lwt_bytes" [
       with
       | Invalid_argument _ -> Lwt.return_true
       | _ -> Lwt.return_false
+      end;
+
+    test "blit from string" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      let () = Lwt_bytes.blit_from_string string1 0 buf2 3 3 in
+      let check = "abcabc" = Lwt_bytes.to_string buf2 in
+      Lwt.return check
     end;
+
+    test "blit from string source out of bounds: lower limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      try
+        let () = Lwt_bytes.blit_from_string string1 (-1) buf2 3 3 in
+        Lwt.return_false
+      with
+      | Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
+    end;
+
+    test "blit from string source out of bounds: upper limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      try
+        let () = Lwt_bytes.blit_from_string string1 1 buf2 3 3 in
+        Lwt.return_false
+      with
+      | Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
+    end;
+
+    test "blit from string destination out of bounds: lower limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      try
+        let () = Lwt_bytes.blit_from_string string1 0 buf2 (-1) 3 in
+        Lwt.return_false
+      with
+      | Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
+    end;
+
+    test "blit from string destination out of bounds: upper limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      try
+        let () = Lwt_bytes.blit_from_string string1 0 buf2 4 3 in
+        Lwt.return_false
+      with
+      | Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
+    end;
+
+    test "blit from string length out of bounds: lower limit" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      try
+        let () = Lwt_bytes.blit_from_string string1 0 buf2 3 (-1) in
+        Lwt.return_false
+      with
+      | Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
+    end;
+
 
     test "blit to bytes" begin fun () ->
       let str1 = "abc" in
@@ -441,6 +511,15 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       let () = Lwt_bytes.unsafe_blit_from_bytes bytes1 0 buf2 3 3 in
+      let check = "abcabc" = Lwt_bytes.to_string buf2 in
+      Lwt.return check
+    end;
+
+    test "unsafe blit from string" begin fun () ->
+      let string1 = "abc" in
+      let str2 = "abcdef" in
+      let buf2 = Lwt_bytes.of_string str2 in
+      let () = Lwt_bytes.unsafe_blit_from_string string1 0 buf2 3 3 in
       let check = "abcabc" = Lwt_bytes.to_string buf2 in
       Lwt.return check
     end;


### PR DESCRIPTION
Lwt_bytes was missing bliting from string.
- add blit_from_string and unsafe_blit_from_string
- update doc to make distinction between `string` and `bytes`
- add tests for the new functions
 