### PR TITLE
Add multicore OCaml to CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,6 +38,11 @@ jobs:
             libev: false
             ppx: true
             local-packages: "*.opam"
+          - os: ubuntu-latest
+            ocaml-compiler: ocaml-variants.4.12.0+domains
+            libev: false
+            ppx: true
+            local-packages: "*.opam"
           - os: macos-latest
             ocaml-compiler: 4.13.x
             libev: true


### PR DESCRIPTION
The effect variant conflicts with ppx and still requires a complex package specification expression, so it's not added at this point.