### PR TITLE
Don't define `CAML_NAME_SPACE`, use mlvalues macros

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@
   * Add missing dependency to `cppo` in lwt-react's opam file. (#946, Rizo I)
   * Improve documentation (especially internal links). (#928, Antonin Décimo)
   * Fix documentation of infix choose. (#952, Reynir Björnsson)
+  * Only define OCAML_NAME_SPACE for OCaml<5.0.0. (#929, Antonin Décimo)
 
 ====== Fixes ======
 

--- a/src/unix/lwt_config.h
+++ b/src/unix/lwt_config.h
@@ -31,4 +31,12 @@
 #define CAML_NAME_SPACE
 #endif
 
+#if OCAML_VERSION < 41200
+#define Val_none Val_int(0)
+#define Some_val(v) Field(v, 0)
+#define Tag_some 0
+#define Is_none(v) ((v) == Val_none)
+#define Is_some(v) Is_block(v)
+#endif
+
 #endif // #ifndef _LWT_CONFIG_H_

--- a/src/unix/lwt_config.h
+++ b/src/unix/lwt_config.h
@@ -26,4 +26,9 @@
 #define NANOSEC(buf, field) 0.0
 #endif
 
+#include <caml/version.h>
+#if OCAML_VERSION < 50000
+#define CAML_NAME_SPACE
+#endif
+
 #endif // #ifndef _LWT_CONFIG_H_

--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -10,8 +10,6 @@
 
 #if defined(HAVE_LIBEV)
 
-#define CAML_NAME_SPACE
-
 #include <assert.h>
 
 #include <caml/alloc.h>

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -3,14 +3,12 @@
 
 
 
-#include <lwt_config.h>
+#include "lwt_config.h"
 
 #if defined(LWT_ON_WINDOWS)
 
 #include <lwt_unix.h>
 
-#define CAML_NAME_SPACE
-#include <caml/version.h>
 #if OCAML_VERSION < 41300
 #define CAML_INTERNALS
 #endif

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -20,8 +20,8 @@
 
 static HANDLE get_handle(value opt) {
   value fd;
-  if (Is_block(opt)) {
-    fd = Field(opt, 0);
+  if (Is_some(opt)) {
+    fd = Some_val(opt);
     if (Descr_kind_val(fd) == KIND_SOCKET) {
       win32_maperr(ERROR_INVALID_HANDLE);
       uerror("CreateProcess", Nothing);

--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -6,11 +6,10 @@
 #ifndef __LWT_UNIX_H
 #define __LWT_UNIX_H
 
-#define CAML_NAME_SPACE
+#include "lwt_config.h"
 
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
-#include <lwt_config.h>
 
 #include <caml/socketaddr.h>
 #include <string.h>

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -8,8 +8,6 @@
 #define _GNU_SOURCE
 #define _POSIX_PTHREAD_SEMANTICS
 
-#define CAML_NAME_SPACE
-
 #include <caml/alloc.h>
 #include <caml/bigarray.h>
 #include <caml/callback.h>
@@ -19,7 +17,6 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
-#include <caml/version.h>
 
 #include <assert.h>
 #include <errno.h>

--- a/src/unix/unix_c/unix_accept4.c
+++ b/src/unix/unix_c/unix_accept4.c
@@ -20,7 +20,7 @@ CAMLprim value lwt_unix_accept4(value vcloexec, value vnonblock, value vsock)
 
     union sock_addr_union addr;
     socklen_param_type addr_len;
-    int cloexec = Is_block(vcloexec) && Bool_val(Field(vcloexec, 0)) ? SOCK_CLOEXEC : 0;
+    int cloexec = Is_some(vcloexec) && Bool_val(Some_val(vcloexec)) ? SOCK_CLOEXEC : 0;
     int nonblock = Bool_val(vnonblock) ? SOCK_NONBLOCK : 0;
     addr_len = sizeof(addr);
 

--- a/src/unix/unix_c/unix_access_job.c
+++ b/src/unix/unix_c/unix_access_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_access_job.c
+++ b/src/unix/unix_c/unix_access_job.c
@@ -49,7 +49,7 @@ static int access_permission_table[] = {
 static int int_of_access_permissions(value list)
 {
   int result = 0;
-  while (Is_block(list)) {
+  while (list != Val_emptylist) {
     result |= access_permission_table[Int_val(Field(list, 0))];
     list = Field(list, 1);
   };

--- a/src/unix/unix_c/unix_chdir_job.c
+++ b/src/unix/unix_c/unix_chdir_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_chmod_job.c
+++ b/src/unix/unix_c/unix_chmod_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_chown_job.c
+++ b/src/unix/unix_c/unix_chown_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_chroot_job.c
+++ b/src/unix/unix_c/unix_chroot_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_close_job.c
+++ b/src/unix/unix_c/unix_close_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_fchmod_job.c
+++ b/src/unix/unix_c/unix_fchmod_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_fchown_job.c
+++ b/src/unix/unix_c/unix_fchown_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_fdatasync_job.c
+++ b/src/unix/unix_c/unix_fdatasync_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_fsync_job.c
+++ b/src/unix/unix_c/unix_fsync_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_ftruncate_job.c
+++ b/src/unix/unix_c/unix_ftruncate_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_getaddrinfo_job.c
+++ b/src/unix/unix_c/unix_getaddrinfo_job.c
@@ -94,7 +94,7 @@ CAMLprim value lwt_unix_getaddrinfo_job(value node, value service, value hints)
     job->info = NULL;
     memset(&job->hints, 0, sizeof(struct addrinfo));
     job->hints.ai_family = PF_UNSPEC;
-    for (/*nothing*/; Is_block(hints); hints = Field(hints, 1)) {
+    for (/*nothing*/; hints != Val_emptylist; hints = Field(hints, 1)) {
         value v = Field(hints, 0);
         if (Is_block(v)) switch (Tag_val(v)) {
                 case 0: /* AI_FAMILY of socket_domain */

--- a/src/unix/unix_c/unix_link_job.c
+++ b/src/unix/unix_c/unix_link_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_lseek_job.c
+++ b/src/unix/unix_c/unix_lseek_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_mkdir_job.c
+++ b/src/unix/unix_c/unix_mkdir_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_mkfifo_job.c
+++ b/src/unix/unix_c/unix_mkfifo_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_pread_job.c
+++ b/src/unix/unix_c/unix_pread_job.c
@@ -11,7 +11,6 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
-#include <caml/version.h>
 #include <errno.h>
 #include <string.h>
 

--- a/src/unix/unix_c/unix_read_job.c
+++ b/src/unix/unix_c/unix_read_job.c
@@ -11,7 +11,6 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
-#include <caml/version.h>
 #include <errno.h>
 #include <string.h>
 

--- a/src/unix/unix_c/unix_recv_send_utils.c
+++ b/src/unix/unix_c/unix_recv_send_utils.c
@@ -73,11 +73,10 @@ value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
     msg.msg_iov = iovs;
     msg.msg_iovlen = n_iovs;
 
-    /* dest: Unix.sockaddr option */
-    if (Is_block(dest)) {
+    if (Is_some(dest)) {
       union sock_addr_union addr;
       socklen_t addr_len;
-      get_sockaddr(Field(dest, 0), &addr, &addr_len);
+      get_sockaddr(Some_val(dest), &addr, &addr_len);
 
       msg.msg_name = &addr.s_gen;
       msg.msg_namelen = addr_len;
@@ -97,7 +96,7 @@ value wrapper_send_msg(int fd, int n_iovs, struct iovec *iovs,
         cm->cmsg_len = CMSG_LEN(n_fds * sizeof(int));
 
         int *fds = (int *)CMSG_DATA(cm);
-        for (; Is_block(val_fds); val_fds = Field(val_fds, 1), fds++)
+        for (/*nothing*/; val_fds != Val_emptylist; val_fds = Field(val_fds, 1), fds++)
             *fds = Int_val(Field(val_fds, 0));
     };
 #else

--- a/src/unix/unix_c/unix_rename_job.c
+++ b/src/unix/unix_c/unix_rename_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_rmdir_job.c
+++ b/src/unix/unix_c/unix_rmdir_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_set_affinity.c
+++ b/src/unix/unix_c/unix_set_affinity.c
@@ -23,7 +23,7 @@ CAMLprim value lwt_unix_set_affinity(value val_pid, value val_cpus)
 {
     cpu_set_t cpus;
     CPU_ZERO(&cpus);
-    for (; Is_block(val_cpus); val_cpus = Field(val_cpus, 1))
+    for (/*nothing*/; val_cpus != Val_emptylist; val_cpus = Field(val_cpus, 1))
         CPU_SET(Int_val(Field(val_cpus, 0)), &cpus);
     if (sched_setaffinity(Int_val(val_pid), sizeof(cpu_set_t), &cpus) < 0)
         uerror("sched_setaffinity", Nothing);

--- a/src/unix/unix_c/unix_symlink_job.c
+++ b/src/unix/unix_c/unix_symlink_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_tcdrain_job.c
+++ b/src/unix/unix_c/unix_tcdrain_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_tcflow_job.c
+++ b/src/unix/unix_c/unix_tcflow_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_tcflush_job.c
+++ b/src/unix/unix_c/unix_tcflush_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_tcsendbreak_job.c
+++ b/src/unix/unix_c/unix_tcsendbreak_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_truncate_job.c
+++ b/src/unix/unix_c/unix_truncate_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/unix_c/unix_unlink_job.c
+++ b/src/unix/unix_c/unix_unlink_job.c
@@ -16,7 +16,6 @@
 */
 
 /* Caml headers. */
-#define CAML_NAME_SPACE
 #include <lwt_unix.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/src/unix/windows_c/windows_pread_job.c
+++ b/src/unix/windows_c/windows_pread_job.c
@@ -11,7 +11,6 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
-#include <caml/version.h>
 
 #include "lwt_unix.h"
 

--- a/src/unix/windows_c/windows_read_job.c
+++ b/src/unix/windows_c/windows_read_job.c
@@ -10,7 +10,6 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
-#include <caml/version.h>
 
 #include "lwt_unix.h"
 

--- a/src/unix/windows_c/windows_system_job.c
+++ b/src/unix/windows_c/windows_system_job.c
@@ -7,8 +7,6 @@
 
 #if defined(LWT_ON_WINDOWS)
 
-#define CAML_NAME_SPACE
-#include <caml/version.h>
 #if OCAML_VERSION < 41300
 #define CAML_INTERNALS
 #endif


### PR DESCRIPTION
`CAML_NAME_SPACE` has no more effect in 5.00 as all the functions are prefixed with `caml_` and the old names were removed.
The mlvalues macros were introduced in 4.12 and help manipulating option and list values in C.