### PR TITLE
Fully initialize custom_operations job_ops

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@
   * Use the WSA_FLAG_NO_HANDLE_INHERIT on Windows when creating sockets with WSASocket if the cloexec (non-inheritable) parameter is true. Fixes a Windows problem where a child process would inherit a supposedly non-inheritable socket. (#910, Antonin Décimo)
   * Fix macOS/arm64 tests which have a 16k page. (#932, Kate Deplaix)
   * Fix Lwt_unix.closedir incorrectly checking the return value of closedir(3). (#942, Antonin Décimo)
+  * Fix custom_operations struct not fully initialized after OCaml 4.08. (Antonin Décimo, #918)
 
 ====== Deprecations ======
 

--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -67,7 +67,10 @@ static long hash_loop(value loop) { return (long)Ev_loop_val(loop); }
 
 static struct custom_operations loop_ops = {
     "lwt.libev.loop", custom_finalize_default,  compare_loops,
-    hash_loop,        custom_serialize_default, custom_deserialize_default};
+    hash_loop,        custom_serialize_default, custom_deserialize_default,
+    custom_compare_ext_default,
+    NULL
+};
 
 /* Do nothing.
 
@@ -125,7 +128,10 @@ static long hash_watcher(value watcher) { return (long)Ev_io_val(watcher); }
 
 static struct custom_operations watcher_ops = {
     "lwt.libev.watcher", custom_finalize_default,  compare_watchers,
-    hash_watcher,        custom_serialize_default, custom_deserialize_default};
+    hash_watcher,        custom_serialize_default, custom_deserialize_default,
+    custom_compare_ext_default,
+    NULL
+};
 
 /* +-----------------------------------------------------------------+
    | IO watchers                                                     |

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -1021,7 +1021,10 @@ static void *worker_loop(void *data) {
 /* Description of jobs. */
 struct custom_operations job_ops = {
     "lwt.unix.job",      custom_finalize_default,  custom_compare_default,
-    custom_hash_default, custom_serialize_default, custom_deserialize_default};
+    custom_hash_default, custom_serialize_default, custom_deserialize_default,
+    custom_compare_ext_default,
+    NULL
+};
 
 /* Get the job structure contained in a custom value. */
 #define Job_val(v) *(lwt_unix_job *)Data_custom_val(v)


### PR DESCRIPTION
It was missing an initializer for `.compare_ext` (since 3.12.1), the
default is `custom_compare_ext_default`; and `.fixed_length` (since
4.08.0) for which `NULL` is good.