### PR TITLE
Windows: make `create_process` duplicate non-inheritable std handles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,10 @@
   * In the Lwt_io module, add `?cloexec:bool` optional arguments to functions that create file descriptors (`pipe`). The `?cloexec` argument is simply forwarded to the wrapped Lwt_unix function. (#872, #911, Antonin Décimo)
   * Add Lwt_result.error, Lwt_result.iter, and Lwt_result.iter_error for consistency with Stdlib. (#927, Antonin Décimo)
 
+====== Misc ======
+
+  * On Windows, make Lwt_process.create_process duplicate standard handles given to the child process if they're not inheritable, to mimic the behaviour of Unix.create_process. (#909, Antonin Décimo)
+
 ====== Fixes ======
 
   * Fix win32_spawn leaking dev_null fd in the parent process. (#906, Antonin Décimo)

--- a/src/unix/lwt_process.ml
+++ b/src/unix/lwt_process.ml
@@ -36,7 +36,7 @@ let win32_get_fd fd redirection =
   | `Keep ->
     Some fd
   | `Dev_null ->
-    Some (Unix.openfile "nul" [Unix.O_RDWR] 0o666)
+    Some (Unix.openfile "nul" [Unix.O_RDWR; Unix.O_CLOEXEC] 0o666)
   | `Close ->
     None
   | `FD_copy fd' ->
@@ -56,11 +56,12 @@ let win32_quote arg =
     Filename.quote arg
 
 let win32_spawn
-    (prog, args) env ?cwd
+    ?cwd
     ?(stdin:redirection=`Keep)
     ?(stdout:redirection=`Keep)
     ?(stderr:redirection=`Keep)
-    toclose =
+    (prog, args) env
+  =
   let cmdline = String.concat " " (List.map win32_quote (Array.to_list args)) in
   let env =
     match env with
@@ -82,7 +83,6 @@ let win32_spawn
       Bytes.set res ofs '\000';
       Some (Bytes.unsafe_to_string res)
   in
-  List.iter Unix.set_close_on_exec toclose;
   let stdin_fd  = win32_get_fd Unix.stdin stdin
   and stdout_fd = win32_get_fd Unix.stdout stdout
   and stderr_fd = win32_get_fd Unix.stderr stderr in
@@ -93,15 +93,9 @@ let win32_spawn
   in
   let close fd fd' =
     match fd with
-    | `FD_move fd ->
-      Unix.close fd
-    | `Dev_null ->
-      begin match fd' with
-        | Some fd' -> Unix.close fd'
-        | None -> assert false
-      end
-    | _ ->
-      ()
+    | `FD_move _ | `Dev_null ->
+      Unix.close (match fd' with Some fd' -> fd' | _ -> assert false)
+    | _ -> ()
   in
   close stdin stdin_fd;
   close stdout stdout_fd;
@@ -129,7 +123,7 @@ let unix_redirect fd redirection = match redirection with
     ()
   | `Dev_null ->
     Unix.close fd;
-    let dev_null = Unix.openfile "/dev/null" [Unix.O_RDWR] 0o666 in
+    let dev_null = Unix.openfile "/dev/null" [Unix.O_RDWR; Unix.O_CLOEXEC] 0o666 in
     if fd <> dev_null then begin
       Unix.dup2 dev_null fd;
       Unix.close dev_null
@@ -145,18 +139,18 @@ let unix_redirect fd redirection = match redirection with
 external unix_exit : int -> 'a = "unix_exit"
 
 let unix_spawn
-    (prog, args) env ?cwd
+    ?cwd
     ?(stdin:redirection=`Keep)
     ?(stdout:redirection=`Keep)
     ?(stderr:redirection=`Keep)
-    toclose =
+    (prog, args) env
+  =
   let prog = if prog = "" && Array.length args > 0 then args.(0) else prog in
   match Lwt_unix.fork () with
   | 0 ->
     unix_redirect Unix.stdin stdin;
     unix_redirect Unix.stdout stdout;
     unix_redirect Unix.stderr stderr;
-    List.iter Unix.close toclose;
     begin
       try
         begin match cwd with
@@ -269,41 +263,38 @@ class virtual common timeout proc channels =
   end
 
 class process_none ?timeout ?env ?cwd ?stdin ?stdout ?stderr cmd =
-  let proc = spawn cmd env ?cwd ?stdin ?stdout ?stderr [] in
+  let proc = spawn cmd env ?cwd ?stdin ?stdout ?stderr in
   object
     inherit common timeout proc []
   end
 
 class process_in ?timeout ?env ?cwd ?stdin ?stderr cmd =
-  let stdout_r, stdout_w = Unix.pipe () in
-  let proc =
-    spawn cmd env ?cwd ?stdin ~stdout:(`FD_move stdout_w) ?stderr [stdout_r] in
-  let stdout = Lwt_io.of_unix_fd ~mode:Lwt_io.input stdout_r in
+  let stdout_r, stdout_w = Lwt_unix.pipe_in ~cloexec:true () in
+  let proc = spawn cmd env ?cwd ?stdin ~stdout:(`FD_move stdout_w) ?stderr in
+  let stdout = Lwt_io.of_fd ~mode:Lwt_io.input stdout_r in
   object
     inherit common timeout proc [cast_chan stdout]
     method stdout = stdout
   end
 
 class process_out ?timeout ?env ?cwd ?stdout ?stderr cmd =
-  let stdin_r, stdin_w = Unix.pipe () in
-  let proc =
-    spawn cmd env ?cwd ~stdin:(`FD_move stdin_r) ?stdout ?stderr [stdin_w] in
-  let stdin = Lwt_io.of_unix_fd ~mode:Lwt_io.output stdin_w in
+  let stdin_r, stdin_w = Lwt_unix.pipe_out ~cloexec:true () in
+  let proc = spawn cmd env ?cwd ~stdin:(`FD_move stdin_r) ?stdout ?stderr in
+  let stdin = Lwt_io.of_fd ~mode:Lwt_io.output stdin_w in
   object
     inherit common timeout proc [cast_chan stdin]
     method stdin = stdin
   end
 
 class process ?timeout ?env ?cwd ?stderr cmd =
-  let stdin_r, stdin_w = Unix.pipe ()
-  and stdout_r, stdout_w = Unix.pipe () in
+  let stdin_r, stdin_w = Lwt_unix.pipe_out ~cloexec:true ()
+  and stdout_r, stdout_w = Lwt_unix.pipe_in ~cloexec:true () in
   let proc =
     spawn
       cmd env ?cwd ~stdin:(`FD_move stdin_r) ~stdout:(`FD_move stdout_w) ?stderr
-      [stdin_w; stdout_r]
   in
-  let stdin = Lwt_io.of_unix_fd ~mode:Lwt_io.output stdin_w
-  and stdout = Lwt_io.of_unix_fd ~mode:Lwt_io.input stdout_r in
+  let stdin = Lwt_io.of_fd ~mode:Lwt_io.output stdin_w
+  and stdout = Lwt_io.of_fd ~mode:Lwt_io.input stdout_r in
   object
     inherit common timeout proc [cast_chan stdin; cast_chan stdout]
     method stdin = stdin
@@ -311,20 +302,19 @@ class process ?timeout ?env ?cwd ?stderr cmd =
   end
 
 class process_full ?timeout ?env ?cwd cmd =
-  let stdin_r, stdin_w = Unix.pipe ()
-  and stdout_r, stdout_w = Unix.pipe ()
-  and stderr_r, stderr_w = Unix.pipe () in
+  let stdin_r, stdin_w = Lwt_unix.pipe_out ~cloexec:true ()
+  and stdout_r, stdout_w = Lwt_unix.pipe_in ~cloexec:true ()
+  and stderr_r, stderr_w = Lwt_unix.pipe_in ~cloexec:true () in
   let proc =
     spawn
       cmd env ?cwd
       ~stdin:(`FD_move stdin_r)
       ~stdout:(`FD_move stdout_w)
       ~stderr:(`FD_move stderr_w)
-      [stdin_w; stdout_r; stderr_r]
   in
-  let stdin = Lwt_io.of_unix_fd ~mode:Lwt_io.output stdin_w
-  and stdout = Lwt_io.of_unix_fd ~mode:Lwt_io.input stdout_r
-  and stderr = Lwt_io.of_unix_fd ~mode:Lwt_io.input stderr_r in
+  let stdin = Lwt_io.of_fd ~mode:Lwt_io.output stdin_w
+  and stdout = Lwt_io.of_fd ~mode:Lwt_io.input stdout_r
+  and stderr = Lwt_io.of_fd ~mode:Lwt_io.input stderr_r in
   object
     inherit
       common timeout proc [cast_chan stdin; cast_chan stdout; cast_chan stderr]

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -34,6 +34,31 @@ static HANDLE get_handle(value opt) {
     return INVALID_HANDLE_VALUE;
 }
 
+/* Ensures the handle [h] is inheritable. Returns the handle for the
+   child process in [hStd] and in [to_close] if it needs to be closed
+   after CreateProcess. */
+static int ensure_inheritable(HANDLE h /* in */,
+                              HANDLE * hStd /* out */,
+                              HANDLE * to_close /* out */)
+{
+  DWORD flags;
+  HANDLE hp;
+
+  if (h == INVALID_HANDLE_VALUE || h == NULL)
+    return 1;
+  if (! GetHandleInformation(h, &flags))
+    return 0;
+  hp = GetCurrentProcess();
+  if (! (flags & HANDLE_FLAG_INHERIT)) {
+    if (! DuplicateHandle(hp, h, hp, hStd, 0, TRUE, DUPLICATE_SAME_ACCESS))
+      return 0;
+    *to_close = *hStd;
+  } else {
+    *hStd = h;
+  }
+  return 1;
+}
+
 CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
                                           value cwd, value fds) {
   CAMLparam5(prog, cmdline, env, cwd, fds);
@@ -41,8 +66,29 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
 
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
-  DWORD flags = CREATE_UNICODE_ENVIRONMENT;
-  BOOL ret;
+  DWORD flags = 0, err;
+  HANDLE hp, fd0, fd1, fd2;
+  HANDLE to_close0 = INVALID_HANDLE_VALUE, to_close1 = INVALID_HANDLE_VALUE,
+    to_close2 = INVALID_HANDLE_VALUE;
+
+  fd0 = get_handle(Field(fds, 0));
+  fd1 = get_handle(Field(fds, 1));
+  fd2 = get_handle(Field(fds, 2));
+
+  err = ERROR_SUCCESS;
+  ZeroMemory(&si, sizeof(si));
+  ZeroMemory(&pi, sizeof(pi));
+  si.cb = sizeof(si);
+  si.dwFlags = STARTF_USESTDHANDLES;
+
+  /* If needed, duplicate the handles fd1, fd2, fd3 to make sure they
+     are inheritable. */
+  if (! ensure_inheritable(fd0, &si.hStdInput, &to_close0) ||
+      ! ensure_inheritable(fd1, &si.hStdOutput, &to_close1) ||
+      ! ensure_inheritable(fd2, &si.hStdError, &to_close2)) {
+    err = GetLastError(); goto ret;
+  }
+
 
 #define string_option(opt) \
   (Is_block(opt) ? caml_stat_strdup_to_os(String_val(Field(opt, 0))) : NULL)
@@ -55,23 +101,25 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
 
 #undef string_option
 
-  ZeroMemory(&si, sizeof(si));
-  ZeroMemory(&pi, sizeof(pi));
-  si.cb = sizeof(si);
-  si.dwFlags = STARTF_USESTDHANDLES;
-  si.hStdInput = get_handle(Field(fds, 0));
-  si.hStdOutput = get_handle(Field(fds, 1));
-  si.hStdError = get_handle(Field(fds, 2));
+  flags |= CREATE_UNICODE_ENVIRONMENT;
+  if (! CreateProcess(progs, cmdlines, NULL, NULL, TRUE, flags,
+                      envs, cwds, &si, &pi)) {
+    err = GetLastError();
+  }
 
-  ret = CreateProcess(progs, cmdlines, NULL, NULL, TRUE, flags,
-                      envs, cwds, &si, &pi);
   caml_stat_free(progs);
   caml_stat_free(cmdlines);
   caml_stat_free(envs);
   caml_stat_free(cwds);
 
-  if (!ret) {
-    win32_maperr(GetLastError());
+ret:
+/* Close the handles if we duplicated them above. */
+  if (to_close0 != INVALID_HANDLE_VALUE) CloseHandle(to_close0);
+  if (to_close1 != INVALID_HANDLE_VALUE) CloseHandle(to_close1);
+  if (to_close2 != INVALID_HANDLE_VALUE) CloseHandle(to_close2);
+
+  if (err != ERROR_SUCCESS) {
+    win32_maperr(err);
     uerror("CreateProcess", Nothing);
   }
 

--- a/test/unix/dummy.ml
+++ b/test/unix/dummy.ml
@@ -1,0 +1,6 @@
+let () =
+  let str = "the quick brown fox jumps over the lazy dog" in
+  match Sys.argv.(1) with
+  | "read" -> if read_line () <> str then exit 1
+  | "write" -> print_string str
+  | _ -> invalid_arg "Sys.argv"

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -6,7 +6,11 @@
 (library
  (name tester)
  (libraries lwt lwttester)
- (modules (:standard \ main luv_main) ))
+ (modules (:standard \ main luv_main dummy) ))
+
+(executable
+ (name dummy)
+ (modules dummy))
 
 (executable
  (name main)
@@ -22,7 +26,7 @@
  (name runtest)
  (package lwt)
  (action (run %{exe:main.exe}))
- (deps bytes_io_data)
+ (deps bytes_io_data %{exe:dummy.exe})
 )
 
 (alias

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -600,7 +600,7 @@ let suite = suite "lwt_bytes" [
     test "read: buffer retention" ~sequential:true begin fun () ->
       let buffer = Lwt_bytes.create 3 in
 
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
       Lwt_unix.set_blocking read_fd true;
 
       Lwt_unix.write_string write_fd "foo" 0 3 >>= fun _ ->
@@ -637,7 +637,7 @@ let suite = suite "lwt_bytes" [
     test "write: buffer retention" ~sequential:true begin fun () ->
       let buffer = Lwt_bytes.create 3 in
 
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
       Lwt_unix.set_blocking write_fd true;
 
       let retained = Lwt_unix.retained buffer in

--- a/test/unix/test_lwt_process.ml
+++ b/test/unix/test_lwt_process.ml
@@ -6,6 +6,8 @@
 open Test
 open Lwt.Infix
 
+let expected = "the quick brown fox jumps over the lazy dog"
+
 let suite = suite "lwt_process" [
   (* The sleep command is not available on Win32. *)
   test "lazy_undefined" ~only_if:(fun () -> not Sys.win32)
@@ -16,5 +18,44 @@ let suite = suite "lwt_process" [
             Lwt.catch
               (fun () -> Lwt_io.read p#stdout)
               (fun _ -> Lwt.return ""))
-        >>= fun _ -> Lwt.return_true)
+        >>= fun _ -> Lwt.return_true);
+
+  test "pread"
+    (fun () ->
+      let args = [|"dummy.exe"; "write"|] in
+      Lwt_process.pread ~stdin:`Close ~stderr:`Close ("./dummy.exe", args)
+      >|= fun actual ->
+      actual = expected);
+
+  test "pread keep"
+    (fun () ->
+      let args = [|"dummy.exe"; "write"|] in
+      Lwt_process.pread ~stdin:`Keep ~stderr:`Keep ("./dummy.exe", args)
+      >|= fun actual ->
+      actual = expected);
+
+  test "pread nul"
+    (fun () ->
+      let args = [|"dummy.exe"; "write"|] in
+      Lwt_process.pread ~stdin:`Dev_null ~stderr:`Dev_null ("./dummy.exe", args)
+      >|= fun actual ->
+      actual = expected);
+
+  test "pwrite"
+    (fun () ->
+      let args = [|"dummy.exe"; "read"|] in
+      Lwt_process.pwrite ~stdout:`Close ~stderr:`Close ("./dummy.exe", args) expected
+      >>= fun () -> Lwt.return_true);
+
+  test "pwrite keep"
+    (fun () ->
+      let args = [|"dummy.exe"; "read"|] in
+      Lwt_process.pwrite ~stdout:`Keep ~stderr:`Keep ("./dummy.exe", args) expected
+      >>= fun () -> Lwt.return_true);
+
+  test "pwrite nul"
+    (fun () ->
+      let args = [|"dummy.exe"; "read"|] in
+      Lwt_process.pwrite ~stdout:`Dev_null ~stderr:`Dev_null ("./dummy.exe", args) expected
+      >>= fun () -> Lwt.return_true);
 ]

--- a/test/unix/test_lwt_unix.cppo.ml
+++ b/test/unix/test_lwt_unix.cppo.ml
@@ -421,7 +421,7 @@ let readv_tests =
              `Bigarray (1, 4, 1)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd "foobar";
@@ -435,7 +435,7 @@ let readv_tests =
              `Bigarray (1, 4, 1)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
         Lwt_unix.set_blocking read_fd true;
 
         Lwt_list.for_all_s (fun t -> t ())
@@ -450,7 +450,7 @@ let readv_tests =
         ]
       in
 
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
       Lwt_unix.set_blocking read_fd true;
 
       Lwt_unix.write_string write_fd "foo" 0 3 >>= fun _ ->
@@ -473,7 +473,7 @@ let readv_tests =
         in
         Lwt_unix.IO_vectors.drop io_vectors 2;
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd "foobar";
@@ -500,14 +500,14 @@ let readv_tests =
 
         let expected = String.make limit 'a' in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd (expected ^ "a");
            reader read_fd io_vectors underlying limit (expected ^ "_")]);
 
     test "readv: windows" ~only_if:(fun () -> Sys.win32) begin fun () ->
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
       let io_vectors, underlying =
         make_io_vectors [
@@ -590,7 +590,7 @@ let writev_tests =
              `Bigarray ("baz", 0, 3)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer ~blocking:false write_fd io_vectors 9;
@@ -605,7 +605,7 @@ let writev_tests =
              `Bigarray ("baz", 0, 3)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
         Lwt_unix.set_blocking write_fd true;
 
         Lwt_list.for_all_s (fun t -> t ())
@@ -620,7 +620,7 @@ let writev_tests =
         ]
       in
 
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
       Lwt_unix.set_blocking write_fd true;
 
       let retained = Lwt_unix.retained io_vectors in
@@ -637,7 +637,7 @@ let writev_tests =
         let io_vectors =
           make_io_vectors [`Bytes ("foo", 1, 2); `Bigarray ("bar", 1, 2)] in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd io_vectors 4;
@@ -652,7 +652,7 @@ let writev_tests =
              `Bigarray ("baz", 0, 3)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         let initially_empty = Lwt_unix.IO_vectors.is_empty io_vectors in
 
@@ -685,7 +685,7 @@ let writev_tests =
              `Bigarray ("bar", 0, 0)]
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         let initially_empty = Lwt_unix.IO_vectors.is_empty io_vectors in
 
@@ -705,7 +705,7 @@ let writev_tests =
         let negative_length' = make_io_vectors [`Bigarray ("foo", 0, -1)] in
         let out_of_bounds' = make_io_vectors [`Bigarray ("foo", 1, 3)] in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         let writer io_vectors =
           fun () ->
@@ -753,7 +753,7 @@ let writev_tests =
           loop (limit + 1)
         in
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd io_vectors limit;
@@ -764,7 +764,7 @@ let writev_tests =
         let io_vectors = make_io_vectors [`Bytes ("foo", 0, 3)] in
         Lwt_unix.IO_vectors.drop io_vectors (-1);
 
-        let read_fd, write_fd = Lwt_unix.pipe () in
+        let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
         Lwt_list.for_all_s (fun t -> t ())
           [writer write_fd io_vectors 3;
@@ -782,7 +782,7 @@ let writev_tests =
         ]
       in
 
-      let read_fd, write_fd = Lwt_unix.pipe () in
+      let read_fd, write_fd = Lwt_unix.pipe ~cloexec:true () in
 
       Lwt_list.for_all_s (fun t -> t ()) [
         writer ~close:false write_fd io_vectors 3;
@@ -796,7 +796,7 @@ let writev_tests =
 let send_recv_msg_tests = [
   test "send_msg, recv_msg" ~only_if:(fun () -> not Sys.win32) begin fun () ->
     let socket_1, socket_2 = Lwt_unix.(socketpair PF_UNIX SOCK_STREAM 0) in
-    let pipe_read, pipe_write = Lwt_unix.pipe () in
+    let pipe_read, pipe_write = Lwt_unix.pipe ~cloexec:true () in
 
     let source_buffer = Bytes.of_string "_foo_bar_" in
     let source_iovecs = Lwt_unix.IO_vectors.create () in
@@ -854,7 +854,7 @@ let send_recv_msg_tests = [
       begin fun () ->
 
     let socket_1, socket_2 = Lwt_unix.(socketpair PF_UNIX SOCK_STREAM 0) in
-    let pipe_read, pipe_write = Lwt_unix.pipe () in
+    let pipe_read, pipe_write = Lwt_unix.pipe ~cloexec:true () in
 
     let source_buffer = Lwt_bytes.of_string "_foo_bar_" in
     let source_iovecs = Lwt_bytes.[


### PR DESCRIPTION
`Unix.create_process` currently always duplicates the handles given to
the child process to make sure they're inheritable (keep-on-exec).  I
have opened the PR 10807 on OCaml to duplicate the handles only if
they're not inheritable (close-on-exec).

This PR mimic this behaviour in Lwt for consistency (assuming the
OCaml PR will be accepted).

See the following PRs:
- https://github.com/ocaml/ocaml/pull/650;
- https://github.com/ocaml/ocaml/pull/10807.