### PR TITLE
Treat ERROR_BROKEN_PIPE on read as zero-read instead of error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,9 @@
   * Lwt_react.S.l[2-6]_s used polymorphic equality which could cause errors when
     handling functional values. (#893, Jérôme Vouillon)
 
+  * On Windows, treat ERROR_BROKEN_PIPE on read as zero-read instead
+    of error. See OCaml PR #4790. (#898, Antonin Décimo)
+
 ====== Additions ======
 
   * Lwt_bytes.blit_from_string: string complement of Lwt_bytes.blit (#882, Hugo Heuzard).

--- a/src/unix/windows_c/windows_bytes_read.c
+++ b/src/unix/windows_c/windows_bytes_read.c
@@ -37,7 +37,12 @@ CAMLprim value lwt_unix_bytes_read(value fd, value buf, value vofs, value vlen)
                           numbytes, &numwritten, NULL))
                 err = GetLastError();
         }
-        if (err) {
+        if (err == ERROR_BROKEN_PIPE) {
+            /* The write handle for an anonymous pipe has been closed. We match
+               the Unix behavior, and treat this as a zero-read instead of a
+               Unix_error. See OCaml PR #4790. */
+            numwritten = 0;
+        } else if (err) {
             win32_maperr(err);
             uerror("write", Nothing);
         }

--- a/src/unix/windows_c/windows_pread.c
+++ b/src/unix/windows_c/windows_pread.c
@@ -38,7 +38,12 @@ CAMLprim value lwt_unix_pread(value fd, value buf, value vfile_offset,
                           &overlapped))
                 err = GetLastError();
         }
-        if (err) {
+        if (err == ERROR_BROKEN_PIPE) {
+            /* The write handle for an anonymous pipe has been closed. We match
+               the Unix behavior, and treat this as a zero-read instead of a
+               Unix_error. See OCaml PR #4790. */
+            numwritten = 0;
+        } else if (err) {
             win32_maperr(err);
             uerror("pread", Nothing);
         }

--- a/src/unix/windows_c/windows_read.c
+++ b/src/unix/windows_c/windows_read.c
@@ -34,7 +34,12 @@ CAMLprim value lwt_unix_read(value fd, value buf, value vofs, value vlen)
             if (!ReadFile(h, &Byte(buf, ofs), numbytes, &numwritten, NULL))
                 err = GetLastError();
         }
-        if (err) {
+        if (err == ERROR_BROKEN_PIPE) {
+            /* The write handle for an anonymous pipe has been closed. We match
+               the Unix behavior, and treat this as a zero-read instead of a
+               Unix_error. See OCaml PR #4790. */
+            numwritten = 0;
+        } else if (err) {
             win32_maperr(err);
             uerror("read", Nothing);
         }

--- a/src/unix/windows_c/windows_read_job.c
+++ b/src/unix/windows_c/windows_read_job.c
@@ -51,7 +51,12 @@ static value result_read(struct job_read *job)
 {
     value result;
     DWORD error = job->error_code;
-    if (error) {
+    if (error == ERROR_BROKEN_PIPE) {
+        /* The write handle for an anonymous pipe has been closed. We match the
+           Unix behavior, and treat this as a zero-read instead of a Unix_error.
+           See OCaml PR #4790. */
+        job->result = 0;
+    } else if (error) {
         caml_remove_generational_global_root(&job->string);
         lwt_unix_free_job(&job->job);
         win32_maperr(error);


### PR DESCRIPTION
This matches the behaviour of win32unix since 3.11.1, see https://github.com/ocaml/ocaml/issues/4790.