### PR TITLE
Require bigarray-compat to enable `lwt.unix` under OCaml 5.00

### DIFF
--- a/lwt.opam
+++ b/lwt.opam
@@ -37,6 +37,7 @@ depopts: [
   "base-threads"
   "base-unix"
   "conf-libev"
+  "bigarray-compat"
 ]
 
 conflicts: [

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -42,7 +42,7 @@ let () = Jbuild_plugin.V1.send @@ {|
  (synopsis "Unix support for Lwt")
  (optional)
  (wrapped false)
- (libraries bigarray lwt mmap ocplib-endian.bigstring threads unix)
+ (libraries bigarray-compat lwt mmap ocplib-endian.bigstring threads unix)
  |} ^ preprocess ^ {|
  (c_names
   lwt_unix_stubs


### PR DESCRIPTION
This fixes the [item](https://github.com/ocsigen/lwt/issues/923#issuecomment-1036168918) raised by @patricoferris in https://github.com/ocsigen/lwt/issues/923.

We enable `lwt.unix` if `bigarray-compat` is present, which is a new depopt.