### PR TITLE
Use `WSA_FLAG_NO_HANDLE_INHERIT` on Windows for cloexec sockets 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@
   * Prefer SetHandleInformation to DuplicateHandle in set_close_on_exec for sockets. DuplicateHandle mustn't be used on sockets. (#907, Antonin Décimo)
   * Lwt.pick and Lwt.choose select preferentially failed promises as per
   documentation (#856, #874, Raman Varabets)
+  * Use the WSA_FLAG_NO_HANDLE_INHERIT on Windows when creating sockets with WSASocket if the cloexec (non-inheritable) parameter is true. Fixes a Windows problem where a child process would inherit a supposedly non-inheritable socket. (#910, Antonin Décimo)
 
 ====== Deprecations ======
 

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -360,7 +360,7 @@ static void lwt_unix_socketpair(int domain, int type, int protocol,
   sockets[0] = INVALID_SOCKET;
   sockets[1] = INVALID_SOCKET;
 
-  listener = socket(domain, type, protocol);
+  listener = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
   if (listener == INVALID_SOCKET) goto failure;
 
   memset(&a, 0, sizeof(a));
@@ -394,7 +394,7 @@ static void lwt_unix_socketpair(int domain, int type, int protocol,
 
   if (listen(listener, 1) == SOCKET_ERROR) goto failure;
 
-  sockets[0] = socket(domain, type, protocol);
+  sockets[0] = WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);
   if (sockets[0] == INVALID_SOCKET) goto failure;
 
   addrlen = domain == PF_INET ? sizeof(a.inaddr) : sizeof(a.inaddr6);


### PR DESCRIPTION
The call to

    socket(domain, type, protocol);

is equivalent to

    WSASocket(domain, type, protocol, NULL, 0, WSA_FLAG_OVERLAPPED);

the latter offering more (needed) control over the creation of
sockets.

On Windows, in order to mark sockets non-inheritable (close-on-exec),
it is sometimes not sufficient to use `SetHandleInformation`. There's
some explanation why in [1] and [KB2398202].

Introduced in the hotfix [KB2398202] and supported on Windows 7 with
SP1, Windows Server 2008 R2 with SP1, and later, the flag
`WSA_FLAG_NO_HANDLE_INHERIT` can be used with `WSASocket` to create a
non-inheritable socket.

We can still call `SetHandleInformation` to clear the inheritable flag
on the socket in case the flag isn't supported (running on an early
Windows Vista or 7).

Related OCaml PR:
- ocaml/ocaml#10809.

[1]: https://stackoverflow.com/questions/12058911/can-tcp-socket-handles-be-set-not-inheritable
[KB2398202]: https://support.microsoft.com/en-us/topic/an-application-may-stop-responding-when-the-application-closes-a-socket-connection-or-shuts-down-41321a1f-d80c-6975-98df-ae499d63133c