### PR TITLE
Add forgotten `ocaml/version.h` include

### DIFF
--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -19,6 +19,7 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
+#include <caml/version.h>
 
 #include <assert.h>
 #include <errno.h>


### PR DESCRIPTION
Fixes the CI failing on Windows and OCaml 4.14.
cc @raphael-proust 