### PR TITLE
Add initial CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+To report any violations, please contact:
+
+- Raphaël Proust `code@bnwr.net`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,4 +8,5 @@ This project follows the OCaml Code of Conduct
 [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
 To report any violations, please contact:
 
+- Any member of the [code-of-conduct enforcement team](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement)
 - Raphaël Proust `code@bnwr.net`


### PR DESCRIPTION
Adding the ocaml code-of-conduct (https://github.com/ocaml/code-of-conduct).

I've only put my own name down as a contact, but it'd be better to have additional points of contact. Anyone wants to add their name down? I think that the Lwt project is widespread enough in the community that it would make sense to add the Code of Conduct team's contact details too (ping @Sudha247).