### PR TITLE
Restore ocaml-ci

### DIFF
--- a/lwt_ppx_let.opam
+++ b/lwt_ppx_let.opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+
+synopsis: "Dummy package context for ppx_let tests"
+
+version: "5.4.2"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ppx_let" {with-test}
+]
+
+description: "Internal package used to partition ppx_let tests."

--- a/test/ppx_let/dune
+++ b/test/ppx_let/dune
@@ -2,3 +2,8 @@
  (name test)
  (preprocess (pps ppx_let))
  (libraries lwt lwt.unix))
+
+(alias
+ (name runtest)
+ (package lwt_ppx_let)
+ (action (run %{exe:test.exe})))


### PR DESCRIPTION
ocaml-ci began to fail when https://github.com/ocurrent/ocaml-ci/pull/338 was merged, since `dune build @check` requires `ppx_let`.

For testing purposes, `ppx_let` only adds a test dependency on base, which (to me at least) doesn't seem to impose as heavy a dependency burden as suggested in https://github.com/ocsigen/lwt/issues/677.

This approach is far from the only possibility, but I add a dummy opam file whose purpose is to create a package context to house the dependency. This gets picked up by ocaml-ci and also by `opam install . --deps-only`