### PR TITLE
Change mentions of Pervasives to Stdlib

### DIFF
--- a/docs/manual.wiki
+++ b/docs/manual.wiki
@@ -58,9 +58,9 @@
 
 === Lwt concepts ===
 
-  Let's take a classic function of the {{{Pervasives}}} module:
+  Let's take a classic function of the {{{Stdlib}}} module:
 
-<<code language="ocaml" |# Pervasives.input_char;;
+<<code language="ocaml" |# Stdlib.input_char;;
 - : in_channel -> char = <fun>
 >>
 
@@ -202,7 +202,7 @@ val p : char Lwt.t = <abstr>
   {{{catch f g}}} will call {{{f ()}}}, then wait for it to become
   resolved, and if it was rejected with an exception {{{exn}}}, call
   {{{g exn}}} to handle it. Note that both exceptions raised with
-  {{{Pervasives.raise}}} and {{{Lwt.fail}}} are caught by
+  {{{Stdlib.raise}}} and {{{Lwt.fail}}} are caught by
   {{{catch}}}.
 
 ==== Cancelable promises ====

--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -115,7 +115,7 @@
      A resolved promise is either "fulfilled" with a value, or "rejected" with
      an exception. The state of a resolved promise will never change again: a
      resolved promise is immutable. A resolved promise is basically equivalent
-     to an [('a, exn) Pervasives.result]. Resolved promises are produced in two
+     to an [('a, exn) Stdlib.result]. Resolved promises are produced in two
      ways:
 
      - [Lwt.return], [Lwt.fail], and related functions, produce "trivial"
@@ -478,7 +478,7 @@ struct
 
      - The type parameters of ['a resolved_state] guarantee that it is either
        [Fulfilled _] or [Rejected _]. So, it is equivalent to
-       [('a, exn) Pervasives.result], and, indeed, should have an identical
+       [('a, exn) Stdlib.result], and, indeed, should have an identical
        memory representation.
 
      - As per the Overview, there are regular callbacks and cancel callbacks.
@@ -574,7 +574,7 @@ struct
 
   (* Internal name of the public [+'a Lwt.result]. The public name is defined
      later in the module. This is to avoid potential confusion with
-     [Pervasives.result]/[Result.result], as the public name would not be
+     [Stdlib.result]/[Result.result], as the public name would not be
      prefixed with [Lwt.] inside this file. *)
   type +'a lwt_result = ('a, exn) Result.t
 

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -347,7 +347,7 @@ let () =
 
     - {!Lwt_unix} for Unix system calls.
     - {!Lwt_bytes} for Unix system calls on bigarrays.
-    - {!Lwt_io} for [Pervasives]-like high-level channels, TCP servers, etc.
+    - {!Lwt_io} for [Stdlib]-like high-level channels, TCP servers, etc.
     - {!Lwt_process} for managing subprocesses.
     - {!Lwt_preemptive} for spawning system threads.
     - Miscellaneous modules {!Lwt_gc}, {!Lwt_engine}, {!Lwt_throttle},

--- a/src/core/lwt_stream.ml
+++ b/src/core/lwt_stream.ml
@@ -459,7 +459,7 @@ let rec get_exn_rec s node =
       (fun () -> get_exn_rec s node)
       (fun exn -> Lwt.return (Some (Error exn : _ result)))
       (* Note: the [Error] constructor above is from [Lwt_stream.result], not
-         [Pervasives.result], nor its alias [Lwt.result]. [Lwt_stream.result] is
+         [Stdlib.result], nor its alias [Lwt.result]. [Lwt_stream.result] is
          a deprecated type, defined right above this function.
 
          The type constraint is necessary to avoid a warning about an ambiguous

--- a/src/unix/lwt_main.mli
+++ b/src/unix/lwt_main.mli
@@ -40,7 +40,7 @@ let () = Lwt_main.run (main ())
       error (i.e., code making such a call is inherently broken).
 
       It is not safe to call [Lwt_main.run] in a function registered with
-      [Pervasives.at_exit], use {!Lwt_main.at_exit} instead. *)
+      [Stdlib.at_exit], use {!Lwt_main.at_exit} instead. *)
 
 val yield : unit -> unit Lwt.t [@@deprecated "Use Lwt.pause instead"]
   (** [yield ()] is a pending promise that is fulfilled after Lwt finishes


### PR DESCRIPTION
Pervasives was replaces by Stdlib in OCaml 4.08.