### PR TITLE
Documentation fixes: cross-refs, internal links

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,13 +14,13 @@
 
   * On Windows, make Lwt_process.create_process duplicate standard handles given to the child process if they're not inheritable, to mimic the behaviour of Unix.create_process. (#909, Antonin Décimo)
   * Add missing dependency to `cppo` in lwt-react's opam file. (#946, Rizo I)
+  * Improve documentation (especially internal links). (#928, Antonin Décimo)
 
 ====== Fixes ======
 
   * Fix win32_spawn leaking dev_null fd in the parent process. (#906, Antonin Décimo)
   * Prefer SetHandleInformation to DuplicateHandle in set_close_on_exec for sockets. DuplicateHandle mustn't be used on sockets. (#907, Antonin Décimo)
-  * Lwt.pick and Lwt.choose select preferentially failed promises as per
-  documentation (#856, #874, Raman Varabets)
+  * Lwt.pick and Lwt.choose select preferentially failed promises as per documentation (#856, #874, Raman Varabets)
   * Use the WSA_FLAG_NO_HANDLE_INHERIT on Windows when creating sockets with WSASocket if the cloexec (non-inheritable) parameter is true. Fixes a Windows problem where a child process would inherit a supposedly non-inheritable socket. (#910, Antonin Décimo)
   * Fix macOS/arm64 tests which have a 16k page. (#932, Kate Deplaix)
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1280,7 +1280,7 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 (** [Lwt.map f p_1] is similar to {!Lwt.bind}[ p_1 f], but [f] is not expected
     to return a promise.
 
-    This function is more convenient that {!Lwt.bind} when [f] inherently does
+    This function is more convenient than {!Lwt.bind} when [f] inherently does
     not return a promise. An example is [Stdlib.int_of_string]:
 
 {[

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -54,16 +54,15 @@ let () =
 
     This is all explained in the next sections:
 
-    - {{: #3_Quickstart} Quick start} links these concepts to actual functions
-      in Lwt – the most fundamental ones.
-    - {{: #3_Tutorial} Tutorial} shows how to write examples like the above, and
-      how concurrency happens.
-    - {{: #3_Executionmodel} Execution model} clarifies control flow when using
-      Lwt.
-    - {{: #3_GuidetotherestofLwt} Guide to the rest of Lwt} shows how
-      {e everything} else in Lwt fits into this framework.
+    - {!3_Quickstart} links these concepts to actual functions in Lwt – the most
+      fundamental ones.
+    - {!3_Tutorial} shows how to write examples like the above, and how
+      concurrency happens.
+    - {!3_Executionmodel} clarifies control flow when using Lwt.
+    - {!3_GuidetotherestofLwt} shows how {e everything} else in Lwt fits into
+      this framework.
 
-    After that is the {{: #2_Fundamentals} reference proper}, which goes into
+    After that is the {{!2_Fundamentals} reference proper}, which goes into
     {e painful} levels of detail on every single type and value in this module,
     [Lwt]. Please be safe, and read only what you need from it :)
 
@@ -71,7 +70,7 @@ let () =
 
 
 
-    {3 Quick start}
+    {3:3_Quickstart Quick start}
 
     {e All} of Lwt is variations on:
 
@@ -88,7 +87,7 @@ let () =
 
 
 
-    {3 Tutorial}
+    {3:3_Tutorial Tutorial}
 
     Let's read  from STDIN. The first version is written using ordinary values
     from the OCaml standard library. This makes the program block until the user
@@ -222,11 +221,10 @@ let () =
 
     And that's it! Concurrency in Lwt is simply a matter of whether you start an
     operation in the callback of another one or not. As a convenience, Lwt
-    provides a few {{: #2_Concurrency} helpers} for common concurrency patterns.
+    provides a few {{!2_Concurrency} helpers} for common concurrency patterns.
 
 
-
-    {3 Execution model}
+    {3:3_Executionmodel Execution model}
 
     It's important to understand that promises are a pure-OCaml data type. They
     don't do any fancy scheduling or I/O. They are just lists of callbacks (if
@@ -313,24 +311,23 @@ let () =
 
 
 
-    {3 Guide to the rest of Lwt}
+    {3:3_GuidetotherestofLwt Guide to the rest of Lwt}
 
     This module [Lwt] is the pure-OCaml definition of promises and
     callback-calling. It has a few extras on top of what's described above:
 
-    - {{: #2_Rejection} Rejection}. Lwt promises can actually be resolved in two
-      ways: {e fulfilled} with a value, or {e rejected} with an exception. There
-      is nothing conceptually special about rejection – it's just that you can
-      ask for callbacks to run only on fulfillment, only on rejection, etc.
-    - {{: #2_Cancelation} Cancellation}. This is a special case of rejection,
-      specifically with exception {!Lwt.Canceled}. It has extra helpers in the
-      Lwt API.
-    - {{: #2_Concurrency} Concurrency helpers}. All of these could be
-      implemented on top of {!Lwt.bind}. As we saw, Lwt concurrency requires
-      only deciding whether to run something inside a callback, or outside it.
-      These functions just implement common patterns, and make intent explicit.
-    - Miscellaneous {{: #2_Convenience} helpers}, and {{: #2_Deprecated}
-      deprecated} APIs.
+    - {!2_Rejection}. Lwt promises can actually be resolved in two ways:
+      {e fulfilled} with a value, or {e rejected} with an exception. There is
+      nothing conceptually special about rejection – it's just that you can ask
+      for callbacks to run only on fulfillment, only on rejection, etc.
+    - {!2_Cancellation}. This is a special case of rejection, specifically with
+      exception {!Lwt.Canceled}. It has extra helpers in the Lwt API.
+    - {{!2_Concurrency} Concurrency helpers}. All of these could be implemented
+      on top of {!Lwt.bind}. As we saw, Lwt concurrency requires only deciding
+      whether to run something inside a callback, or outside it. These functions
+      just implement common patterns, and make intent explicit.
+    - Miscellaneous {{!2_Convenience} helpers}, and {{!2_Deprecated} deprecated}
+      APIs.
 
     The next layer above module [Lwt] is the pure-OCaml Lwt “core” library,
     which provides some promise-friendly patterns, like streams and mvars. This
@@ -360,7 +357,7 @@ let () =
 
 
 
-(** {2 Fundamentals} *)
+(** {2:2_Fundamentals Fundamentals} *)
 
 (** {3 Promises} *)
 
@@ -575,7 +572,7 @@ let () =
 
 
 
-(** {2 Rejection} *)
+(** {2:2_Rejection Rejection} *)
 
 val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
 (** [Lwt.catch f h] applies [f ()], which returns a promise, and then makes it
@@ -915,7 +912,7 @@ v}
 
 
 
-(** {2 Concurrency} *)
+(** {2:2_Concurrency Concurrency} *)
 
 (** {3 Multiple wait} *)
 
@@ -1063,7 +1060,7 @@ val nchoose_split : ('a t) list -> ('a list * ('a t) list) t
 
 
 
-(** {2 Cancellation}
+(** {2:2_Cancellation Cancellation}
 
     Note: cancelation has proved difficult to understand, explain, and maintain,
     so use of these functions is discouraged in new code. See
@@ -1267,7 +1264,7 @@ val wrap_in_cancelable : 'a t -> 'a t
 *)
 
 
-(** {2 Convenience} *)
+(** {2:2_Convenience Convenience} *)
 
 (** {3 Callback helpers} *)
 
@@ -1681,7 +1678,7 @@ val state : 'a t -> 'a state
 
 
 
-(** {2 Deprecated} *)
+(** {2:2_Deprecated Deprecated} *)
 
 (** {3 Implicit callback arguments}
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -396,8 +396,7 @@ type -'a u
     {!Lwt.wakeup_later_result} to resolve that promise. *)
 
 val wait : unit -> ('a t * 'a u)
-(** Creates a new pending {{: #TYPEt} promise}, paired with its {{: #TYPEu}
-    resolver}.
+(** Creates a new pending {{!t} promise}, paired with its {{!u} resolver}.
 
     It is rare to use this function directly. Many helpers in Lwt, and Lwt-aware
     libraries, call it internally, and return only the promise. You then chain
@@ -413,13 +412,12 @@ val wait : unit -> ('a t * 'a u)
 
 val wakeup_later : 'a u -> 'a -> unit
 (** [Lwt.wakeup_later r v] {e fulfills}, with value [v], the {e pending}
-    {{: #TYPEt} promise} associated with {{: #TYPEu} resolver} [r]. This
-    triggers callbacks attached to the promise.
+    {{!t} promise} associated with {{!u} resolver} [r]. This triggers callbacks
+    attached to the promise.
 
     If the promise is not pending, [Lwt.wakeup_later] raises
-    {{: https://ocaml.org/api/Stdlib.html#VALinvalid_arg}
-    [Invalid_argument]}, unless the promise is {{: #VALcancel} canceled}. If the
-    promise is canceled, [Lwt.wakeup_later] has no effect.
+    {!Stdlib.Invalid_argument}, unless the promise is {{!Lwt.cancel} canceled}.
+    If the promise is canceled, [Lwt.wakeup_later] has no effect.
 
     If your program has multiple threads, it is important to make sure that
     [Lwt.wakeup_later] (and any similar function) is only called from the main
@@ -430,12 +428,11 @@ val wakeup_later : 'a u -> 'a -> unit
 
 val wakeup_later_exn : _ u -> exn -> unit
 (** [Lwt.wakeup_later_exn r exn] is like {!Lwt.wakeup_later}, except, if the
-    associated {{: #TYPEt} promise} is {e pending}, it is {e rejected} with
-    [exn]. *)
+    associated {{!t} promise} is {e pending}, it is {e rejected} with [exn]. *)
 
 val return : 'a -> 'a t
-(** [Lwt.return v] creates a new {{: #TYPEt} promise} that is {e already
-    fulfilled} with value [v].
+(** [Lwt.return v] creates a new {{!t} promise} that is {e already fulfilled}
+    with value [v].
 
     This is needed to satisfy the type system in some cases. For example, in a
     [match] expression where one case evaluates to a promise, the other cases
@@ -447,7 +444,7 @@ match need_input with
 | false -> Lwt.return ""             (* ...so wrap empty string in a promise. *)
 ]}
 
-    Another typical usage is in {{: #VALbind} [let%lwt]}. The expression after
+    Another typical usage is in {{!Lwt.bind} [let%lwt]}. The expression after
     the “[in]” has to evaluate to a promise. So, if you compute an ordinary
     value instead, you have to wrap it:
 
@@ -457,8 +454,8 @@ Lwt.return (line ^ ".")
 ]} *)
 
 val fail : exn -> _ t
-(** [Lwt.fail exn] is like {!Lwt.return}, except the new {{: #TYPEt} promise}
-    that is {e already rejected} with [exn].
+(** [Lwt.fail exn] is like {!Lwt.return}, except the new {{!t} promise} that is
+    {e already rejected} with [exn].
 
     Whenever possible, it is recommended to use [raise exn] instead, as [raise]
     captures a backtrace, while [Lwt.fail] does not. If you call [raise exn] in
@@ -473,8 +470,8 @@ val fail : exn -> _ t
 (** {3 Callbacks} *)
 
 val bind : 'a t -> ('a -> 'b t) -> 'b t
-(** [Lwt.bind p_1 f] makes it so that [f] will run when [p_1] is {{: #TYPEt}
-    {e fulfilled}}.
+(** [Lwt.bind p_1 f] makes it so that [f] will run when [p_1] is
+    {{!t} {e fulfilled}}.
 
     When [p_1] is fulfilled with value [v_1], the callback [f] is called with
     that same value [v_1]. Eventually, after perhaps starting some I/O or other
@@ -582,8 +579,7 @@ let () =
 
 val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
 (** [Lwt.catch f h] applies [f ()], which returns a promise, and then makes it
-    so that [h] (“handler”) will run when that promise is {{: #TYPEt}
-    {e rejected}}.
+    so that [h] (“handler”) will run when that promise is {{!t} {e rejected}}.
 
 {[
 let () =
@@ -677,8 +673,7 @@ let () =
 
 val finalize : (unit -> 'a t) -> (unit -> unit t) -> 'a t
 (** [Lwt.finalize f c] applies [f ()], which returns a promise, and then makes
-    it so [c] (“cleanup”) will run when that promise is {{: #TYPEt}
-    {e resolved}}.
+    it so [c] (“cleanup”) will run when that promise is {{!t} {e resolved}}.
 
     In other words, [c] runs no matter whether promise [f ()] is fulfilled or
     rejected. As the names suggest, [Lwt.finalize] corresponds to the [finally]
@@ -750,8 +745,8 @@ let () =
 val try_bind : (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 (** [Lwt.try_bind f g h] applies [f ()], and then makes it so that:
 
-    - [g] will run when promise [f ()] is {{: #TYPEt} {e fulfilled}},
-    - [h] will run when promise [f ()] is {{: #TYPEt} {e rejected}}.
+    - [g] will run when promise [f ()] is {{!t} {e fulfilled}},
+    - [h] will run when promise [f ()] is {{!t} {e rejected}}.
 
     [Lwt.try_bind] is a generalized {!Lwt.finalize}. The difference is that
     [Lwt.try_bind] runs different callbacks depending on {e how} [f ()] is
@@ -798,8 +793,8 @@ val try_bind : (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 
 val dont_wait : (unit -> unit t) -> (exn -> unit) -> unit
 (** [Lwt.dont_wait f handler] applies [f ()], which returns a promise, and then
-    makes it so that if the promise is {{: #TYPEt} {e rejected}}, the exception
-    is passed to [handler].
+    makes it so that if the promise is {{!t} {e rejected}}, the exception is
+    passed to [handler].
 
     In addition, if [f ()] raises an exception, it is also passed to [handler].
 
@@ -817,7 +812,7 @@ val dont_wait : (unit -> unit t) -> (exn -> unit) -> unit
 
 val async : (unit -> unit t) -> unit
 (** [Lwt.async f] applies [f ()], which returns a promise, and then makes it so
-    that if the promise is {{: #TYPEt} {e rejected}}, the exception is passed to
+    that if the promise is {{!t} {e rejected}}, the exception is passed to
     [!]{!Lwt.async_exception_hook}.
 
     In addition, if [f ()] raises an exception, it is also passed to
@@ -926,7 +921,7 @@ v}
 
 val both : 'a t -> 'b t -> ('a * 'b) t
 (** [Lwt.both p_1 p_2] returns a promise that is pending until {e both} promises
-    [p_1] and [p_2] become {{: #TYPEt} {e resolved}}.
+    [p_1] and [p_2] become {{!t} {e resolved}}.
 
 {[
 let () =
@@ -957,7 +952,7 @@ let () =
 
 val join : (unit t) list -> unit t
 (** [Lwt.join ps] returns a promise that is pending until {e all} promises in
-    the list [ps] become {{: #TYPEt} {e resolved}}.
+    the list [ps] become {{!t} {e resolved}}.
 
 {[
 let () =
@@ -985,7 +980,7 @@ let () =
 
 val all : ('a t) list -> ('a list) t
 (** [Lwt.all ps] is like {!Lwt.join}[ ps]: it waits for all promises in the list
-    [ps] to become {{: #TYPEt} {e resolved}}.
+    [ps] to become {{!t} {e resolved}}.
 
     It then resolves the returned promise with the list of all resulting values.
 
@@ -1003,8 +998,8 @@ val all : ('a t) list -> ('a list) t
 (** {3 Racing} *)
 
 val pick : ('a t) list -> 'a t
-(** [Lwt.pick ps] returns a promise that is pending until {e one} promise in
-    the list [ps] becomes {{: #TYPEt} {e resolved}}.
+(** [Lwt.pick ps] returns a promise that is pending until {e one} promise in the
+    list [ps] becomes {{!t} {e resolved}}.
 
     When at least one promise in [ps] is resolved, [Lwt.pick] tries to cancel
     all other promises that are still pending, using {!Lwt.cancel}.
@@ -1081,7 +1076,7 @@ exception Canceled
 
 val task : unit -> ('a t * 'a u)
 (** [Lwt.task] is the same as {!Lwt.wait}, except the resulting promise [p] is
-    {{: #VALcancel} cancelable}.
+    {{!Lwt.cancel} cancelable}.
 
     This is significant, because it means promises created by [Lwt.task] can be
     resolved (specifically, rejected) by canceling them directly, in addition to
@@ -1194,7 +1189,7 @@ val on_cancel : _ t -> (unit -> unit) -> unit
     [!]{!Lwt.async_exception_hook}, which terminates the process by default. *)
 
 val protected : 'a t -> 'a t
-(** [Lwt.protected p] creates a {{: #VALcancel} cancelable} promise [p']. The
+(** [Lwt.protected p] creates a {{!Lwt.cancel} cancelable} promise [p']. The
     original state of [p'] is the same as the state of [p] at the time of the
     call.
 
@@ -1202,7 +1197,7 @@ val protected : 'a t -> 'a t
     a. if [p] changes state (i.e., is resolved), then [p'] eventually changes
        state to match [p]'s, and
     b. during cancellation, if the backwards search described in {!Lwt.cancel}
-       reaches [p'] then it changes state to {!Rejected} [Canceled] and the
+       reaches [p'] then it changes state to rejected [Canceled] and the
        search stops.
 
     As a consequence of the b. case, [Lwt.cancel (protected p)] does not cancel
@@ -1213,25 +1208,25 @@ val protected : 'a t -> 'a t
     [Lwt.protected] only prevents cancellation of [p] through [p']. *)
 
 val no_cancel : 'a t -> 'a t
-(** [Lwt.no_cancel p] creates a non-{{: #VALcancel}cancelable} promise [p']. The
+(** [Lwt.no_cancel p] creates a non-{{!Lwt.cancel}cancelable} promise [p']. The
     original state of [p'] is the same as [p] at the time of the call.
 
     If the state of [p] changes, then the state of [p'] eventually changes too
     to match [p]'s.
 
-    Note that even though [p'] is non-{{: #VALcancel}cancelable}, it can still
+    Note that even though [p'] is non-{{!Lwt.cancel}cancelable}, it can still
     become canceled if [p] is canceled. [Lwt.no_cancel] only prevents
     cancellation of [p] and [p'] through [p']. *)
 
 val wrap_in_cancelable : 'a t -> 'a t
-(** [Lwt.wrap_in_cancelable p] creates a {{: #VALcancel} cancelable} promise
+(** [Lwt.wrap_in_cancelable p] creates a {{!Lwt.cancel} cancelable} promise
     [p']. The original state of [p'] is the same as [p].
 
     The state of [p'] can change in one of two ways:
     a. if [p] changes state (i.e., is resolved), then [p'] eventually changes
        state to match [p]'s, and
     b. during cancellation, if the backwards search described in {!Lwt.cancel}
-       reaches [p'] then it changes state to {!Rejected} [Canceled] and the
+       reaches [p'] then it changes state to rejected [Canceled] and the
        search continues to [p].
 *)
 
@@ -1309,7 +1304,7 @@ let read_int : unit -> int Lwt.t = fun () ->
 
     As with {!Lwt.bind}, sequences of calls to [Lwt.map] result in excessive
     indentation and parentheses. The recommended syntactic sugar for avoiding
-    this is the {{: #VAL(>|=)} [>|=]} operator, which comes from module
+    this is the {{!Lwt.Infix.(>|=)} [>|=]} operator, which comes from module
     [Lwt.Infix]:
 
 {[
@@ -1340,8 +1335,8 @@ let read_int : unit -> int Lwt.t = fun () ->
     - If [f v] raises exception [exn], [p_3] is rejected with [exn]. *)
 
 val on_success : 'a t -> ('a -> unit) -> unit
-(** [Lwt.on_success p f] makes it so that [f] will run when [p] is {{: #TYPEt}
-    {e fulfilled}}.
+(** [Lwt.on_success p f] makes it so that [f] will run when [p] is
+    {{!t} {e fulfilled}}.
 
     It is similar to {!Lwt.bind}, except no new promises are created. [f] is a
     plain, arbitrary function attached to [p], to perform some side effect.
@@ -1350,8 +1345,8 @@ val on_success : 'a t -> ('a -> unit) -> unit
     By default, this will terminate the process. *)
 
 val on_failure : _ t -> (exn -> unit) -> unit
-(** [Lwt.on_failure p f] makes it so that [f] will run when [p] is {{: #TYPEt}
-    {e rejected}}.
+(** [Lwt.on_failure p f] makes it so that [f] will run when [p] is
+    {{!t} {e rejected}}.
 
     It is similar to {!Lwt.catch}, except no new promises are created.
 
@@ -1360,7 +1355,7 @@ val on_failure : _ t -> (exn -> unit) -> unit
 
 val on_termination : _ t -> (unit -> unit) -> unit
 (** [Lwt.on_termination p f] makes it so that [f] will run when [p] is
-    {{: #TYPEt} {e resolved}} – that is, fulfilled {e or} rejected.
+    {{!t} {e resolved}} – that is, fulfilled {e or} rejected.
 
     It is similar to {!Lwt.finalize}, except no new promises are created.
 
@@ -1370,8 +1365,8 @@ val on_termination : _ t -> (unit -> unit) -> unit
 val on_any : 'a t -> ('a -> unit) -> (exn -> unit) -> unit
 (** [Lwt.on_any p f g] makes it so that:
 
-    - [f] will run when [p] is {{: #TYPEt} {e fulfilled}},
-    - [g] will run when [p] is, alternatively, {{: #TYPEt} {e rejected}}.
+    - [f] will run when [p] is {{!t} {e fulfilled}},
+    - [g] will run when [p] is, alternatively, {{!t} {e rejected}}.
 
     It is similar to {!Lwt.try_bind}, except no new promises are created.
 
@@ -1626,8 +1621,7 @@ type +'a Lwt.result =
     A resolved promise of type ['a ]{!Lwt.t} is either fulfilled with a value of
     type ['a], or rejected with an exception.
 
-    This corresponds to the cases of a
-    [('a, exn)]{{: https://ocaml.org/api/Stdlib.html#TYPEresult}[Stdlib.result]}:
+    This corresponds to the cases of a [('a, exn)]{!Stdlib.result}:
     fulfilled corresponds to [Ok of 'a], and rejected corresponds to
     [Error of exn].
 
@@ -1663,7 +1657,7 @@ val wakeup_later_result : 'a u -> 'a result -> unit
     - If [result] is [Error exn], [p] is rejected with [exn].
 
     If [p] is not pending, [Lwt.wakeup_later_result] raises
-    [Stdlib.Invalid_argument _], except if [p] is {{: #VALcancel} canceled}. If
+    [Stdlib.Invalid_argument _], except if [p] is {{!Lwt.cancel} canceled}. If
     [p] is canceled, [Lwt.wakeup_later_result] has no effect. *)
 
 
@@ -1678,11 +1672,10 @@ type 'a state =
 val state : 'a t -> 'a state
 (** [Lwt.state p] evaluates to the current state of promise [p]:
 
-    - If [p] is {{: #TYPEt} fulfilled} with value [v], the result is
-      [Lwt.Return v].
-    - If [p] is {{: #TYPEt} rejected} with exception [exn], the result is
+    - If [p] is {{!t} fulfilled} with value [v], the result is [Lwt.Return v].
+    - If [p] is {{!t} rejected} with exception [exn], the result is
       [Lwt.Fail exn].
-    - If [p] is {{: #TYPEt} pending}, the result is [Lwt.Sleep].
+    - If [p] is {{!t} pending}, the result is [Lwt.Sleep].
 
     The constructor names are historical holdovers. *)
 
@@ -1831,21 +1824,18 @@ val wakeup_result : 'a u -> 'a result -> unit
 val make_value : 'a -> 'a result
   [@@ocaml.deprecated
     " Use Result.Ok, which is the same as Ok since OCaml 4.03."]
-(** [Lwt.make_value v] is equivalent to
-    {{: https://ocaml.org/api/Stdlib.html#TYPEresult}
-    [Ok v]} since OCaml 4.03. If you need compatibility with OCaml 4.02, use
-    [Result.Ok] and depend on opam package
-    {{: https://opam.ocaml.org/packages/result/} [result]}.
+(** [Lwt.make_value v] is equivalent to {!Stdlib.Result.Ok} since OCaml 4.03.
+    If you need compatibility with OCaml 4.02, use [Result.Ok] and depend on
+    opam package {{: https://opam.ocaml.org/packages/result/} [result]}.
 
     @deprecated Use [Result.Ok] instead *)
 
 val make_error : exn -> _ result
   [@@ocaml.deprecated
     " Use Result.Error, which is the same as Error since OCaml 4.03."]
-(** [Lwt.make_error exn] is equivalent to
-    {{: https://ocaml.org/api/Stdlib.html#TYPEresult}
-    [Error exn]} since OCaml 4.03. If you need compatibility with OCaml 4.02,
-    use [Result.Error] and depend on opam package
+(** [Lwt.make_error exn] is equivalent to {!Stdlib.Result.Error} since OCaml
+    4.03. If you need compatibility with OCaml 4.02, use [Result.Error] and
+    depend on opam package
     {{: https://opam.ocaml.org/packages/result/} [result]}.
 
     @deprecated Use [Result.Error] instead. *)
@@ -1956,13 +1946,13 @@ val wakeup_paused : unit -> unit
 
 val paused_count : unit -> int
 (** Returns the number of promises that would be fulfilled by calling
-    {!Lwt.wakeup_paused} right now.
+    [Lwt.wakeup_paused] right now.
 
     This function is intended for internal use by Lwt. *)
 
 val register_pause_notifier : (int -> unit) -> unit
 (** [Lwt.register_pause_notifier f] causes [f] to be called every time
-    {!Lwt.pause} is called. The result of {!Lwt.paused_count}[ ()] is passed to
+    {!Lwt.pause} is called. The result of [Lwt.paused_count ()] is passed to
     [f].
 
     Only one such function can be registered at a time. There is only a single
@@ -2031,7 +2021,11 @@ let g v =
 
 
 
-(** {3 Unscoped infix operators} *)
+(** {3 Unscoped infix operators}
+
+Use the operators in module {!Lwt.Infix} instead. Using these
+instances of the operators directly requires opening module [Lwt],
+which brings an excessive number of other names into scope. *)
 
 val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
 val (>|=) : 'a t -> ('a -> 'b) -> 'b t
@@ -2039,16 +2033,13 @@ val (<?>) : 'a t -> 'a t -> 'a t
 val (<&>) : unit t -> unit t -> unit t
 val (=<<) : ('a -> 'b t) -> 'a t -> 'b t
 val (=|<) : ('a -> 'b) -> 'a t -> 'b t
-(** Use the operators in module {{: #MODULEInfix} [Lwt.Infix]} instead. Using
-    these instances of the operators directly requires opening module [Lwt],
-    which brings an excessive number of other names into scope. *)
 
 
 
 (** {3 Miscellaneous} *)
 
 val is_sleeping : _ t -> bool
-(** [Lwt.is_sleeping p] is equivalent to {!Lwt.state}[ p = Lwt.Sleep]. *)
+(** [Lwt.is_sleeping p] is equivalent to {!val:Lwt.state}[ p = Lwt.Sleep]. *)
 
 val ignore_result : _ t -> unit
 (** An obsolete variant of {!Lwt.async}.
@@ -2066,7 +2057,7 @@ val ignore_result : _ t -> unit
     - The behavior is different depending on whether [p] is rejected now or
       later.
     - The name is misleading, and has led to users thinking this function is
-      analogous to [Stdlib.ignore], i.e. that it waits for [p] to become
+      analogous to {!Stdlib.ignore}, i.e. that it waits for [p] to become
       resolved, completing any associated side effects along the way. In fact,
       the function that does {e that} is ordinary {!Lwt.bind}. *)
 

--- a/src/core/lwt_mvar.mli
+++ b/src/core/lwt_mvar.mli
@@ -28,7 +28,7 @@
 
 (** Mailbox variables *)
 
-(** "Mailbox" variables implement a synchronising variable, used for
+(** “Mailbox” variables implement a synchronising variable, used for
     communication between concurrent threads. *)
 
 type 'a t

--- a/src/core/lwt_pqueue.mli
+++ b/src/core/lwt_pqueue.mli
@@ -6,11 +6,11 @@
 (** Functional priority queues (deprecated).
 
     A priority queue maintains, in the abstract sense, a set of elements in
-    order, and supports fast lookup and removal of the first ("minimum")
+    order, and supports fast lookup and removal of the first (“minimum”)
     element. This is used in Lwt for organizing threads that are waiting for
     timeouts.
 
-    The priority queues in this module preserve "duplicates": elements that
+    The priority queues in this module preserve “duplicates”: elements that
     compare equal in their order.
 
     @deprecated This module is an internal implementation detail of Lwt, and may

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -45,10 +45,8 @@ val create : unit -> 'a t * ('a option -> unit)
 (** [create ()] returns a new stream and a push function.
 
     To notify the stream's consumer of errors, either use a separate
-    communication channel, or use a
-    {{:https://ocaml.org/api/Stdlib.html#TYPEresult}
-    [result]} stream. There is no way to push an exception into a
-    push-stream. *)
+    communication channel, or use a {!Stdlib.result} stream. There is
+    no way to push an exception into a push-stream. *)
 
 val create_with_reference : unit -> 'a t * ('a option -> unit) * ('b -> unit)
 (** [create_with_reference ()] returns a new stream and a push
@@ -78,22 +76,22 @@ class type ['a] bounded_push = object
   (** Change the size of the stream queue. Note that the new size
       can smaller than the current stream queue size.
 
-      It raises [Invalid_argument] if [size < 0]. *)
+      It raises {!Stdlib.Invalid_argument} if [size < 0]. *)
 
   method push : 'a -> unit Lwt.t
   (** Pushes a new element to the stream. If the stream is full then
       it will block until one element is consumed. If another thread
-      is already blocked on {!push}, it raises {!Full}. *)
+      is already blocked on [push], it raises {!Lwt_stream.Full}. *)
 
   method close : unit
-  (** Closes the stream. Any thread currently blocked on {!push}
-      fails with {!Closed}. *)
+  (** Closes the stream. Any thread currently blocked on
+      {!Lwt_stream.bounded_push.push} fails with {!Lwt_stream.Closed}. *)
 
   method count : int
   (** Number of elements in the stream queue. *)
 
   method blocked : bool
-  (** Is a thread is blocked on {!push} ? *)
+  (** Is a thread is blocked on {!Lwt_stream.bounded_push.push} ? *)
 
   method closed : bool
   (** Is the stream closed ? *)

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -236,11 +236,7 @@ val junk_while_s : ('a -> bool Lwt.t) -> 'a t -> unit Lwt.t
 
 val junk_old : 'a t -> unit Lwt.t
 (** [junk_old st] removes all elements that are ready to be read
-    without yielding from [st].
-
-    For example, the [read_password] function of [Lwt_read_line]
-    uses it to flush keys previously typed by the user.
-*)
+    without yielding from [st]. *)
 
 val get_available : 'a t -> 'a list
 (** [get_available st] returns all available elements of [l] without
@@ -395,7 +391,11 @@ val hexdump : char t -> string t
     Basically, here is a simple implementation of [hexdump -C]:
 
     {[
-      let () = Lwt_main.run (Lwt_io.write_lines Lwt_io.stdout (Lwt_stream.hexdump (Lwt_io.read_lines Lwt_io.stdin)))
+      let () = Lwt_main.run begin
+          Lwt_io.write_lines
+            Lwt_io.stdout
+            (Lwt_stream.hexdump (Lwt_io.read_lines Lwt_io.stdin))
+        end
     ]}
 *)
 

--- a/src/react/lwt_react.mli
+++ b/src/react/lwt_react.mli
@@ -31,7 +31,7 @@ module E : sig
   val next : 'a event -> 'a Lwt.t
   (** [next e] returns the next occurrence of [e].
 
-      Avoid trying to create an "asynchronous loop" by calling [next e] again in
+      Avoid trying to create an “asynchronous loop” by calling [next e] again in
       a callback attached to the promise returned by [next e]:
 
       - The callback is called within the React update step, so calling [next e]
@@ -40,7 +40,7 @@ module E : sig
       - If you instead arrange for the React update step to end (for example, by
         calling [Lwt.pause ()] within the callback), multiple React update steps
         may occur before the callback calls [next e] again, so some occurrences
-        can be effectively "lost."
+        can be effectively “lost.”
 
       To robustly asynchronously process occurrences of [e] in a loop, use
       [to_stream e], and repeatedly call {!Lwt_stream.next} on the resulting

--- a/src/react/lwt_react.mli
+++ b/src/react/lwt_react.mli
@@ -66,7 +66,7 @@ module E : sig
         value is available on the stream.
 
         If updating the event causes an exception at any point during the update
-        step, the excpetion is passed to [!]{!Lwt.async_exception_hook}, which
+        step, the exception is passed to [!]{!Lwt.async_exception_hook}, which
         terminates the process by default. *)
 
   val delay : 'a event Lwt.t -> 'a event

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -463,10 +463,10 @@ struct
            linking with -lpthread fails. So, try to link the test code without
            any flags first.
 
-           If that fails and we are not targetting Android, try to link with
+           If that fails and we are not targeting Android, try to link with
            -lpthread. If *that* fails, search for libpthread in the filesystem.
 
-           When targetting Android, compiling without -lpthread is the only way
+           When targeting Android, compiling without -lpthread is the only way
            to link with pthread, and we don't to search for libpthread, because
            if we find it, it is likely the host's libpthread. *)
         match compiles context code with

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -144,7 +144,7 @@ class libev : ?backend:Ev_backend.t -> unit -> object
     (** Returns [loop]. *)
 end
 
-(** Engine based on [Unix.select]. *)
+(** Engine based on {!Unix.select}. *)
 class select : t
 
 (** Abstract class for engines based on a select-like function. *)

--- a/src/unix/lwt_fmt.mli
+++ b/src/unix/lwt_fmt.mli
@@ -7,10 +7,9 @@
 
     @since 4.1.0 *)
 
-(** This module bridges the gap between
-    {{:https://ocaml.org/api/Format.html} [Format]}
-    and {!Lwt}. Although it is not required, it is recommended to use this
-    module with the {{:http://erratique.ch/software/fmt} [Fmt]} library.
+(** This module bridges the gap between {!Stdlib.Format} and {!Lwt}.
+    Although it is not required, it is recommended to use this module
+    with the {{:http://erratique.ch/software/fmt} [Fmt]} library.
 
     Compared to regular formatting function, the main difference is that
     printing statements will now return promises instead of blocking.
@@ -18,15 +17,11 @@
 
 val printf : ('a, Format.formatter, unit, unit Lwt.t) format4 -> 'a
 (** Returns a promise that prints on the standard output.
-    Similar to
-    {{:https://ocaml.org/api/Format.html#VALprintf}
-    [Format.printf]}. *)
+    Similar to {!Stdlib.Format.printf}. *)
 
 val eprintf : ('a, Format.formatter, unit, unit Lwt.t) format4 -> 'a
 (** Returns a promise that prints on the standard error.
-    Similar to
-    {{:https://ocaml.org/api/Format.html#VALeprintf}
-    [Format.eprintf]}. *)
+    Similar to {!Stdlib.Format.eprintf}. *)
 
 (** {1 Formatters} *)
 
@@ -55,16 +50,14 @@ val stderr : formatter
 val make_formatter :
   commit:(unit -> unit Lwt.t) -> fmt:Format.formatter -> unit -> formatter
 (** [make_formatter ~commit ~fmt] creates a new lwt formatter based on the
-    {{:https://ocaml.org/api/Format.html#TYPEformatter}
-    [Format.formatter]} [fmt]. The [commit] function will be called by the
+    {!Stdlib.Format.formatter} [fmt]. The [commit] function will be called by the
     printing functions to update the underlying channel.
 *)
 
 val get_formatter : formatter -> Format.formatter
-(** [get_formatter fmt] returns the underlying
-    {{:https://ocaml.org/api/Format.html#TYPEformatter}
-    [Format.formatter]}. To access the underlying formatter during printing, it
-    isvrecommended to use [%t] and [%a].
+(** [get_formatter fmt] returns the underlying {!Stdlib.Format.formatter}.
+    To access the underlying formatter during printing, it
+    is recommended to use [%t] and [%a].
 *)
 
 (** {2 Printing} *)
@@ -82,10 +75,8 @@ val ikfprintf :
   formatter -> ('b, Format.formatter, unit, 'a) format4 -> 'b
 
 val flush : formatter -> unit Lwt.t
-(** [flush fmt] flushes the formatter (as with
-    {{:https://ocaml.org/api/Format.html#VALpp_print_flush}
-    [Format.pp_print_flush]}) and
-    executes all the printing action on the underlying channel.
+(** [flush fmt] flushes the formatter (as with {!Stdlib.Format.pp_print_flush})
+    and executes all the printing action on the underlying channel.
 *)
 
 

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -28,7 +28,7 @@
     Note about errors: input functions of this module raise
     [End_of_file] when the end-of-file is reached (i.e. when the read
     function returns [0]). Other exceptions are ones caused by the
-    backend read/write functions, such as [Unix.Unix_error].
+    backend read/write functions, such as {!Unix.Unix_error}.
 *)
 
 exception Channel_closed of string
@@ -118,7 +118,7 @@ val make :
       @param close close function of the channel. It defaults to
       [Lwt.return]
 
-      @param seek same meaning as [Unix.lseek]
+      @param seek same meaning as {!Unix.lseek}
 
       @param mode either {!input} or {!output}
 
@@ -275,17 +275,15 @@ val read_into_exactly_bigstring : input_channel -> Lwt_bytes.t -> int -> int -> 
 
 val read_value : input_channel -> 'a Lwt.t
 (** [read_value channel] reads a marshaled value from [channel]; it corresponds
-    to the standard library's
-    {{:https://ocaml.org/api/Marshal.html#VALfrom_channel} [Marshal.from_channel]}.
-    The corresponding writing function is {!write_value}.
+    to the standard library's {!Stdlib.Marshal.from_channel}. The corresponding
+    writing function is {!write_value}.
 
     Note that reading marshaled values is {e not}, in general, type-safe. See
-    the warning in the description of module
-    {{:https://ocaml.org/api/Marshal.html}
-    [Marshal]} for details. The short version is: if you read a value of one
-    type, such as [string], when a value of another type, such as [int] has
-    actually been marshaled to [channel], you may get arbitrary behavior,
-    including segmentation faults, access violations, security bugs, etc. *)
+    the warning in the description of module {!Stdlib.Marshal} for details. The
+    short version is: if you read a value of one type, such as [string], when a
+    value of another type, such as [int] has actually been marshaled to
+    [channel], you may get arbitrary behavior, including segmentation faults,
+    access violations, security bugs, etc. *)
 
 (** {2 Writing} *)
 
@@ -336,9 +334,8 @@ val write_from_string_exactly :
 val write_value :
   output_channel -> ?flags : Marshal.extern_flags list -> 'a -> unit Lwt.t
 (** [write_value channel ?flags v] writes [v] to [channel] using the [Marshal]
-    module of the standard library. See
-    {{:https://ocaml.org/api/Marshal.html#VALto_channel}
-    [Marshal.to_channel]} for an explanation of [?flags].
+    module of the standard library. See {!Stdlib.Marshal.to_channel} for an
+    explanation of [?flags].
 
     The corresponding reading function is {!read_value}. See warnings about type
     safety in the description of {!read_value}. *)
@@ -421,8 +418,7 @@ val open_file :
     If [~buffer] is supplied, it is used as the I/O buffer.
 
     If [~flags] is supplied, the file is opened with the given flags (see
-    {{: https://ocaml.org/api/Unix.html#TYPEopen_flag}
-    [Unix.open_flag]}). Note that [~flags] is used {e exactly} as given. For
+    {!Unix.open_flag}). Note that [~flags] is used {e exactly} as given. For
     example, opening a file with [~flags] and [~mode:Input] does {e not}
     implicitly add [O_RDONLY]. So, you should include [O_RDONLY] when opening
     for reading ([~mode:Input]), and [O_WRONLY] when opening for writing
@@ -436,7 +432,7 @@ val open_file :
     Note: if opening for writing ([~mode:Output]), and the file already exists,
     [open_file] truncates (clears) the file by default. If you would like to
     keep the pre-existing contents of the file, use the [~flags] parameter to
-    pass a custom flags list that does not include [Unix.O_TRUNC].
+    pass a custom flags list that does not include {!Unix.O_TRUNC}.
 
     @raise Unix.Unix_error on error. *)
 
@@ -482,12 +478,9 @@ val open_temp_file :
     file.
 
     [?temp_dir] can be used to choose the directory in which the file is
-    created. For the current directory, use
-    {{: https://ocaml.org/api/Filename.html#VALcurrent_dir_name}
-    [Filename.current_dir_name]}. If not specified, the directory is taken from
-    {{: https://ocaml.org/api/Filename.html#VALget_temp_dir_name}
-    [Filename.get_temp_dir_name]}, which is typically set to your system
-    temporary file directory.
+    created. For the current directory, use {!Stdlib.Filename.current_dir_name}.
+    If not specified, the directory is taken from {!Stdlib.Filename.get_temp_dir_name},
+    which is typically set to your system temporary file directory.
 
     [?prefix] helps determine the name of the file. It will be the prefix
     concatenated with a random sequence of characters. If not specified,
@@ -739,7 +732,7 @@ type byte_order = Lwt_sys.byte_order = Little_endian | Big_endian
     (** Type of byte order *)
 
 val system_byte_order : byte_order
-  (** Same as {!Lwt_sys.byte_order}. *)
+  (** Same as {!val:Lwt_sys.byte_order}. *)
 
 (** {2 Low-level access to the internal buffer} *)
 
@@ -768,7 +761,7 @@ type direct_access = {
 }
 
 val direct_access : 'a channel -> (direct_access -> 'b Lwt.t) -> 'b Lwt.t
-  (** [direct_access ch f] passes to [f] a {!direct_access}
+  (** [direct_access ch f] passes to [f] a {!type:direct_access}
       structure. [f] must use it and update [da_ptr] to reflect how
       many bytes have been read/written. *)
 
@@ -782,7 +775,7 @@ val set_default_buffer_size : int -> unit
   (** Change the default buffer size.
 
       @raise Invalid_argument if the given size is smaller than [16]
-      or greater than [Sys.max_string_length] *)
+      or greater than {!Stdlib.Sys.max_string_length} *)
 
 (** {2 Deprecated} *)
 

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -63,8 +63,8 @@ val abandon_yielded_and_paused : unit -> unit
     [yield] is now deprecated in favor of the more general {!Lwt.pause}.
     Once [yield] is phased out, this function will be deprecated as well.
 
-    This is meant for use with {!Lwt.fork}, as a way to "abandon" more promise
-    chains that are pending in your process. *)
+    This is meant for use with {!Lwt_unix.fork}, as a way to "abandon" more
+    promise chains that are pending in your process. *)
 
 
 

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -63,7 +63,7 @@ val abandon_yielded_and_paused : unit -> unit
     [yield] is now deprecated in favor of the more general {!Lwt.pause}.
     Once [yield] is phased out, this function will be deprecated as well.
 
-    This is meant for use with {!Lwt_unix.fork}, as a way to "abandon" more
+    This is meant for use with {!Lwt_unix.fork}, as a way to “abandon” more
     promise chains that are pending in your process. *)
 
 

--- a/src/unix/lwt_process.ml
+++ b/src/unix/lwt_process.ml
@@ -21,7 +21,7 @@ type redirection =
   | `FD_move of Unix.file_descr ]
 
 (* +-----------------------------------------------------------------+
-   | OS-depentent command spawning                                   |
+   | OS-dependent command spawning                                   |
    +-----------------------------------------------------------------+ *)
 
 type proc = {

--- a/src/unix/lwt_process.mli
+++ b/src/unix/lwt_process.mli
@@ -53,22 +53,17 @@ val shell : string -> command
 (** {3 Redirections} *)
 
 type redirection =
-    [ `Keep
-    | `Dev_null
-    | `Close
-    | `FD_copy of Unix.file_descr
-    | `FD_move of Unix.file_descr]
+    [ `Keep                     (** Point to the same file as in the parent. *)
+    | `Dev_null                 (** Redirect to [/dev/null] (POSIX) or [nul] (Win32). *)
+    | `Close                    (** Close the file descriptor. *)
+    | `FD_copy of Unix.file_descr (** Redirect to the file pointed to by [fd].
+                                      [fd] remains open in the parent.  *)
+    | `FD_move of Unix.file_descr (** Redirect to the file pointed to by [fd].
+                                      [fd] is then closed in the parent. *)
+    ]
 (** File descriptor redirections. These are used with the [~stdin], [~stdout],
     and [~stderr] arguments below to specify how the standard file descriptors
     should be redirected in the child process.
-
-    - [`Keep]: point to the same file as in the parent.
-    - [`Dev_null]: redirect to [/dev/null] (POSIX) or [nul] (Win32).
-    - [`Close]: close the file descriptor.
-    - [`FD_copy fd] redirect to the file pointed to by [fd]. [fd] remains open.
-    - [`FD_move fd] redirect to the file pointed to by [fd]. [fd] is then
-      closed.
-
     All optional redirection arguments default to [`Keep]. *)
 
 (** {3 Executing} *)

--- a/src/unix/lwt_process.mli
+++ b/src/unix/lwt_process.mli
@@ -44,7 +44,7 @@ val shell : string -> command
 
 (** All the following functions take an optional argument
     [timeout]. If specified, after expiration, the process will be
-    sent a [Unix.sigkill] signal and channels will be closed. When the channels
+    sent a {!Unix.sigkill} signal and channels will be closed. When the channels
     are closed, any pending I/O operations on them (such as
     {!Lwt_io.read_chars}) fail with exception {!Lwt_io.Channel_closed}. *)
 
@@ -202,7 +202,8 @@ object
 
   method terminate : unit
     (** Terminates the process. It is equivalent to [kill Sys.sigkill]
-        on Unix but also works on Windows (unlike {!kill}). *)
+        on Unix but also works on Windows
+        (unlike {!Lwt_process.process_none.kill}). *)
 
   method status : Unix.process_status Lwt.t
     (** Threads which wait for the sub-process to exit then returns its

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -6,7 +6,7 @@
 (** Cooperative system calls *)
 
 (** This modules maps system calls, like those of the standard
-    library's [Unix] module, to cooperative ones, which will not block
+    library's {!Unix} module, to cooperative ones, which will not block
     the program.
 
     The semantics of all operations is the following: if the action
@@ -42,7 +42,7 @@
 *)
 
 val handle_unix_error : ('a -> 'b Lwt.t) -> 'a -> 'b Lwt.t
-  (** Same as [Unix.handle_unix_error] but catches lwt-level
+  (** Same as {!Unix.handle_unix_error} but catches lwt-level
       exceptions *)
 
 (** {2 Sleeping} *)
@@ -88,15 +88,18 @@ val with_timeout : float -> (unit -> 'a Lwt.t) -> 'a Lwt.t
         Lwt.pick [Lwt_unix.timeout d; f ()]
       ]}
 
-      @raise Timeout 
+      @raise Timeout
       The promise [with_timeout d f] raises {!Timeout} if the promise returned
       by [f ()] takes more than [d] seconds to resolve. *)
 
 (** {2 Operations on file-descriptors} *)
 
 type file_descr
-  (** The abstract type for {b file descriptor}s. An Lwt {b file
-      descriptor} can be
+  (** The abstract type for {b file descriptor}s. A Lwt {b file
+      descriptor} is a pair of a unix {b file descriptor} (of type
+      {!Unix.file_descr}) and a {b state}.
+
+      A {b file descriptor} may be:
 
       - {b opened}, in which case it is fully usable
       - {b closed} or {b aborted}, in which case it is no longer
@@ -114,7 +117,7 @@ type state =
           possible is {!close}, all others will fail. *)
 
 val state : file_descr -> state
-  (** [state fd] returns the {!type:state} of [fd] *)
+  (** [state fd] returns the {!type:state} of [fd]. *)
 
 val unix_file_descr : file_descr -> Unix.file_descr
   (** Returns the underlying unix {b file descriptor}. It always
@@ -122,7 +125,7 @@ val unix_file_descr : file_descr -> Unix.file_descr
       [Opened]. *)
 
 val of_unix_file_descr : ?blocking : bool -> ?set_flags : bool -> Unix.file_descr -> file_descr
-(** Wraps a [Unix] file descriptor [fd] in an Lwt {!type:file_descr} [fd'].
+(** Wraps a [Unix] file descriptor [fd] in an Lwt {!file_descr} [fd'].
 
     [~blocking] controls the {e internal} strategy Lwt uses to perform I/O on
     the underlying [fd]. Regardless of [~blocking], at the API level,
@@ -158,7 +161,7 @@ val blocking : file_descr -> bool Lwt.t
 (** [blocking fd] indicates whether Lwt is internally using blocking or
     non-blocking I/O with [fd].
 
-    Note that this may differ from the blocking mode of the underlying [Unix]
+    Note that this may differ from the blocking mode of the underlying Unix
     file descriptor (i.e. [unix_file_descr fd]).
 
     See {!of_unix_file_descr} for details. *)
@@ -190,8 +193,8 @@ val abort : file_descr -> exn -> unit
 (** {2 Process handling} *)
 
 val fork : unit -> int
-  (** [fork ()] does the same as [Unix.fork]. You must use this
-      function instead of [Unix.fork] when you want to use Lwt in the
+  (** [fork ()] does the same as {!Unix.fork}. You must use this
+      function instead of {!Unix.fork} when you want to use Lwt in the
       child process, even if you have not started using Lwt before the fork.
 
       Notes:
@@ -207,7 +210,7 @@ val fork : unit -> int
         during process exit.
       - None of the above is necessary if you intend to call [exec]. Indeed, in
         that case, it is not even necessary to use [Lwt_unix.fork]. You can use
-        [Unix.fork].
+        {!Unix.fork}.
       - To abandon some more promises, see
         {!Lwt_main.abandon_yielded_and_paused}. *)
 
@@ -223,13 +226,12 @@ type wait_flag =
   | WUNTRACED
 
 val wait : unit -> (int * process_status) Lwt.t
-  (** Wrapper for [Unix.wait] *)
+  (** Wrapper for {!Unix.wait} *)
 
 val waitpid : wait_flag list -> int -> (int * process_status) Lwt.t
-(** A promise-returning analog to
-    {{: https://ocaml.org/api/Unix.html#VALwaitpid}
-    [Unix.waitpid]}. This call is non-blocking on Unix-like systems, but is
-    always blocking on Windows. *)
+(** A promise-returning analog to {!Unix.waitpid}. This call is
+    non-blocking on Unix-like systems, but is always blocking on
+    Windows. *)
 
 (** Resource usages *)
 type resource_usage = {
@@ -291,7 +293,7 @@ type open_flag =
 #endif
 
 val openfile : string -> open_flag list -> file_perm -> file_descr Lwt.t
-  (** Wrapper for [Unix.openfile]. *)
+  (** Wrapper for {!Unix.openfile}. *)
 
 val close : file_descr -> unit Lwt.t
   (** Close a {b file descriptor}. This close the underlying unix {b
@@ -311,9 +313,9 @@ val read : file_descr -> bytes -> int -> int -> int Lwt.t
     If Lwt is using blocking I/O on [fd], [read] writes data into a temporary
     buffer, then copies it into [buf].
 
-    The promise can be rejected with any exception that can be raised by
-    [Unix.read], except [Unix.Unix_error Unix.EAGAIN],
-    [Unix.Unix_error Unix.EWOULDBLOCK] or [Unix.Unix_error Unix.EINTR]. *)
+    The promise can be rejected with any exception that can be raised by {!Unix.read},
+    except [Unix.Unix_error Unix.EAGAIN], [Unix.Unix_error Unix.EWOULDBLOCK] or
+    [Unix.Unix_error Unix.EINTR]. *)
 
 val pread : file_descr -> bytes -> file_offset:int -> int -> int -> int Lwt.t
 (** [pread fd buf ~file_offset ofs len] on file descriptors allowing seek,
@@ -340,7 +342,7 @@ val write : file_descr -> bytes -> int -> int -> int Lwt.t
     If Lwt is using blocking I/O on [fd], [buf] is copied before writing.
 
     The promise can be rejected with any exception that can be raised by
-    [Unix.single_write], except [Unix.Unix_error Unix.EAGAIN],
+    {!Unix.single_write}, except [Unix.Unix_error Unix.EAGAIN],
     [Unix.Unix_error Unix.EWOULDBLOCK] or [Unix.Unix_error Unix.EINTR]. *)
 
 val pwrite : file_descr -> bytes -> file_offset:int -> int -> int -> int Lwt.t
@@ -509,13 +511,13 @@ type seek_command =
   | SEEK_END
 
 val lseek : file_descr -> int -> seek_command -> int Lwt.t
-  (** Wrapper for [Unix.lseek] *)
+  (** Wrapper for {!Unix.lseek} *)
 
 val truncate : string -> int -> unit Lwt.t
-  (** Wrapper for [Unix.truncate] *)
+  (** Wrapper for {!Unix.truncate} *)
 
 val ftruncate : file_descr -> int -> unit Lwt.t
-  (** Wrapper for [Unix.ftruncate] *)
+  (** Wrapper for {!Unix.ftruncate} *)
 
 (** {2 Syncing} *)
 
@@ -559,27 +561,25 @@ type stats =
     }
 
 val stat : string -> stats Lwt.t
-  (** Wrapper for [Unix.stat] *)
+  (** Wrapper for {!Unix.stat} *)
 
 val lstat : string -> stats Lwt.t
-  (** Wrapper for [Unix.lstat] *)
+  (** Wrapper for {!Unix.lstat} *)
 
 val fstat : file_descr -> stats Lwt.t
-  (** Wrapper for [Unix.fstat] *)
+  (** Wrapper for {!Unix.fstat} *)
 
 val file_exists : string -> bool Lwt.t
   (** [file_exists name] tests if a file named [name] exists.
 
       Note that [file_exists] behaves similarly to
-      {{:https://ocaml.org/api/Sys.html#VALfile_exists}
-      [Sys.file_exists]}:
+      {!Sys.file_exists}:
 
       - "file" is interpreted as "directory entry" in this context
 
       - [file_exists name] will return [false] in
         circumstances that would make {!stat} raise a
-        {{:https://ocaml.org/api/Unix.html#EXCEPTIONUnix_error}
-        [Unix.Unix_error]} exception.
+        {!Unix.Unix_error} exception.
      *)
 
 val utimes : string -> float -> float -> unit Lwt.t
@@ -587,27 +587,25 @@ val utimes : string -> float -> float -> unit Lwt.t
     file at [path]. The access time is set to [atime] and the modification time
     to [mtime]. To set both to the current time, call [utimes path 0. 0.].
 
-    This function corresponds to
-    {{:https://ocaml.org/api/Unix.html#VALutimes}
-    [Unix.utimes]}. See also
+    This function corresponds to {!Unix.utimes}. See also
     {{:http://man7.org/linux/man-pages/man3/utimes.3p.html} [utimes(3p)]}.
 
     @since 2.6.0 *)
 
 val isatty : file_descr -> bool Lwt.t
-  (** Wrapper for [Unix.isatty] *)
+  (** Wrapper for {!Unix.isatty} *)
 
 (** {2 File operations on large files} *)
 
 module LargeFile : sig
   val lseek : file_descr -> int64 -> seek_command -> int64 Lwt.t
-    (** Wrapper for [Unix.LargeFile.lseek] *)
+    (** Wrapper for {!Unix.LargeFile.lseek} *)
 
   val truncate : string -> int64 -> unit Lwt.t
-    (** Wrapper for [Unix.LargeFile.truncate] *)
+    (** Wrapper for {!Unix.LargeFile.truncate} *)
 
   val ftruncate : file_descr -> int64 -> unit Lwt.t
-    (** Wrapper for [Unix.LargeFile.ftruncate] *)
+    (** Wrapper for {!Unix.LargeFile.ftruncate} *)
 
   type stats =
       Unix.LargeFile.stats =
@@ -627,54 +625,52 @@ module LargeFile : sig
       }
 
   val stat : string -> stats Lwt.t
-    (** Wrapper for [Unix.LargeFile.stat] *)
+    (** Wrapper for {!Unix.LargeFile.stat} *)
 
   val lstat : string -> stats Lwt.t
-    (** Wrapper for [Unix.LargeFile.lstat] *)
+    (** Wrapper for {!Unix.LargeFile.lstat} *)
 
   val fstat : file_descr -> stats Lwt.t
-    (** Wrapper for [Unix.LargeFile.fstat] *)
+    (** Wrapper for {!Unix.LargeFile.fstat} *)
 
   val file_exists : string -> bool Lwt.t
     (** [file_exists name] tests if a file named [name] exists.
 
         Note that [file_exists] behaves similarly to
-        {{:https://ocaml.org/api/Sys.html#VALfile_exists}
-        [Sys.file_exists]}:
+        {!Sys.file_exists}:
 
         - "file" is interpreted as "directory entry" in this context
 
         - [file_exists name] will return [false] in
           circumstances that would make {!stat} raise a
-          {{:https://ocaml.org/api/Unix.html#EXCEPTIONUnix_error}
-          [Unix.Unix_error]} exception.
+          {!Unix.Unix_error} exception.
      *)
 end
 
 (** {2 Operations on file names} *)
 
 val unlink : string -> unit Lwt.t
-  (** Wrapper for [Unix.unlink] *)
+  (** Wrapper for {!Unix.unlink} *)
 
 val rename : string -> string -> unit Lwt.t
-  (** Wrapper for [Unix.rename] *)
+  (** Wrapper for {!Unix.rename} *)
 
 val link : string -> string -> unit Lwt.t
-  (** Wrapper for [Unix.link] *)
+  (** Wrapper for {!Unix.link} *)
 
 (** {2 File permissions and ownership} *)
 
 val chmod : string -> file_perm -> unit Lwt.t
-  (** Wrapper for [Unix.chmod] *)
+  (** Wrapper for {!Unix.chmod} *)
 
 val fchmod : file_descr -> file_perm -> unit Lwt.t
-  (** Wrapper for [Unix.fchmod] *)
+  (** Wrapper for {!Unix.fchmod} *)
 
 val chown : string -> int -> int -> unit Lwt.t
-  (** Wrapper for [Unix.chown] *)
+  (** Wrapper for {!Unix.chown} *)
 
 val fchown : file_descr -> int -> int -> unit Lwt.t
-  (** Wrapper for [Unix.fchown] *)
+  (** Wrapper for {!Unix.fchown} *)
 
 type access_permission =
     Unix.access_permission =
@@ -684,57 +680,54 @@ type access_permission =
   | F_OK
 
 val access : string -> access_permission list -> unit Lwt.t
-  (** Wrapper for [Unix.access] *)
+  (** Wrapper for {!Unix.access} *)
 
 (** {2 Operations on file descriptors} *)
 
 val dup : ?cloexec:bool ->
           file_descr -> file_descr
-  (** Wrapper for [Unix.dup] *)
+  (** Wrapper for {!Unix.dup} *)
 
 val dup2 : ?cloexec:bool ->
            file_descr -> file_descr -> unit
-  (** Wrapper for [Unix.dup2] *)
+  (** Wrapper for {!Unix.dup2} *)
 
 val set_close_on_exec : file_descr -> unit
-  (** Wrapper for [Unix.set_close_on_exec] *)
+  (** Wrapper for {!Unix.set_close_on_exec} *)
 
 val clear_close_on_exec : file_descr -> unit
-  (** Wrapper for [Unix.clear_close_on_exec] *)
+  (** Wrapper for {!Unix.clear_close_on_exec} *)
 
 (** {2 Directories} *)
 
 val mkdir : string -> file_perm -> unit Lwt.t
-  (** Wrapper for [Unix.mkdir] *)
+  (** Wrapper for {!Unix.mkdir} *)
 
 val rmdir : string -> unit Lwt.t
-  (** Wrapper for [Unix.rmdir] *)
+  (** Wrapper for {!Unix.rmdir} *)
 
 val chdir : string -> unit Lwt.t
-  (** Wrapper for [Unix.chdir] *)
+  (** Wrapper for {!Unix.chdir} *)
 
 val getcwd : unit -> string Lwt.t
-(** Wrapper for [Unix.getcwd]
+(** Wrapper for {!Unix.getcwd}
 
     @since 3.1.0 *)
 
 val chroot : string -> unit Lwt.t
-  (** Wrapper for [Unix.chroot] *)
+  (** Wrapper for {!Unix.chroot} *)
 
 type dir_handle = Unix.dir_handle
 
 val opendir : string -> dir_handle Lwt.t
 (** Opens a directory for listing. Directories opened with this function must be
     explicitly closed with {!closedir}. This is a cooperative analog of
-    {{:https://ocaml.org/api/Unix.html#VALopendir}
-    [Unix.opendir]}. *)
+    {!Unix.opendir}. *)
 
 val readdir : dir_handle -> string Lwt.t
 (** Reads the next directory entry from the given directory. Special entries
     such as [.] and [..] are included. If all entries have been read, raises
-    [End_of_file]. This is a cooperative analog of
-    {{:https://ocaml.org/api/Unix.html#VALreaddir}
-    [Unix.readdir]}. *)
+    [End_of_file]. This is a cooperative analog of {!Unix.readdir}. *)
 
 val readdir_n : dir_handle -> int -> string array Lwt.t
   (** [readdir_n handle count] reads at most [count] entries from the
@@ -745,14 +738,10 @@ val readdir_n : dir_handle -> int -> string array Lwt.t
 
 val rewinddir : dir_handle -> unit Lwt.t
 (** Resets the given directory handle, so that directory listing can be
-    restarted. Cooperative analog of
-    {{:https://ocaml.org/api/Unix.html#VALrewinddir}
-    [Unix.rewinddir]}. *)
+    restarted. Cooperative analog of {!Unix.rewinddir}. *)
 
 val closedir : dir_handle -> unit Lwt.t
-(** Closes a directory handle. Cooperative analog of
-    {{:https://ocaml.org/api/Unix.html#VALclosedir}
-    [Unix.closedir]}. *)
+(** Closes a directory handle. Cooperative analog of {!Unix.closedir}. *)
 
 val files_of_directory : string -> string Lwt_stream.t
   (** [files_of_directory dir] returns the stream of all files of
@@ -762,7 +751,7 @@ val files_of_directory : string -> string Lwt_stream.t
 
 val pipe : ?cloexec:bool ->
            unit -> file_descr * file_descr
-  (** [pipe ()] creates pipe using [Unix.pipe] and returns two lwt {b
+  (** [pipe ()] creates pipe using {!Unix.pipe} and returns two lwt {b
       file descriptor}s created from unix {b file_descriptor} *)
 
 val pipe_in : ?cloexec:bool ->
@@ -778,15 +767,15 @@ val pipe_out : ?cloexec:bool ->
       use this before forking to send data to the child process *)
 
 val mkfifo : string -> file_perm -> unit Lwt.t
-  (** Wrapper for [Unix.mkfifo] *)
+  (** Wrapper for {!Unix.mkfifo} *)
 
 (** {2 Symbolic links} *)
 
 val symlink : ?to_dir:bool -> string -> string -> unit Lwt.t
-  (** Wrapper for [Unix.symlink] *)
+  (** Wrapper for {!Unix.symlink} *)
 
 val readlink : string -> string Lwt.t
-  (** Wrapper for [Unix.readlink] *)
+  (** Wrapper for {!Unix.readlink} *)
 
 (** {2 Locking} *)
 
@@ -800,7 +789,7 @@ type lock_command =
   | F_TRLOCK
 
 val lockf : file_descr -> lock_command -> int -> unit Lwt.t
-  (** Wrapper for [Unix.lockf] *)
+  (** Wrapper for {!Unix.lockf} *)
 
 (** {2 User id, group id} *)
 
@@ -826,19 +815,19 @@ type group_entry =
   }
 
 val getlogin : unit -> string Lwt.t
-  (** Wrapper for [Unix.getlogin] *)
+  (** Wrapper for {!Unix.getlogin} *)
 
 val getpwnam : string -> passwd_entry Lwt.t
-  (** Wrapper for [Unix.getpwnam] *)
+  (** Wrapper for {!Unix.getpwnam} *)
 
 val getgrnam : string -> group_entry Lwt.t
-  (** Wrapper for [Unix.getgrnam] *)
+  (** Wrapper for {!Unix.getgrnam} *)
 
 val getpwuid : int -> passwd_entry Lwt.t
-  (** Wrapper for [Unix.getpwuid] *)
+  (** Wrapper for {!Unix.getpwuid} *)
 
 val getgrgid : int -> group_entry Lwt.t
-  (** Wrapper for [Unix.getgrgid] *)
+  (** Wrapper for {!Unix.getgrgid} *)
 
 (** {2 Signals} *)
 
@@ -888,27 +877,26 @@ type sockaddr = Unix.sockaddr = ADDR_UNIX of string | ADDR_INET of inet_addr * i
 
 val socket : ?cloexec:bool ->
              socket_domain -> socket_type -> int -> file_descr
-  (** [socket domain type proto] is the same as [Unix.socket] but maps
+  (** [socket domain type proto] is the same as {!Unix.socket} but maps
       the result into a lwt {b file descriptor} *)
 
 val socketpair : ?cloexec:bool ->
                  socket_domain -> socket_type -> int -> file_descr * file_descr
-  (** Wrapper for [Unix.socketpair] *)
+  (** Wrapper for {!Unix.socketpair} *)
 
 val bind : file_descr -> sockaddr -> unit Lwt.t
 (** Binds an address to the given socket. This is the cooperative analog of
-    {{:https://ocaml.org/api/Unix.html#VALbind}
-    [Unix.bind]}. See also
+    {!Unix.bind}. See also
     {{:http://man7.org/linux/man-pages/man3/bind.3p.html} [bind(3p)]}.
 
     @since 3.0.0 *)
 
 val listen : file_descr -> int -> unit
-  (** Wrapper for [Unix.listen] *)
+  (** Wrapper for {!Unix.listen} *)
 
 val accept : ?cloexec:bool ->
              file_descr -> (file_descr * sockaddr) Lwt.t
-  (** Wrapper for [Unix.accept] *)
+  (** Wrapper for {!Unix.accept} *)
 
 val accept_n : ?cloexec:bool ->
                file_descr -> int -> ((file_descr * sockaddr) list * exn option) Lwt.t
@@ -931,7 +919,7 @@ val accept_n : ?cloexec:bool ->
       {{:http://portal.acm.org/citation.cfm?id=1247435}Acceptable strategies for improving web server performance} *)
 
 val connect : file_descr -> sockaddr -> unit Lwt.t
-  (** Wrapper for [Unix.connect] *)
+  (** Wrapper for {!Unix.connect} *)
 
 type shutdown_command =
     Unix.shutdown_command =
@@ -940,13 +928,13 @@ type shutdown_command =
   | SHUTDOWN_ALL
 
 val shutdown : file_descr -> shutdown_command -> unit
-  (** Wrapper for [Unix.shutdown] *)
+  (** Wrapper for {!Unix.shutdown} *)
 
 val getsockname : file_descr -> sockaddr
-  (** Wrapper for [Unix.getsockname] *)
+  (** Wrapper for {!Unix.getsockname} *)
 
 val getpeername : file_descr -> sockaddr
-  (** Wrapper for [Unix.getpeername] *)
+  (** Wrapper for {!Unix.getpeername} *)
 
 type msg_flag =
     Unix.msg_flag =
@@ -955,24 +943,24 @@ type msg_flag =
   | MSG_PEEK
 
 val recv : file_descr -> bytes -> int -> int -> msg_flag list -> int Lwt.t
-(** Wrapper for [Unix.recv].
+(** Wrapper for {!Unix.recv}.
 
     On Windows, [recv] writes data into a temporary buffer, then copies it into
     the given one. *)
 
 val recvfrom : file_descr -> bytes -> int -> int -> msg_flag list -> (int * sockaddr) Lwt.t
-(** Wrapper for [Unix.recvfrom].
+(** Wrapper for {!Unix.recvfrom}.
 
     On Windows, [recvfrom] writes data into a temporary buffer, then copies it
     into the given one. *)
 
 val send : file_descr -> bytes -> int -> int -> msg_flag list -> int Lwt.t
-(** Wrapper for [Unix.send].
+(** Wrapper for {!Unix.send}.
 
     On Windows, [send] copies the given buffer before writing. *)
 
 val sendto : file_descr -> bytes -> int -> int -> msg_flag list -> sockaddr -> int Lwt.t
-(** Wrapper for [Unix.sendto].
+(** Wrapper for {!Unix.sendto}.
 
     On Windows, [sendto] copies the given buffer before writing. *)
 
@@ -1070,31 +1058,31 @@ type socket_float_option =
     for timeouts. *)
 
 val getsockopt : file_descr -> socket_bool_option -> bool
-  (** Wrapper for [Unix.getsockopt] *)
+  (** Wrapper for {!Unix.getsockopt} *)
 
 val setsockopt : file_descr -> socket_bool_option -> bool -> unit
-  (** Wrapper for [Unix.setsockopt] *)
+  (** Wrapper for {!Unix.setsockopt} *)
 
 val getsockopt_int : file_descr -> socket_int_option -> int
-  (** Wrapper for [Unix.getsockopt_int] *)
+  (** Wrapper for {!Unix.getsockopt_int} *)
 
 val setsockopt_int : file_descr -> socket_int_option -> int -> unit
-  (** Wrapper for [Unix.setsockopt_int] *)
+  (** Wrapper for {!Unix.setsockopt_int} *)
 
 val getsockopt_optint : file_descr -> socket_optint_option -> int option
-  (** Wrapper for [Unix.getsockopt_optint] *)
+  (** Wrapper for {!Unix.getsockopt_optint} *)
 
 val setsockopt_optint : file_descr -> socket_optint_option -> int option -> unit
-  (** Wrapper for [Unix.setsockopt_optint] *)
+  (** Wrapper for {!Unix.setsockopt_optint} *)
 
 val getsockopt_float : file_descr -> socket_float_option -> float
-  (** Wrapper for [Unix.getsockopt_float] *)
+  (** Wrapper for {!Unix.getsockopt_float} *)
 
 val setsockopt_float : file_descr -> socket_float_option -> float -> unit
-  (** Wrapper for [Unix.setsockopt_float] *)
+  (** Wrapper for {!Unix.setsockopt_float} *)
 
 val getsockopt_error : file_descr -> Unix.error option
-  (** Wrapper for [Unix.getsockopt_error] *)
+  (** Wrapper for {!Unix.getsockopt_error} *)
 
 (** {3 Multicast functions} *)
 
@@ -1141,25 +1129,25 @@ type service_entry =
     }
 
 val gethostname : unit -> string Lwt.t
-  (** Wrapper for [Unix.gethostname] *)
+  (** Wrapper for {!Unix.gethostname} *)
 
 val gethostbyname : string -> host_entry Lwt.t
-  (** Wrapper for [Unix.gethostbyname] *)
+  (** Wrapper for {!Unix.gethostbyname} *)
 
 val gethostbyaddr : inet_addr -> host_entry Lwt.t
-  (** Wrapper for [Unix.gethostbyaddr] *)
+  (** Wrapper for {!Unix.gethostbyaddr} *)
 
 val getprotobyname : string -> protocol_entry Lwt.t
-  (** Wrapper for [Unix.getprotobyname] *)
+  (** Wrapper for {!Unix.getprotobyname} *)
 
 val getprotobynumber : int -> protocol_entry Lwt.t
-  (** Wrapper for [Unix.getprotobynumber] *)
+  (** Wrapper for {!Unix.getprotobynumber} *)
 
 val getservbyname : string -> string -> service_entry Lwt.t
-  (** Wrapper for [Unix.getservbyname] *)
+  (** Wrapper for {!Unix.getservbyname} *)
 
 val getservbyport : int -> string -> service_entry Lwt.t
-  (** Wrapper for [Unix.getservbyport] *)
+  (** Wrapper for {!Unix.getservbyport} *)
 
 type addr_info =
     Unix.addr_info =
@@ -1181,7 +1169,7 @@ type getaddrinfo_option =
   | AI_PASSIVE
 
 val getaddrinfo : string -> string -> getaddrinfo_option list -> addr_info list Lwt.t
-  (** Wrapper for [Unix.getaddrinfo] *)
+  (** Wrapper for {!Unix.getaddrinfo} *)
 
 type name_info =
     Unix.name_info =
@@ -1199,7 +1187,7 @@ type getnameinfo_option =
   | NI_DGRAM
 
 val getnameinfo : sockaddr -> getnameinfo_option list -> name_info Lwt.t
-  (** Wrapper for [Unix.getnameinfo] *)
+  (** Wrapper for {!Unix.getnameinfo} *)
 
 (** {2 Terminal interface} *)
 
@@ -1247,7 +1235,7 @@ type terminal_io =
     }
 
 val tcgetattr : file_descr -> terminal_io Lwt.t
-  (** Wrapper for [Unix.tcgetattr] *)
+  (** Wrapper for {!Unix.tcgetattr} *)
 
 type setattr_when =
     Unix.setattr_when =
@@ -1256,13 +1244,13 @@ type setattr_when =
   | TCSAFLUSH
 
 val tcsetattr : file_descr -> setattr_when -> terminal_io -> unit Lwt.t
-  (** Wrapper for [Unix.tcsetattr] *)
+  (** Wrapper for {!Unix.tcsetattr} *)
 
 val tcsendbreak : file_descr -> int -> unit Lwt.t
-  (** Wrapper for [Unix.tcsendbreak] *)
+  (** Wrapper for {!Unix.tcsendbreak} *)
 
 val tcdrain : file_descr -> unit Lwt.t
-  (** Wrapper for [Unix.tcdrain] *)
+  (** Wrapper for {!Unix.tcdrain} *)
 
 type flush_queue =
     Unix.flush_queue =
@@ -1271,7 +1259,7 @@ type flush_queue =
   | TCIOFLUSH
 
 val tcflush : file_descr -> flush_queue -> unit Lwt.t
-  (** Wrapper for [Unix.tcflush] *)
+  (** Wrapper for {!Unix.tcflush} *)
 
 type flow_action =
     Unix.flow_action =
@@ -1281,7 +1269,7 @@ type flow_action =
   | TCION
 
 val tcflow : file_descr -> flow_action -> unit Lwt.t
-  (** Wrapper for [Unix.tcflow] *)
+  (** Wrapper for {!Unix.tcflow} *)
 
 
 

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -575,7 +575,7 @@ val file_exists : string -> bool Lwt.t
       Note that [file_exists] behaves similarly to
       {!Sys.file_exists}:
 
-      - "file" is interpreted as "directory entry" in this context
+      - “file” is interpreted as “directory entry” in this context
 
       - [file_exists name] will return [false] in
         circumstances that would make {!stat} raise a
@@ -639,7 +639,7 @@ module LargeFile : sig
         Note that [file_exists] behaves similarly to
         {!Sys.file_exists}:
 
-        - "file" is interpreted as "directory entry" in this context
+        - “file” is interpreted as “directory entry” in this context
 
         - [file_exists name] will return [false] in
           circumstances that would make {!stat} raise a

--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -205,7 +205,7 @@ struct lwt_unix_job {
     /* The function to call to extract the result and free memory
        allocated by the job.
 
-       Note: if you want to raise an excpetion, be sure to free
+       Note: if you want to raise an exception, be sure to free
        resources before raising it!
 
        It has been introduced in Lwt 2.3.3. */


### PR DESCRIPTION
This PR changes all external hyperlinks to the standard API to odoc cross-references. That way, the offline Lwt doc API will correctly refer to the offline OCaml documentation. The PR also adds more cross-references to the `Unix` library, fixes the internal references to never directly use an html anchor, and adds misc. documentation fixes.
All of this is aimed at a better odoc/odig integration.

My final goal is also to convert the manual to mld, to have it installable with the opam package and browsable with odig and odoc, but that'll come in a follow-up PR.