### PR TITLE
Add Lwt_preemptive.run_in_main_no_wait

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@
 
   * Lwt.reraise an exception raising function which preserves backtraces, recommended for use in Lwt.catch (#963)
 
-  * Lwt_preemptive.run_in_main_no_wait to run a function in the main preemptive thread but without waiting for the result. (Kate Deplaix, #960)
+  * Lwt_preemptive.run_in_main_dont_wait to run a function in the main preemptive thread but without waiting for the result. (Kate Deplaix, #960)
 
 ====== Build ======
 

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@
 
   * Lwt.reraise an exception raising function which preserves backtraces, recommended for use in Lwt.catch (#963)
 
+  * Lwt_preemptive.run_in_main_no_wait to run a function in the main preemptive thread but without waiting for the result. (Kate Deplaix, #960)
+
 ====== Build ======
 
   * Remove unused dependency in dune file. (#969, Kate Deplaix)

--- a/src/unix/lwt_preemptive.ml
+++ b/src/unix/lwt_preemptive.ml
@@ -263,4 +263,3 @@ let run_in_main f =
 let run_in_main_dont_wait f handler =
   let f () = Lwt.catch f (fun exc -> handler exc; Lwt.return_unit) in
   run_in_main_dont_wait f
-

--- a/src/unix/lwt_preemptive.ml
+++ b/src/unix/lwt_preemptive.ml
@@ -258,3 +258,9 @@ let run_in_main f =
   match CELL.get cell with
   | Result.Ok ret -> ret
   | Result.Error exn -> raise exn
+
+(* This version shadows the one above, adding an exception handler *)
+let run_in_main_dont_wait f handler =
+  let f () = Lwt.catch f (fun exc -> handler exc; Lwt.return_unit) in
+  run_in_main_dont_wait f
+

--- a/src/unix/lwt_preemptive.ml
+++ b/src/unix/lwt_preemptive.ml
@@ -228,7 +228,7 @@ let job_notification =
        Mutex.unlock jobs_mutex;
        ignore (thunk ()))
 
-let run_in_main_no_wait f =
+let run_in_main_dont_wait f =
   (* Add the job to the queue. *)
   Mutex.lock jobs_mutex;
   Queue.add f jobs;
@@ -253,7 +253,7 @@ let run_in_main f =
     CELL.set cell result;
     Lwt.return_unit
   in
-  run_in_main_no_wait job;
+  run_in_main_dont_wait job;
   (* Wait for the result. *)
   match CELL.get cell with
   | Result.Ok ret -> ret

--- a/src/unix/lwt_preemptive.mli
+++ b/src/unix/lwt_preemptive.mli
@@ -34,9 +34,12 @@ val run_in_main : (unit -> 'a Lwt.t) -> 'a
       retrieve values set this way inside [f ()], but not values set using
       {!Lwt.with_value} outside [f ()]. *)
 
-val run_in_main_dont_wait : (unit -> unit Lwt.t) -> unit
-(** [run_in_main_dont_wait f] does the same as [run_in_main f] but a bit faster
+val run_in_main_dont_wait : (unit -> unit Lwt.t) -> (exn -> unit) -> unit
+(** [run_in_main_dont_wait f h] does the same as [run_in_main f] but a bit faster
     and lighter as it does not wait for the result of [f].
+
+    If [f]'s promise is rejected (or if it raises), then the function [h] is
+    called with the rejection exception.
 
     @since 5.7.0 *)
 

--- a/src/unix/lwt_preemptive.mli
+++ b/src/unix/lwt_preemptive.mli
@@ -34,8 +34,8 @@ val run_in_main : (unit -> 'a Lwt.t) -> 'a
       retrieve values set this way inside [f ()], but not values set using
       {!Lwt.with_value} outside [f ()]. *)
 
-val run_in_main_no_wait : (unit -> unit Lwt.t) -> unit
-(** [run_in_main_no_wait f] does the same as [run_in_main f] but a bit faster
+val run_in_main_dont_wait : (unit -> unit Lwt.t) -> unit
+(** [run_in_main_dont_wait f] does the same as [run_in_main f] but a bit faster
     and lighter as it does not wait for the result of [f].
 
     @since 5.7.0 *)

--- a/src/unix/lwt_preemptive.mli
+++ b/src/unix/lwt_preemptive.mli
@@ -34,6 +34,12 @@ val run_in_main : (unit -> 'a Lwt.t) -> 'a
       retrieve values set this way inside [f ()], but not values set using
       {!Lwt.with_value} outside [f ()]. *)
 
+val run_in_main_no_wait : (unit -> unit Lwt.t) -> unit
+(** [run_in_main_no_wait f] does the same as [run_in_main f] but a bit faster
+    and lighter as it does not wait for the result of [f].
+
+    @since 5.7.0 *)
+
 val init : int -> int -> (string -> unit) -> unit
   (** [init min max log] initialises this module. i.e. it launches the
       minimum number of preemptive threads and starts the {b

--- a/test/unix/test_lwt_unix.ml
+++ b/test/unix/test_lwt_unix.ml
@@ -1063,10 +1063,10 @@ let lwt_preemptive_tests = [
     Lwt_preemptive.detach f () >>= fun x ->
     Lwt.return (x = 42)
   end;
-  test "run_in_main_no_wait" begin fun () ->
+  test "run_in_main_dont_wait" begin fun () ->
     let p, r = Lwt.wait () in
     let f () =
-      Lwt_preemptive.run_in_main_no_wait (fun () ->
+      Lwt_preemptive.run_in_main_dont_wait (fun () ->
         Lwt.pause () >>= fun () ->
         Lwt.pause () >>= fun () ->
         Lwt.wakeup r 42;

--- a/test/unix/test_lwt_unix.ml
+++ b/test/unix/test_lwt_unix.ml
@@ -1063,6 +1063,36 @@ let lwt_preemptive_tests = [
     Lwt_preemptive.detach f () >>= fun x ->
     Lwt.return (x = 42)
   end;
+  test "run_in_main_no_wait" begin fun () ->
+    let p, r = Lwt.wait () in
+    let f () =
+      Lwt_preemptive.run_in_main_no_wait (fun () ->
+        Lwt.pause () >>= fun () ->
+        Lwt.pause () >>= fun () ->
+        Lwt.wakeup r 42;
+        Lwt.return ())
+    in
+    Lwt_preemptive.detach f () >>= fun () ->
+    p >>= fun x ->
+    Lwt.return (x = 42)
+  end;
+  test "run_in_main_with_dont_wait" begin fun () ->
+    let p, r = Lwt.wait () in
+    let f () =
+      Lwt_preemptive.run_in_main (fun () ->
+        Lwt.dont_wait
+          (fun () ->
+            Lwt.pause () >>= fun () ->
+            Lwt.pause () >>= fun () ->
+            Lwt.wakeup r 42;
+            Lwt.return ())
+          (function _ -> Stdlib.exit 2);
+        Lwt.return ())
+    in
+    Lwt_preemptive.detach f () >>= fun () ->
+    p >>= fun x ->
+    Lwt.return (x = 42)
+  end;
 ]
 
 let getlogin_works =


### PR DESCRIPTION
Useful if you want `Lwt_preemptive.run_in_main` but does not need to wait for the result of the function to finish.