### PR TITLE
poc for await

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,4 @@
+
+(executable
+  (name test)
+  (libraries lwt lwt.unix))

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -1025,7 +1025,7 @@ end
 open Pending_callbacks
 
 
-let[@inline] await (p: 'a t) : 'a =
+let await (p: 'a t) : 'a =
   let Internal p = Public_types.to_internal_promise p in
   let p = underlying p in
   match p.state with

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -403,7 +403,7 @@ val wait : unit -> ('a t * 'a u)
     “constructor.” All other functions that evaluate to a promise can be, or
     are, eventually implemented in terms of it. *)
 
-
+val await : 'a t -> 'a
 
 (** {3 Resolving} *)
 

--- a/test.ml
+++ b/test.ml
@@ -5,13 +5,16 @@ let suspend f =
   let* () = Lwt.pause() in
   f()
 
-let f n =
+let rec sleep_rec n =
+  let before = if n >= 2 then sleep_rec (n-1) else Lwt.return () in
+  let cur = Lwt_unix.sleep (float n) in
   suspend @@ fun () ->
-  let+ () = Lwt_unix.sleep (float n) in
-  Printf.printf "sleep %d done \n%!" n
+  Lwt.await (Lwt.join [before; cur]);
+  Printf.printf "sleep %d done \n%!" n;
+  Lwt.return ()
 
 let main () =
-  let l = List.init 15 f in
+  let l = List.init 10 sleep_rec in
   suspend @@ fun () ->
   List.iter Lwt.await l;
   Lwt.return()

--- a/test.ml
+++ b/test.ml
@@ -1,0 +1,20 @@
+
+open Lwt.Syntax
+
+let suspend f =
+  let* () = Lwt.pause() in
+  f()
+
+let f n =
+  suspend @@ fun () ->
+  let+ () = Lwt_unix.sleep (float n) in
+  Printf.printf "sleep %d done \n%!" n
+
+let main () =
+  let l = List.init 15 f in
+  suspend @@ fun () ->
+  List.iter Lwt.await l;
+  Lwt.return()
+
+let () =
+  Lwt_main.run @@ main ()


### PR DESCRIPTION
This is not intended to be merged. It's a super basic proof of concept for `Lwt.await`. This works with `dune exec ./test.exe` on 4.12+domains+effects:

```ocaml
open Lwt.Syntax

let suspend f =
  let* () = Lwt.pause() in
  f()

let f n =
  let+ () = Lwt_unix.sleep (float n) in
  Printf.printf "sleep %d done \n%!" n

let main () =
  let l = List.init 15 f in
  suspend @@ fun () ->
  List.iter Lwt.await l; (* direct style! *)
  Lwt.return()

let () =
  Lwt_main.run @@ main ()
```