### PR TITLE
Core: remove some `mutable` to fix warning

### DIFF
--- a/src/core/lwt_mutex.ml
+++ b/src/core/lwt_mutex.ml
@@ -14,7 +14,7 @@ module Lwt_sequence = Lwt_sequence
 
 open Lwt.Infix
 
-type t = { mutable locked : bool; mutable waiters : unit Lwt.u Lwt_sequence.t  }
+type t = { mutable locked : bool; waiters : unit Lwt.u Lwt_sequence.t  }
 
 let create () = { locked = false; waiters = Lwt_sequence.create () }
 

--- a/src/core/lwt_sequence.ml
+++ b/src/core/lwt_sequence.ml
@@ -11,8 +11,8 @@ type 'a t = {
 }
 
 type 'a node = {
-  mutable node_prev : 'a t;
-  mutable node_next : 'a t;
+  node_prev : 'a t;
+  node_next : 'a t;
   mutable node_data : 'a;
   mutable node_active : bool;
 }

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -45,7 +45,7 @@ type push = {
   (* Thread signaled when a new element is added to the stream. *)
   mutable push_waiting : bool;
   (* Is a thread waiting on [push_signal] ? *)
-  mutable push_external : Obj.t;
+  mutable push_external : Obj.t [@ocaml.warning "-69"];
   (* Reference to an external source. *)
 }
 
@@ -66,7 +66,7 @@ type 'a push_bounded = {
   mutable pushb_push_waiter : unit Lwt.t;
   mutable pushb_push_wakener : unit Lwt.u;
   (* Thread blocked on push. *)
-  mutable pushb_external : Obj.t;
+  mutable pushb_external : Obj.t [@ocaml.warning "-69"];
   (* Reference to an external source. *)
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/raphael-proust/lwt/pull/new/fix-some-warnings there are new warnings in OCaml 4.13 and we need to modify things a little bit to avoid them.