### PR TITLE
Remove several deprecated values, especially result-related

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,18 @@
 
   * Lwt_result.catch now takes a function (unit -> 'a t) rather than a promise ('a t) (#965)
 
+  * Remove the deprecated Lwt.result type (use Stdlib.result instead) (#968)
+
+  * Remove the deprecated Lwt.make_value and Lwt.make_result functions (use Ok and Error instead) (#968)
+
+  * Remove the deprecated and unsafe waiter_of_wakener (keep the waiter around when you create the wakener instead) (#968)
+
+  * Remove the deprecated Lwt_stream.on_termination and Lwt_stream.on_terminate (bind to Lwt_stream.closed instead) (#968)
+
+  * Remove the deprecated Lwt_stream.result type (use Stdlib.result instead) (#968)
+
+  * Remove the deprecated Lwt_stream.map_exn function (use wrap_exn instead) (#968)
+
 ====== Additions ======
 
   * Lwt.reraise an exception raising function which preserves backtraces, recommended for use in Lwt.catch (#963)

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -1600,18 +1600,7 @@ Lwt.fail (Stdlib.Invalid_argument s)
 
 (** {3 Result type} *)
 
-type nonrec +'a result = ('a, exn) result
-(** Representation of the content of a resolved promise of type
-    ['a ]{!Lwt.t}.
-
-    This type is effectively
-
-{[
-type +'a Lwt.result =
-  | Ok of 'a
-  | Error of exn
-]}
-
+(**
     A resolved promise of type ['a ]{!Lwt.t} is either fulfilled with a value of
     type ['a], or rejected with an exception.
 
@@ -1619,18 +1608,10 @@ type +'a Lwt.result =
     fulfilled corresponds to [Ok of 'a], and rejected corresponds to
     [Error of exn].
 
-    It's important to note that this type constructor, [Lwt.result], is
-    different from [Stdlib.result]. It is a specialization of [Stdlib.result] so
-    that the [Error] constructor always carries [exn].
-
     For Lwt programming with [result] where the [Error] constructor can carry
-    arbitrary error types, see module {!Lwt_result}.
+    arbitrary error types, see module {!Lwt_result}. *)
 
-    The naming conflict between [Lwt.result] and [Stdlib.result] is an
-    unfortunate historical accident. [Stdlib.result] did not exist when
-    [Lwt.result] was created. *)
-
-val of_result : 'a result -> 'a t
+val of_result : ('a, exn) result -> 'a t
 (** [Lwt.of_result r] converts an r to a resolved promise.
 
     - If [r] is [Ok v], [Lwt.of_result r] is [Lwt.return v], i.e. a promise
@@ -1638,7 +1619,7 @@ val of_result : 'a result -> 'a t
     - If [r] is [Error exn], [Lwt.of_result r] is [Lwt.fail exn], i.e. a promise
       rejected with [exn]. *)
 
-val wakeup_later_result : 'a u -> 'a result -> unit
+val wakeup_later_result : 'a u -> ('a, exn) result -> unit
 (** [Lwt.wakeup_later_result r result] resolves the pending promise [p]
     associated to resolver [r], according to [result]:
 
@@ -1802,41 +1783,10 @@ val wakeup_exn : _ u -> exn -> unit
 (** [Lwt.wakeup_exn r exn] is like {!Lwt.wakeup_later_exn}[ r exn], but has
     the same problems as {!Lwt.wakeup}. *)
 
-val wakeup_result : 'a u -> 'a result -> unit
+val wakeup_result : 'a u -> ('a, exn) result -> unit
 (** [Lwt.wakeup_result r result] is like {!Lwt.wakeup_later_result}[ r result],
     but has the same problems as {!Lwt.wakeup}. *)
 
-
-
-(** {3 Helpers for resolving} *)
-
-val make_value : 'a -> 'a result
-  [@@ocaml.deprecated
-    " Use Ok (from Stdlib) instead."]
-(** [Lwt.make_value v] is equivalent to
-    {{: https://ocaml.org/api/Stdlib.html#TYPEresult}
-    [Ok v]}.
-
-    @deprecated Use [Ok] instead *)
-
-val make_error : exn -> _ result
-  [@@ocaml.deprecated
-    " Use Error (from Stdlib) instead."]
-(** [Lwt.make_error exn] is equivalent to
-    {{: https://ocaml.org/api/Stdlib.html#TYPEresult}
-    [Error exn]}.
-
-    @deprecated Use [Error] (from Stdlib) instead. *)
-
-val waiter_of_wakener : 'a u -> 'a t
-  [@@ocaml.deprecated
-" This function should be avoided, because it makes subtyping of resolvers
- unsound. See
-  https://github.com/ocsigen/lwt/issues/458"]
-(** [Lwt.waiter_of_wakener r] evaluates to the promise associated with resolver
-    [r].
-
-    @deprecated Keep the reference to the promise instead. *)
 
 
 

--- a/src/core/lwt_stream.mli
+++ b/src/core/lwt_stream.mli
@@ -263,20 +263,6 @@ val closed : 'a t -> unit Lwt.t
 
     @since 2.6.0 *)
 
-val on_termination : 'a t -> (unit -> unit) -> unit
-[@@ocaml.deprecated " Bind on Lwt_stream.closed."]
-(** [on_termination st f] executes [f] when the end of the stream [st]
-    is reached. Note that the stream may still contain elements if
-    {!peek} or similar was used.
-
-    @deprecated Use {!closed}. *)
-
-val on_terminate : 'a t -> (unit -> unit) -> unit
-[@@ocaml.deprecated " Bind on Lwt_stream.closed."]
-(** Same as {!on_termination}.
-
-    @deprecated Use {!closed}. *)
-
 (** {2 Stream transversal} *)
 
 (** Note: all the following functions are destructive.
@@ -360,7 +346,7 @@ val concat : 'a t t -> 'a t
 val flatten : 'a list t -> 'a t
 (** [flatten st = map_list (fun l -> l) st] *)
 
-val wrap_exn : 'a t -> 'a Lwt.result t
+val wrap_exn : 'a t -> ('a, exn) result t
 (** [wrap_exn s] is a stream [s'] such that each time [s] yields a value [v],
     [s'] yields [Result.Ok v], and when the source of [s] raises an exception
     [e], [s'] yields [Result.Error e].
@@ -398,32 +384,3 @@ val hexdump : char t -> string t
         end
     ]}
 *)
-
-(** {2 Deprecated} *)
-
-type 'a result =
-  | Value of 'a
-  | Error of exn
-[@@ocaml.deprecated
-  " This type is being replaced by Lwt.result and the corresponding function
- Lwt_stream.wrap_exn."]
-(** A value or an error.
-
-    @deprecated Replaced by {!wrap_exn}, which uses {!Lwt.result}. *)
-
-[@@@ocaml.warning "-3"]
-val map_exn : 'a t -> 'a result t
-[@@ocaml.deprecated " Use Lwt_stream.wrap_exn"]
-(** [map_exn s] returns a stream that captures all exceptions raised
-    by the source of the stream (the function passed to {!from}).
-
-    Note that for push-streams (as returned by {!create}) all
-    elements of the mapped streams are values.
-
-    If the stream source keeps raising the same exception [e] each time the
-    stream is read, the stream produced by [map_exn] is unbounded. Reading it
-    will produce [Lwt_stream.Error e] indefinitely.
-
-    @deprecated Use {!wrap_exn}. *)
-
-[@@@ocaml.warning "+3"]

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -163,11 +163,6 @@ let initial_promise_tests = suite "initial promises" [
     Lwt.wakeup_result r (Result.Ok "foo");
     state_is (Lwt.Return "foo") p
   end;
-
-  test "waiter_of_wakener" begin fun () ->
-    let p, r = Lwt.wait () in
-    Lwt.return ((Lwt.waiter_of_wakener [@ocaml.warning "-3"]) r == p)
-  end;
 ]
 let suites = suites @ [initial_promise_tests]
 
@@ -4357,23 +4352,6 @@ let lift_tests = suite "apply and wrap" [
   end;
 ]
 let suites = suites @ [lift_tests]
-
-
-
-(* [Lwt.make_value] and [Lwt.make_error] are deprecated, but test them anyway,
-   for good measure. *)
-let make_value_and_error_tests = suite "make_value and make_error" [
-  test "make_value" begin fun () ->
-    Lwt.return ((Lwt.make_value [@ocaml.warning "-3"]) 42 = Result.Ok 42)
-  end;
-
-  test "make_error" begin fun () ->
-    Lwt.return
-      ((Lwt.make_error [@ocaml.warning "-3"]) Exception =
-        Result.Error Exception)
-  end;
-]
-let suites = suites @ [make_value_and_error_tests]
 
 
 

--- a/test/core/test_lwt_stream.ml
+++ b/test/core/test_lwt_stream.ml
@@ -371,7 +371,7 @@ let suite = suite "lwt_stream" [
       let b9 = Lwt_stream.is_closed st in
       return (b1 && b2 && b3 && b4 && b5 && b6 && not b7 && not b8 && b9));
 
-  test "closed"
+  test "closed(bind)"
     (fun () ->
       let st = Lwt_stream.from_direct (
         let value = ref (Some 1) in
@@ -387,15 +387,14 @@ let suite = suite "lwt_stream" [
       let b2 = !b = true in
       return (b1 && b2));
 
-  test "on_termination"
+  test "closed(on_termination)"
     (fun () ->
       let st = Lwt_stream.from_direct (
         let value = ref (Some 1) in
         fun () -> let r = !value in value := None; r)
       in
       let b = ref false in
-      (Lwt_stream.on_termination [@ocaml.warning "-3"])
-        st (fun () -> b := true);
+      (Lwt.on_termination (Lwt_stream.closed st) (fun () -> b := true));
       ignore (Lwt_stream.peek st);
       let b1 = !b = false in
       ignore (Lwt_stream.junk st);
@@ -404,13 +403,12 @@ let suite = suite "lwt_stream" [
       let b3 = Lwt_stream.is_closed st in
       Lwt.return (b1 && b2 && b3));
 
-  test "on_termination when closed"
+  test "closed when closed"
     (fun () ->
       let st = Lwt_stream.of_list [] in
       let b = ref false in
       let b1 = Lwt_stream.is_closed st in
-      (Lwt_stream.on_termination [@ocaml.warning "-3"])
-        st (fun () -> b := true);
+      (Lwt.on_termination (Lwt_stream.closed st) (fun () -> b := true));
       Lwt.return (b1 && !b));
 
   test "choose_exhausted"


### PR DESCRIPTION
This PR removes some long-deprecated functions. Mostly those related to the result type.