### PR TITLE
 `CreateProcess` needs `CREATE_UNICODE_ENVIRONMENT`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,7 +41,7 @@
 
   * Code quality improvement: remove an uneeded Obj.magic (#844, Benoit Montagu).
 
-  * On Windows, use the Unicode API in C stubs and functions introduced in OCaml 4.06 to handle Unicode strings. Raise the minimum requirement to OCaml 4.06 (on Windows only). (#843, Antonin Décimo)
+  * On Windows, use the Unicode API in C stubs and functions introduced in OCaml 4.06 to handle Unicode strings. Raise the minimum requirement to OCaml 4.06 (on Windows only). (#843, #903, Antonin Décimo)
 
 ===== 5.4.2 =====
 

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -41,6 +41,7 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
 
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
+  DWORD flags = CREATE_UNICODE_ENVIRONMENT;
   BOOL ret;
 
 #define string_option(opt) \
@@ -62,7 +63,7 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
   si.hStdOutput = get_handle(Field(fds, 1));
   si.hStdError = get_handle(Field(fds, 2));
 
-  ret = CreateProcess(progs, cmdlines, NULL, NULL, TRUE, 0,
+  ret = CreateProcess(progs, cmdlines, NULL, NULL, TRUE, flags,
                       envs, cwds, &si, &pi);
   caml_stat_free(progs);
   caml_stat_free(cmdlines);

--- a/src/unix/windows_c/windows_system_job.c
+++ b/src/unix/windows_c/windows_system_job.c
@@ -51,6 +51,7 @@ CAMLprim value lwt_unix_system_job(value cmdline)
     CAMLparam1(cmdline);
     STARTUPINFO si;
     PROCESS_INFORMATION pi;
+    DWORD flags = CREATE_UNICODE_ENVIRONMENT;
     BOOL ret;
 
     char_os *cmdlines = caml_stat_strdup_to_os(String_val(cmdline));
@@ -59,7 +60,7 @@ CAMLprim value lwt_unix_system_job(value cmdline)
     ZeroMemory(&pi, sizeof(pi));
     si.cb = sizeof(si);
 
-    ret = CreateProcess(NULL, cmdlines, NULL, NULL, TRUE, 0,
+    ret = CreateProcess(NULL, cmdlines, NULL, NULL, TRUE, flags,
                         NULL, NULL, &si, &pi);
     caml_stat_free(cmdlines);
     if (!ret) {


### PR DESCRIPTION
> If the environment block pointed to by `lpEnvironment` contains
> Unicode characters, be sure that `dwCreationFlags` includes
> `CREATE_UNICODE_ENVIRONMENT`. If this parameter is `NULL` and the
> environment block of the parent process contains Unicode characters,
> you must also ensure that `dwCreationFlags` includes
> `CREATE_UNICODE_ENVIRONMENT`.

From [doc1][].

> If this flag is set, the environment block pointed to by
> `lpEnvironment` uses Unicode characters. Otherwise, the environment
> block uses ANSI characters.

From [doc2][].

This was forgotten from PR #843 that switched to Unicode strings on
Windows (including the environment). I noticed it when reading code
from win32unix.

[doc1]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
[doc2]: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#CREATE_UNICODE_ENVIRONMENT