### PR TITLE
Support deleting symlinks in Lwt_io.with_temp_dir on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
     the behavior of Lwt_io.with_temp_dir following symlinks to
     directories on Win32. (#883, Antonin Décimo)
 
+  * Support deleting symlinks on Windows during cleanup of Lwt_io.with_temp_dir (#886, Antonin Décimo)
+
   * Lwt_react.S.l[2-6]_s used polymorphic equality which could cause errors when
     handling functional values. (#893, Jérôme Vouillon)
 


### PR DESCRIPTION
If a Windows symlink points to a directory, then rmdir is the correct
function to call. If it points to a file, then unlink is the correct
function. When pointing to a file, the symlink can also have the
read-only attribute, which makes it subject of the little chmod dance.

This depends on the fix in https://github.com/ocsigen/lwt/pull/883.