### PR TITLE
Fix Lwt_unix.lstat calling Unix.stat on Win32

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,10 @@
 
   * Support IPv6 socketpair on Windows (#870, #876, Antonin Décimo, David Allsopp).
 
+  * Lwt_unix.lstat was incorrectly calling Unix.stat on Win32. Fixes
+    the behavior of Lwt_io.with_temp_dir following symlinks to
+    directories on Win32. (#883, Antonin Décimo)
+
 ====== Additions ======
 
   * Lwt_seq: a Seq-like data-structure with Lwt delayed nodes (#836, #842, Zach Shipko).

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -1017,7 +1017,7 @@ external lstat_job : string -> Unix.stats job = "lwt_unix_lstat_job"
 
 let lstat name =
   if Sys.win32 then
-    Lwt.return (Unix.stat name)
+    Lwt.return (Unix.lstat name)
   else
     run_job (lstat_job name)
 


### PR DESCRIPTION
A nice little bug here ;)

It can become rather nasty with this code (how I found it):

```ocaml
  Lwt_main.run begin
      with_temp_dir @@ fun dir ->
      let link = Filename.(concat dir "link") in
      Unix.symlink ~to_dir:true "C:/Windows" link;
      do_stuff_here ()
    end
  (* If [link] is a directory, Lwt will enter it and try to
     delete its contents *)
```

A little grep in Lwt tells that only `Lwt_io.with_temp_dir` uses `Lwt_unix.lstat`.