### PR TITLE
Remove obsolete second wakeup_paused

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,7 +41,7 @@
 
 ====== Misc ======
 
-  * Resolve paused promises only once in main loop. This lets Lwt.pause behave identical to Lwt_unix.yield. (#917, Christopher Zimmermann)
+  * Resolve paused promises only once in main loop. This lets Lwt.pause behave identical to Lwt_unix.yield. (#917, Christopher Zimmermann, Favonia)
 
 
 ===== 5.6.1 =====

--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,10 @@
 
   * Alias Lwt_result.map_err and Lwt_result.bind_lwt_err to Lwt_result.map_error and Lwt_result.bind_lwt_error for consistency with Stdlib. (#927, Antonin Décimo)
 
+====== Misc ======
+
+  * Resolve paused promises only once in main loop. This lets Lwt.pause behave identical to Lwt_unix.yield.(#917, Christopher Zimmermann)
+
 ===== 5.5.0 =====
 
 ====== Deprecations ======

--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,10 @@
 
   * Fix marshall header size in Lwt_io.read_value. (Simmo Saan, #995)
 
+====== Misc ======
+
+  * Resolve paused promises only once in main loop. This lets Lwt.pause behave identical to Lwt_unix.yield. (#917, Christopher Zimmermann)
+
 
 ===== 5.6.1 =====
 
@@ -88,10 +92,6 @@
 ====== Deprecations ======
 
   * Alias Lwt_result.map_err and Lwt_result.bind_lwt_err to Lwt_result.map_error and Lwt_result.bind_lwt_error for consistency with Stdlib. (#927, Antonin Décimo)
-
-====== Misc ======
-
-  * Resolve paused promises only once in main loop. This lets Lwt.pause behave identical to Lwt_unix.yield.(#917, Christopher Zimmermann)
 
 ===== 5.5.0 =====
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1836,6 +1836,9 @@ val pause : unit -> unit t
     Putting the rest of your computation into a callback of [Lwt.pause ()]
     creates a “yield” that gives other callbacks a chance to run first.
 
+    To wait for one complete iteration of the main loop you need to wait for
+    [Lwt.pause () >>= Lwt.pause]
+
     For example, to break up a long-running computation, allowing I/O to be
     handled between chunks:
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1836,9 +1836,6 @@ val pause : unit -> unit t
     Putting the rest of your computation into a callback of [Lwt.pause ()]
     creates a “yield” that gives other callbacks a chance to run first.
 
-    To wait for one complete iteration of the main loop you need to wait for
-    [Lwt.pause () >>= Lwt.pause]
-
     For example, to break up a long-running computation, allowing I/O to be
     handled between chunks:
 

--- a/src/unix/lwt_main.ml
+++ b/src/unix/lwt_main.ml
@@ -17,7 +17,7 @@ open Lwt.Infix
 let enter_iter_hooks = Lwt_sequence.create ()
 let leave_iter_hooks = Lwt_sequence.create ()
 
-let yield () = Lwt.pause ()
+let yield = Lwt.pause
 
 let abandon_yielded_and_paused () =
   Lwt.abandon_paused ()

--- a/src/unix/lwt_main.ml
+++ b/src/unix/lwt_main.ml
@@ -26,8 +26,6 @@ let abandon_yielded_and_paused () =
 
 let run p =
   let rec run_loop () =
-    (* Fulfill paused promises now. *)
-    Lwt.wakeup_paused ();
     match Lwt.poll p with
     | Some x ->
       x
@@ -40,7 +38,7 @@ let run p =
         Lwt.paused_count () = 0 && Lwt_sequence.is_empty yielded in
       Lwt_engine.iter should_block_waiting_for_io;
 
-      (* Fulfill paused promises again. *)
+      (* Fulfill paused promises. *)
       Lwt.wakeup_paused ();
 
       (* Fulfill yield promises. *)

--- a/src/unix/lwt_main.ml
+++ b/src/unix/lwt_main.ml
@@ -16,12 +16,10 @@ open Lwt.Infix
 
 let enter_iter_hooks = Lwt_sequence.create ()
 let leave_iter_hooks = Lwt_sequence.create ()
-let yielded = Lwt_sequence.create ()
 
-let yield () = (Lwt.add_task_r [@ocaml.warning "-3"]) yielded
+let yield () = Lwt.pause ()
 
 let abandon_yielded_and_paused () =
-  Lwt_sequence.clear yielded;
   Lwt.abandon_paused ()
 
 let run p =
@@ -34,19 +32,11 @@ let run p =
       Lwt_sequence.iter_l (fun f -> f ()) enter_iter_hooks;
 
       (* Do the main loop call. *)
-      let should_block_waiting_for_io =
-        Lwt.paused_count () = 0 && Lwt_sequence.is_empty yielded in
+      let should_block_waiting_for_io = Lwt.paused_count () = 0 in
       Lwt_engine.iter should_block_waiting_for_io;
 
       (* Fulfill paused promises. *)
       Lwt.wakeup_paused ();
-
-      (* Fulfill yield promises. *)
-      if not (Lwt_sequence.is_empty yielded) then begin
-        let tmp = Lwt_sequence.create () in
-        Lwt_sequence.transfer_r yielded tmp;
-        Lwt_sequence.iter_l (fun resolver -> Lwt.wakeup resolver ()) tmp
-      end;
 
       (* Call leave hooks. *)
       Lwt_sequence.iter_l (fun f -> f ()) leave_iter_hooks;

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -55,8 +55,7 @@ val abandon_yielded_and_paused : unit -> unit [@@deprecated "Use Lwt.abandon_pau
 (** Causes promises created with {!Lwt.pause} and {!Lwt_main.yield} to remain
     forever pending.
 
-    [yield] is now deprecated in favor of the more general {!Lwt.pause}.
-    Once [yield] is phased out, this function will be deprecated as well.
+    (Note that [yield] is deprecated in favor of the more general {!Lwt.pause}.)
 
     This is meant for use with {!Lwt_unix.fork}, as a way to “abandon” more
     promise chains that are pending in your process.

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -49,14 +49,9 @@ val yield : unit -> unit Lwt.t [@@deprecated "Use Lwt.pause instead"]
 
       @deprecated Since 5.5.0 [yield] is deprecated in favor of the more general
       {!Lwt.pause} in order to avoid discrepancies in resolution (see below) and
-      stay compatible with other execution environments such as js_of_ocaml.
+      stay compatible with other execution environments such as js_of_ocaml. *)
 
-      Currently, paused promises are resolved more frequently than yielded promises.
-      The difference is unintended but existing applications could depend on it.
-      Unifying the two pools of promises into one in the future would eliminate
-      possible discrepancies and simplify the code. *)
-
-val abandon_yielded_and_paused : unit -> unit
+val abandon_yielded_and_paused : unit -> unit [@@deprecated "Use Lwt.abandon_paused instead"]
 (** Causes promises created with {!Lwt.pause} and {!Lwt_main.yield} to remain
     forever pending.
 
@@ -64,7 +59,10 @@ val abandon_yielded_and_paused : unit -> unit
     Once [yield] is phased out, this function will be deprecated as well.
 
     This is meant for use with {!Lwt_unix.fork}, as a way to “abandon” more
-    promise chains that are pending in your process. *)
+    promise chains that are pending in your process.
+
+    @deprecated Since 5.5.1 [abandon_yielded_and_paused] is deprecated in favour
+    of [Lwt.abandon_paused]. *)
 
 
 

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -60,7 +60,7 @@ val abandon_yielded_and_paused : unit -> unit [@@deprecated "Use Lwt.abandon_pau
     This is meant for use with {!Lwt_unix.fork}, as a way to “abandon” more
     promise chains that are pending in your process.
 
-    @deprecated Since 5.5.1 [abandon_yielded_and_paused] is deprecated in favour
+    @deprecated Since 5.7 [abandon_yielded_and_paused] is deprecated in favour
     of [Lwt.abandon_paused]. *)
 
 

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -123,7 +123,7 @@ let sleep delay =
   Lwt.on_cancel waiter (fun () -> Lwt_engine.stop_event ev);
   waiter
 
-let yield = (Lwt_main.yield [@warning "-3"])
+let yield = Lwt.pause
 
 let auto_yield timeout =
   let limit = ref (Unix.gettimeofday () +. timeout) in


### PR DESCRIPTION
It was introduced in d5822af9a80b745515e0988541d7a43ed9a6faba.
If I understand correctly this was done to prevent calling select
without timeout while there were pending paused promises.

Since now we explicitely check for this condition and call select with
zero timeout (`should_block_waiting_for_io`). This extra `wakeup_paused`
seems to be obsolete.

Maybe in `Lwt.pause` it should also be documented that Lwt.pause () needs to be used 2 / 3 times to enforce completion of a whole main loop iteration. The current documentation talks about the 'next "tick"'? #916