### PR TITLE
Lwt_domain: update to domainslib.0.5.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,12 +42,6 @@ jobs:
             local-packages: |
               *.opam
               !lwt_domain.opam
-          - os: ubuntu-latest
-            ocaml-compiler: ocaml-variants.4.12.0+domains
-            libev: false
-            ppx: true
-            domain: true
-            local-packages: "*.opam"
           - os: macos-latest
             ocaml-compiler: 4.14.x
             libev: true

--- a/lwt_domain.opam
+++ b/lwt_domain.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "lwt" {>= "3.0.0"}
   "ocaml" {>= "4.08"}
-  "domainslib" {>= "0.3.2"}
+  "domainslib" {>= "0.5.0"}
   "base-domains"
 ]
 

--- a/src/domain/lwt_domain.ml
+++ b/src/domain/lwt_domain.ml
@@ -5,8 +5,8 @@ module T = Domainslib.Task
 
 type pool = Domainslib.Task.pool
 
-let setup_pool ?name num_additional_domains =
-    T.setup_pool ?name ~num_additional_domains ()
+let setup_pool ?name num_domains =
+    T.setup_pool ?name ~num_domains ()
 
 let teardown_pool = T.teardown_pool
 

--- a/src/domain/lwt_domain.mli
+++ b/src/domain/lwt_domain.mli
@@ -56,8 +56,8 @@
         is recommended to use this function sparingly. *)
 
   val setup_pool : ?name:string -> int -> pool
-  (** [setup_pool name num_additional_domains] returns a task pool with
-      [num_additional_domains] domains including the current domain.
+  (** [setup_pool name num_domains] returns a task pool with
+      [num_domains] new domains.
 
       It is recommended to use this function to create a pool once before
       calling [Lwt_main.run] and to not call it again afterwards. To resize the

--- a/test/domain/test_lwt_domain.ml
+++ b/test/domain/test_lwt_domain.ml
@@ -56,7 +56,7 @@ let lwt_domain_test = [
       (fun _ -> Lwt.return_false)
       (fun exn ->
         Lwt.return (exn = Invalid_argument
-        "Task.setup_pool: num_additional_domains must be at least 0"))
+        "Task.setup_pool: num_domains must be at least 0"))
   end;
   test "detach_exception" begin fun () ->
     let pool = Option.get (Lwt_domain.lookup_pool "pool_1") in


### PR DESCRIPTION
This updates the `lwt_domain` module to work with the latest version of domainslib. Please note that this is not backwards compatible in its current form.