### PR TITLE
Add `?cloexec:bool` argument to wrapped `Unix` functions in `Lwt_unix`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,8 @@
 
   * Support IPv6 (always) and PF_UNIX (with OCaml >= 4.14) socketpair on Windows (#870, #876, Antonin Décimo, David Allsopp).
 
+  * In the Lwt_unix module, add `?cloexec:bool` optional arguments to functions that create file descriptors (`dup`, `dup2`, `pipe`, `pipe_in`, `pipe_out`, `socket`, `socketpair`, `accept`, `accept_n`). The `?cloexec` argument is simply forwarded to the wrapped Unix function (with OCaml >= 4.05, see PR ocaml/ocaml#650), or emulated as best-effort with `Unix.set_close_on_exec` on older OCaml versions (#327, #847, #872, #901, Antonin Décimo).
+
 ====== Misc ======
 
   * Code quality improvement: remove an uneeded Obj.magic (#844, Benoit Montagu).

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -681,10 +681,12 @@ val access : string -> access_permission list -> unit Lwt.t
 
 (** {2 Operations on file descriptors} *)
 
-val dup : file_descr -> file_descr
+val dup : ?cloexec:bool ->
+          file_descr -> file_descr
   (** Wrapper for [Unix.dup] *)
 
-val dup2 : file_descr -> file_descr -> unit
+val dup2 : ?cloexec:bool ->
+           file_descr -> file_descr -> unit
   (** Wrapper for [Unix.dup2] *)
 
 val set_close_on_exec : file_descr -> unit
@@ -751,17 +753,20 @@ val files_of_directory : string -> string Lwt_stream.t
 
 (** {2 Pipes and redirections} *)
 
-val pipe : unit -> file_descr * file_descr
+val pipe : ?cloexec:bool ->
+           unit -> file_descr * file_descr
   (** [pipe ()] creates pipe using [Unix.pipe] and returns two lwt {b
       file descriptor}s created from unix {b file_descriptor} *)
 
-val pipe_in : unit -> file_descr * Unix.file_descr
+val pipe_in : ?cloexec:bool ->
+              unit -> file_descr * Unix.file_descr
   (** [pipe_in ()] is the same as {!pipe} but maps only the unix {b
       file descriptor} for reading into a lwt one. The second is not
       put into non-blocking mode. You usually want to use this before
       forking to receive data from the child process. *)
 
-val pipe_out : unit -> Unix.file_descr * file_descr
+val pipe_out : ?cloexec:bool ->
+               unit -> Unix.file_descr * file_descr
   (** [pipe_out ()] is the inverse of {!pipe_in}. You usually want to
       use this before forking to send data to the child process *)
 
@@ -874,11 +879,13 @@ type socket_type =
 
 type sockaddr = Unix.sockaddr = ADDR_UNIX of string | ADDR_INET of inet_addr * int
 
-val socket : socket_domain -> socket_type -> int -> file_descr
+val socket : ?cloexec:bool ->
+             socket_domain -> socket_type -> int -> file_descr
   (** [socket domain type proto] is the same as [Unix.socket] but maps
       the result into a lwt {b file descriptor} *)
 
-val socketpair : socket_domain -> socket_type -> int -> file_descr * file_descr
+val socketpair : ?cloexec:bool ->
+                 socket_domain -> socket_type -> int -> file_descr * file_descr
   (** Wrapper for [Unix.socketpair] *)
 
 val bind : file_descr -> sockaddr -> unit Lwt.t
@@ -892,10 +899,12 @@ val bind : file_descr -> sockaddr -> unit Lwt.t
 val listen : file_descr -> int -> unit
   (** Wrapper for [Unix.listen] *)
 
-val accept : file_descr -> (file_descr * sockaddr) Lwt.t
+val accept : ?cloexec:bool ->
+             file_descr -> (file_descr * sockaddr) Lwt.t
   (** Wrapper for [Unix.accept] *)
 
-val accept_n : file_descr -> int -> ((file_descr * sockaddr) list * exn option) Lwt.t
+val accept_n : ?cloexec:bool ->
+               file_descr -> int -> ((file_descr * sockaddr) list * exn option) Lwt.t
   (** [accept_n fd count] accepts up to [count] connections at one time.
 
       - if no connection is available right now, it returns a sleeping

--- a/src/unix/unix_c/unix_accept4.c
+++ b/src/unix/unix_c/unix_accept4.c
@@ -20,8 +20,8 @@ CAMLprim value lwt_unix_accept4(value vcloexec, value vnonblock, value vsock)
 
     union sock_addr_union addr;
     socklen_param_type addr_len;
-    int cloexec = Int_val(vcloexec) ? SOCK_CLOEXEC : 0;
-    int nonblock = Int_val(vnonblock) ? SOCK_NONBLOCK : 0;
+    int cloexec = Is_block(vcloexec) && Bool_val(Field(vcloexec, 0)) ? SOCK_CLOEXEC : 0;
+    int nonblock = Bool_val(vnonblock) ? SOCK_NONBLOCK : 0;
     addr_len = sizeof(addr);
 
     int fd =


### PR DESCRIPTION
In the Lwt_unix module, add `?cloexec:bool` optional arguments to
functions that create file descriptors (`dup`, `dup2`, `pipe`,
`pipe_in`, `pipe_out`, `socket`, `socketpair`, `accept`, `accept_n`).
The `?cloexec` argument is simply forwarded to the wrapped Unix
function (with OCaml >= 4.05, see [ocaml/ocaml#650][650]), or emulated
as best-effort with `Unix.set_close_on_exec` on older OCaml versions.

Fix #327. Fix #847. See also #872.

[650]: https://github.com/ocaml/ocaml/pull/650