### PR TITLE
Prefer `SetHandleInformation` to `DuplicateHandle` in `set_close_on_exec`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 ====== Fixes ======
 
   * Fix win32_spawn leaking dev_null fd in the parent process. (#906, Antonin Décimo)
+  * Prefer SetHandleInformation to DuplicateHandle in set_close_on_exec for sockets. DuplicateHandle mustn't be used on sockets. (#907, Antonin Décimo)
 
 ===== 5.5.0 =====
 


### PR DESCRIPTION
From [DuplicateHandle][]:

> You should not use `DuplicateHandle` to duplicate handles to the following objects:
>
> - […]
> - Sockets. No error is returned, but the duplicate handle may not be
>   recognized by Winsock at the target process. Also, using
>   `DuplicateHandle` interferes with internal reference counting on
>   the underlying object. To duplicate a socket handle, use the
>   `WSADuplicateSocket` function.

and from [Inheriting Handles][]:

> Use the `SetHandleInformation` function to control if an existing
> handle is inheritable or not.

and from [SetHandleInformation][]:

> You can specify a handle to one of the following types of objects:
> […], socket, […].

So `DuplicateHandle` shouldn't be used on sockets, and it's safe to
replace it with `SetHandleInformation`.

[DuplicateHandle]: https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle#remarks
[Inheriting Handles]: https://docs.microsoft.com/en-us/windows/win32/procthread/inheritance#inheriting-handles
[SetHandleinformation]: https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-sethandleinformation#parameters