### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Hack Git CRLF for ocaml/setup-ocaml issue #529
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        run: |
+          & "C:\Program Files\Git\bin\git.exe" config --system core.autocrlf input
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:

--- a/lwt_domain.opam
+++ b/lwt_domain.opam
@@ -21,6 +21,7 @@ depends: [
   "lwt" {>= "3.0.0"}
   "ocaml" {>= "4.03"}
   "domainslib" {>= "0.3.2"}
+  "base-domains"
 ]
 
 build: [

--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -21,6 +21,7 @@ depends: [
   "lwt"
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.16.0"}
+  "ocaml" {>= "4.08"}
 ]
 
 build: [

--- a/lwt_ppx_let.opam
+++ b/lwt_ppx_let.opam
@@ -22,6 +22,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "lwt"
   "ppx_let" {with-test}
+  "ocaml" {>= "4.08"}
 ]
 
 description: "Internal package used to partition ppx_let tests."


### PR DESCRIPTION
The CI has several known failures which are being ignored rn. This PR attempts to fix them all.

Note that some of the failures are triggered in the `ocaml-ci`, the configuration for which is handled separately. I'll post updates about this in comments to this PR.