### PR TITLE
Support OCaml 5 new Unix API names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 
   * Lwt is now compatible with OCaml 5.00. Lwt is now incompatible with OCaml 4.02. (#925, #923, Kate Deplaix, Patrick Ferris)
   * Lwt is now incompatible with OCaml.4.07 and earlier. (#947, Hannes Mehnert, Tim McGilchrist)
+  * Lwt-unix is now compatible with OCaml 5.0.0. (#953, David Allsopp)
 
 ====== Additions ======
 

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -9,6 +9,13 @@ let preprocess =
 let () = Jbuild_plugin.V1.send @@ {|
 
 (rule
+ (targets lwt_process.ml)
+ (deps (:ml lwt_process.cppo.ml))
+ (action
+  (chdir %{project_root}
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{ml} -o %{targets}))))
+
+(rule
  (targets lwt_unix.ml)
  (deps (:ml lwt_unix.cppo.ml))
  (action

--- a/src/unix/lwt_process.cppo.ml
+++ b/src/unix/lwt_process.cppo.ml
@@ -136,7 +136,11 @@ let unix_redirect fd redirection = match redirection with
     Unix.dup2 fd' fd;
     Unix.close fd'
 
+#if OCAML_VERSION >= (5, 0, 0)
+external unix_exit : int -> 'a = "caml_unix_exit"
+#else
 external unix_exit : int -> 'a = "unix_exit"
+#endif
 
 let unix_spawn
     ?cwd

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -2434,7 +2434,11 @@ let wait () = waitpid [] (-1)
 
 external system_job : string -> int job = "lwt_unix_system_job"
 
+#if OCAML_VERSION >= (5, 0, 0)
+external unix_exit : int -> 'a = "caml_unix_exit"
+#else
 external unix_exit : int -> 'a = "unix_exit"
+#endif
 
 let system cmd =
   if Sys.win32 then

--- a/src/unix/unix_c/unix_get_network_information_utils.c
+++ b/src/unix/unix_c/unix_get_network_information_utils.c
@@ -102,9 +102,6 @@ char *s_strdup(const char *s)
 }
 #endif
 
-CAMLexport value alloc_inet_addr(struct in_addr *inaddr);
-CAMLexport value alloc_inet6_addr(struct in6_addr *inaddr);
-
 static value alloc_one_addr(char const *a)
 {
     struct in_addr addr;

--- a/src/unix/unix_c/unix_getaddrinfo_job.c
+++ b/src/unix/unix_c/unix_getaddrinfo_job.c
@@ -51,8 +51,10 @@ static value convert_addrinfo(struct addrinfo *a)
     vcanonname =
         caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
     vres = caml_alloc_small(5, 0);
-    Field(vres, 0) = cst_to_constr(a->ai_family, socket_domain_table, 3, 0);
-    Field(vres, 1) = cst_to_constr(a->ai_socktype, socket_type_table, 4, 0);
+    Field(vres, 0) =
+      cst_to_constr(a->ai_family, caml_unix_socket_domain_table, 3, 0);
+    Field(vres, 1) =
+      cst_to_constr(a->ai_socktype, caml_unix_socket_type_table, 4, 0);
     Field(vres, 2) = Val_int(a->ai_protocol);
     Field(vres, 3) = vaddr;
     Field(vres, 4) = vcanonname;
@@ -97,11 +99,11 @@ CAMLprim value lwt_unix_getaddrinfo_job(value node, value service, value hints)
         if (Is_block(v)) switch (Tag_val(v)) {
                 case 0: /* AI_FAMILY of socket_domain */
                     job->hints.ai_family =
-                        socket_domain_table[Int_val(Field(v, 0))];
+                        caml_unix_socket_domain_table[Int_val(Field(v, 0))];
                     break;
                 case 1: /* AI_SOCKTYPE of socket_type */
                     job->hints.ai_socktype =
-                        socket_type_table[Int_val(Field(v, 0))];
+                        caml_unix_socket_type_table[Int_val(Field(v, 0))];
                     break;
                 case 2: /* AI_PROTOCOL of int */
                     job->hints.ai_protocol = Int_val(Field(v, 0));

--- a/src/unix/unix_c/unix_open_job.c
+++ b/src/unix/unix_c/unix_open_job.c
@@ -10,6 +10,7 @@
 #include <caml/alloc.h>
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
+#include <caml/version.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -28,6 +29,10 @@
 #endif
 #ifndef O_RSYNC
 #define O_RSYNC 0
+#endif
+
+#if OCAML_VERSION_MAJOR < 5
+#define caml_unix_cloexec_default unix_cloexec_default
 #endif
 
 static int open_flag_table[] = {
@@ -64,7 +69,7 @@ static void worker_open(struct job_open *job)
     else if (job->fd & KEEPEXEC)
         cloexec = 0;
     else
-        cloexec = unix_cloexec_default;
+        cloexec = caml_unix_cloexec_default;
 
 #if defined(O_CLOEXEC)
     if (cloexec) job->flags |= O_CLOEXEC;

--- a/src/unix/unix_c/unix_recv_send_utils.h
+++ b/src/unix/unix_c/unix_recv_send_utils.h
@@ -27,12 +27,18 @@
 
 #include <caml/mlvalues.h>
 #include <caml/socketaddr.h>
+#include <caml/version.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 
+#if OCAML_VERSION_MAJOR < 5
+#define caml_unix_socket_domain_table socket_domain_table
+#define caml_unix_socket_type_table socket_type_table
+#endif
+
 extern int msg_flag_table[];
-extern int socket_domain_table[];
-extern int socket_type_table[];
+extern int caml_unix_socket_domain_table[];
+extern int caml_unix_socket_type_table[];
 extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
                          socklen_t *addr_len /*out*/);
 value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs);


### PR DESCRIPTION
The compiler is considering ensuring all symbols in the Unix library are prefixed `caml_` for 5.0 (https://github.com/ocaml/ocaml/pull/10926).

This requires:
- Pre-processing to select `unix_exit` or `caml_unix_exit`
- The removal of redundant declarations for functions in `caml/socketaddr.h`
- Version-based checking for the `socket_domain_table` and `socket_type_table` internal Unix symbols