### PR TITLE
Prepare for 5.6.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,10 @@
 ===== dev =====
 
+===== 5.6.1 =====
+
 ====== Fixes ======
 
-  *  Fix null file descriptor being closed when used as redirection for standard fd of child processes. (#957, Antonin Décimo) 
+  *  Fix null file descriptor being closed when used as redirection for standard fd of child processes. (#957, Antonin Décimo)
 
 ===== 5.6.0 =====
 

--- a/lwt.opam
+++ b/lwt.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "5.6.0"
+version: "5.6.1"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"


### PR DESCRIPTION
This is to prepare for the 5.6.1 release. It is meant to be merged once 5.6.1 is available in opam, holding commits that may accumulate in the process.

This release is a bugfix release only.