### PR TITLE
fix setting Lwt_process env on Windows

### DIFF
--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -9,8 +9,11 @@
 
 #include <lwt_unix.h>
 
-#if OCAML_VERSION < 41300
+/* needed for caml_stat_strdup_to_os before ocaml 4.13, and for
+   caml_win32_multi_byte_to_wide_char, at least as of ocaml 5.0 */
 #define CAML_INTERNALS
+#if OCAML_VERSION < 50000
+#define caml_win32_multi_byte_to_wide_char win_multi_byte_to_wide_char
 #endif
 
 #include <caml/alloc.h>
@@ -68,6 +71,7 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
   HANDLE hp, fd0, fd1, fd2;
   HANDLE to_close0 = INVALID_HANDLE_VALUE, to_close1 = INVALID_HANDLE_VALUE,
     to_close2 = INVALID_HANDLE_VALUE;
+  int size;
 
   fd0 = get_handle(Field(fds, 0));
   fd1 = get_handle(Field(fds, 1));
@@ -94,10 +98,23 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
   char_os
     *progs = string_option(prog),
     *cmdlines = caml_stat_strdup_to_os(String_val(cmdline)),
-    *envs = string_option(env),
     *cwds = string_option(cwd);
 
 #undef string_option
+
+  char_os *envs;
+  if (Is_some(env)) {
+    env = Some_val(env);
+    size =
+      caml_win32_multi_byte_to_wide_char(String_val(env),
+                                         caml_string_length(env), NULL, 0);
+    envs = caml_stat_alloc((size + 1)*sizeof(char_os));
+    caml_win32_multi_byte_to_wide_char(String_val(env),
+                                       caml_string_length(env), envs, size);
+    envs[size] = 0;
+  } else {
+    envs = NULL;
+  }
 
   flags |= CREATE_UNICODE_ENVIRONMENT;
   if (! CreateProcess(progs, cmdlines, NULL, NULL, TRUE, flags,

--- a/test/unix/dummy.ml
+++ b/test/unix/dummy.ml
@@ -23,9 +23,18 @@ let read () =
 let write fd =
   assert (test_input_len = Unix.write fd test_input 0 test_input_len)
 
+let printenv () =
+  (* stdout is in text mode by default, which converts \n to \r\n on Windows.
+    switch to binary mode to prevent this, so the output is the same across
+    platforms. *)
+  set_binary_mode_out stdout true;
+  Array.iter (Printf.printf "%s\n") (Unix.unsafe_environment ());
+  flush stdout
+
 let () =
   match Sys.argv.(1) with
   | "read" -> exit @@ if read () then 0 else 1
   | "write" -> write Unix.stdout
   | "errwrite" -> write Unix.stderr
+  | "printenv" -> printenv ()
   | _ -> invalid_arg "Sys.argv"


### PR DESCRIPTION
`env` is an "environment block": a null-terminated block of null-terminated strings. using `caml_stat_strdup_to_os` on it doesn't work, it only copies the first string.

instead, we need to use an explicit length (`caml_string_length(env)`), but there's no public `*_to_os` function for this so we have to use the internal `caml_win32_multi_byte_to_wide_char` directly.

Fixes https://github.com/ocsigen/lwt/issues/966