### PR TITLE
Add support for OCaml 5.00 (again)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,8 +2,7 @@ BLD=../_build/default/src
 SRC=../src
 
 PKGS=\
-	-package bytes -package result \
-	-package bigarray -package unix \
+	-package bigarray-compat -package unix \
 	-package ocaml-migrate-parsetree -package ppx_tools_versioned \
 	-package react \
 	-package domainslib

--- a/lwt.opam
+++ b/lwt.opam
@@ -26,6 +26,7 @@ depends: [
   "ocaml" {>= "4.03.0" & "os" != "win32 " | >= "4.06.0"}
   ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
   "ocplib-endian"
+  "bigarray-compat" # needed as long as Lwt supports OCaml < 4.07
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -42,7 +42,7 @@ let () = Jbuild_plugin.V1.send @@ {|
  (synopsis "Unix support for Lwt")
  (optional)
  (wrapped false)
- (libraries bigarray lwt mmap ocplib-endian.bigstring threads unix)
+ (libraries bigarray-compat lwt mmap ocplib-endian.bigstring threads unix)
  |} ^ preprocess ^ {|
  (c_names
   lwt_unix_stubs

--- a/src/unix/lwt_bytes.ml
+++ b/src/unix/lwt_bytes.ml
@@ -3,7 +3,7 @@
 
 
 
-open Bigarray
+open Bigarray_compat
 
 type t = (char, int8_unsigned_elt, c_layout) Array1.t
 
@@ -177,7 +177,7 @@ let sendto fd buf pos len flags addr =
 
 let map_file ~fd ?pos ~shared ?(size=(-1)) () =
   Mmap.V1.map_file fd ?pos char c_layout shared [|size|]
-  |> Bigarray.array1_of_genarray
+  |> Bigarray_compat.array1_of_genarray
 
 [@@@ocaml.warning "-3"]
 external mapped : t -> bool = "lwt_unix_mapped" "noalloc"

--- a/src/unix/lwt_bytes.mli
+++ b/src/unix/lwt_bytes.mli
@@ -5,7 +5,11 @@
 
 (** Byte arrays *)
 
-type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type t =
+  (char,
+   Bigarray_compat.int8_unsigned_elt,
+   Bigarray_compat.c_layout)
+  Bigarray_compat.Array1.t
     (** Type of array of bytes. *)
 
 val create : int -> t

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -636,7 +636,10 @@ let close ch =
     run_job (close_job ch.fd)
 
 type bigarray =
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (char,
+   Bigarray_compat.int8_unsigned_elt,
+   Bigarray_compat.c_layout)
+  Bigarray_compat.Array1.t
 
 let wait_read ch =
   Lwt.catch
@@ -685,7 +688,7 @@ external read_bigarray_job :
   "lwt_unix_bytes_read_job"
 
 let read_bigarray function_name fd buf pos len =
-  if pos < 0 || len < 0 || pos > Bigarray.Array1.dim buf - len then
+  if pos < 0 || len < 0 || pos > Bigarray_compat.Array1.dim buf - len then
     invalid_arg function_name
   else
     blocking fd >>= function
@@ -751,7 +754,7 @@ external write_bigarray_job :
   "lwt_unix_bytes_write_job"
 
 let write_bigarray function_name fd buf pos len =
-  if pos < 0 || len < 0 || pos > Bigarray.Array1.dim buf - len then
+  if pos < 0 || len < 0 || pos > Bigarray_compat.Array1.dim buf - len then
     invalid_arg function_name
   else
     blocking fd >>= function
@@ -844,7 +847,7 @@ struct
     let buffer_length =
       match io_vector.buffer with
       | Bytes s -> Bytes.length s
-      | Bigarray a -> Bigarray.Array1.dim a
+      | Bigarray a -> Bigarray_compat.Array1.dim a
     in
 
     if io_vector.length < 0 ||

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -369,7 +369,10 @@ sig
       and the length of the slice. *)
 
   type _bigarray =
-    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    (char,
+     Bigarray_compat.int8_unsigned_elt,
+     Bigarray_compat.c_layout)
+    Bigarray_compat.Array1.t
   (** Type abbreviation equivalent to {!Lwt_bytes.t}. Do not use this type name
       directly; use {!Lwt_bytes.t} instead. *)
 

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -108,7 +108,7 @@ let suite = suite "lwt_bytes" [
     test "create" begin fun () ->
       let len = 5 in
       let buff = Lwt_bytes.create len in
-      let len' = Bigarray.Array1.dim buff in
+      let len' = Bigarray_compat.Array1.dim buff in
       Lwt.return (len = len')
     end;
 


### PR DESCRIPTION
The bigarray library was removed from OCaml 5.00 (but now included in the stdlib itself)
This bug was hidden because of a bug in dune:
* https://github.com/ocaml/dune/issues/5420
* https://github.com/ocaml/dune/pull/5421

bigarray-compat is a compatiblity library which allows us to keep compatibility with older versions of the compiler easily.