### PR TITLE
Lwt_result.catch takes a function as parameter now

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 ===== dev =====
 
-===== Build =====
+====== Breaking API changes ======
+
+  * Lwt_result.catch now takes a function (unit -> 'a t) rather than a promise ('a t) (#965)
+
+====== Build ======
 
   * Remove unused dependency in dune file. (#969, Kate Deplaix)
 

--- a/src/core/lwt_result.ml
+++ b/src/core/lwt_result.ml
@@ -31,7 +31,7 @@ let map_err f e = map_error f e
 
 let catch e =
   Lwt.catch
-    (fun () -> ok e)
+    (fun () -> ok (e ()))
     fail
 
 let get_exn e =

--- a/src/core/lwt_result.mli
+++ b/src/core/lwt_result.mli
@@ -23,9 +23,9 @@ val ok : 'a Lwt.t -> ('a, _) t
 val error : 'b Lwt.t -> (_, 'b) t
 (** @since 5.6.0  *)
 
-val catch : 'a Lwt.t -> ('a, exn) t
-(** [catch x] behaves like [return y] if [x] evaluates to [y],
-    and like [fail e] if [x] raises [e] *)
+val catch : (unit -> 'a Lwt.t) -> ('a, exn) t
+(** [catch x] behaves like [return y] if [x ()] evaluates to [y],
+    and like [fail e] if [x ()] raises [e] *)
 
 val get_exn : ('a, exn) t -> 'a Lwt.t
 (** [get_exn] is the opposite of {!catch}: it unwraps the result type,

--- a/test/core/test_lwt_result.ml
+++ b/test/core/test_lwt_result.ml
@@ -87,13 +87,25 @@ let suite =
 
     test "catch"
       (fun () ->
-         let x = Lwt.return 0 in
+         let x () = Lwt.return 0 in
          Lwt.return (Lwt_result.catch x = Lwt_result.return 0)
       );
 
     test "catch, error case"
       (fun () ->
-         let x = Lwt.fail Dummy_error in
+         let x () = Lwt.fail Dummy_error in
+         Lwt.return (Lwt_result.catch x = Lwt_result.fail Dummy_error)
+      );
+
+    test "catch, bound raise"
+      (fun () ->
+         let x () = Lwt.bind Lwt.return_unit (fun () -> raise Dummy_error) in
+         Lwt.return (Lwt_result.catch x = Lwt_result.fail Dummy_error)
+      );
+
+    test "catch, immediate raise"
+      (fun () ->
+         let x () = raise Dummy_error in
          Lwt.return (Lwt_result.catch x = Lwt_result.fail Dummy_error)
       );
 


### PR DESCRIPTION
This PR is a work-in-progress. It should probably use a `deprecated` annotation instead, and introduce a new function to replace the existing one. Although:

- The name `catch` is a good name for what the function does.
- It seems like the function is barely used at all. So I could just open pull requests on the handful of packages that use it.

- `dune` uses this function. Specifically [otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml](https://github.com/ocaml/dune/blob/main/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml) has one occurrence of it. Ping @rgrinberg 
- `openvpn` uses this function. Specifically [openvpn_client_lwt.ml](https://github.com/roburio/openvpn/blob/main/app/openvpn_client_lwt.ml) has two occurrences of it. Ping @hannesm 
- `ocaml-zmq` uses this function. Specifically [zmq-lwt/src/deferred.ml](https://github.com/issuu/ocaml-zmq/blob/master/zmq-lwt/src/deferred.ml) has one occurrence of it. Ping @andersfugmann
- `aws-s3` uses this function. Specifically, [aws-s3-lwt/io.ml](https://github.com/andersfugmann/aws-s3/blob/master/aws-s3-lwt/io.ml) has one occurrence of it. Ping @andersfugmann

@rgrinberg @hannesm @andersfugmann would you be ok with this breaking change of interface if I open a PR on your repos to adapt your code to match? Or do you need to stay compatible with multiple versions of Lwt for some packaging or dependency management reason?