### PR TITLE
Use Lwt's pre-allocated promises

### DIFF
--- a/src/core/lwt_list.ml
+++ b/src/core/lwt_list.ml
@@ -182,7 +182,7 @@ let rec find_s f l =
       (find_s [@ocaml.tailcall]) f l
 
 let _optionalize f x =
-  f x >>= fun b -> if b then Lwt.return (Some x) else Lwt.return None
+  f x >>= fun b -> if b then Lwt.return (Some x) else Lwt.return_none
 
 let filter_s f l =
   filter_map_s (_optionalize f) l

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -1504,7 +1504,7 @@ let rec delete_recursively directory =
   |> Lwt_stream.iter_s begin fun entry ->
     if entry = Filename.current_dir_name ||
        entry = Filename.parent_dir_name then
-      Lwt.return ()
+      Lwt.return_unit
     else
       let path = Filename.concat directory entry in
       Lwt_unix.lstat path >>= fun {Lwt_unix.st_kind; _} ->

--- a/src/unix/lwt_throttle.ml
+++ b/src/unix/lwt_throttle.ml
@@ -83,7 +83,7 @@ module Make (H : Hashtbl.HashedType) : (S with type key = H.t) = struct
                 replacing. *)
              prerr_endline "internal error";
              Printexc.print_backtrace stderr;
-             Lwt.return ())
+             Lwt.return_unit)
       in
       Some t
 

--- a/test/core/test_lwt.ml
+++ b/test/core/test_lwt.ml
@@ -177,9 +177,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup r "foo";
     try
       Lwt.wakeup r "foo";
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup: double use on task" begin fun () ->
@@ -187,9 +187,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup r "foo";
     try
       Lwt.wakeup r "foo";
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_exn: double use on wait" begin fun () ->
@@ -197,9 +197,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup_exn r Exception;
     try
       Lwt.wakeup_exn r Exception;
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_exn" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_exn: double use on task" begin fun () ->
@@ -207,9 +207,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup_exn r Exception;
     try
       Lwt.wakeup_exn r Exception;
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_exn" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_result: double use on wait" begin fun () ->
@@ -217,9 +217,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup_exn r Exception;
     try
       Lwt.wakeup_result r (Result.Ok ());
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_result" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_result: double use on task" begin fun () ->
@@ -227,9 +227,9 @@ let double_resolve_tests = suite "double resolve" [
     Lwt.wakeup_exn r Exception;
     try
       Lwt.wakeup_result r (Result.Ok ());
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_result" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 ]
 let suites = suites @ [double_resolve_tests]
@@ -258,9 +258,9 @@ let bind_tests = suite "bind" [
     let p = Lwt.return "foo" in
     try
       Lwt.bind p (fun _ -> raise Exception) |> ignore;
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "already rejected" begin fun () ->
@@ -272,7 +272,7 @@ let bind_tests = suite "bind" [
   test "pending" begin fun () ->
     let f_ran = ref false in
     let p, _ = Lwt.wait () in
-    let p = Lwt.bind p (fun _ -> f_ran := true; Lwt.return ()) in
+    let p = Lwt.bind p (fun _ -> f_ran := true; Lwt.return_unit) in
     Lwt.bind (state_is Lwt.Sleep p) (fun correct ->
     Lwt.return (correct && !f_ran = false))
   end;
@@ -375,7 +375,7 @@ let bind_tests = suite "bind" [
      does not form cycles. It's only relevant for the native implementation. *)
   test "cycle" begin fun () ->
     let p, r = Lwt.wait () in
-    let p' = ref (Lwt.return ()) in
+    let p' = ref (Lwt.return_unit) in
     p' := Lwt.bind p (fun _ -> !p');
     Lwt.wakeup r ();
     Lwt.return (Lwt.state !p' = Lwt.Sleep)
@@ -399,7 +399,7 @@ let bind_tests = suite "bind" [
              implementation, this code could cause Lwt to hang forever, or crash
              the process. *)
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
@@ -451,7 +451,7 @@ let backtrace_bind_tests = suite "backtrace_bind" [
         p1
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
@@ -562,9 +562,9 @@ let catch_tests = suite "catch" [
       ignore @@ Lwt.catch
         (fun () -> Lwt.fail Exit)
         (fun _ -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "pending" begin fun () ->
@@ -572,7 +572,7 @@ let catch_tests = suite "catch" [
     let p =
       Lwt.catch
         (fun () -> fst (Lwt.wait ()))
-        (fun _ -> h_ran := true; Lwt.return ())
+        (fun _ -> h_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is Lwt.Sleep p) (fun correct ->
     Lwt.return (correct && !h_ran = false))
@@ -634,7 +634,7 @@ let catch_tests = suite "catch" [
         (fun () -> p1)
         (fun _exn ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
@@ -676,7 +676,7 @@ let backtrace_catch_tests = suite "backtrace_catch" [
     let p =
       Lwt.backtrace_catch add_loc
         (fun () -> fst (Lwt.wait ()))
-        (fun _ -> h_ran := true; Lwt.return ())
+        (fun _ -> h_ran := true; Lwt.return_unit)
     in
     state_is Lwt.Sleep p
   end;
@@ -723,7 +723,7 @@ let backtrace_catch_tests = suite "backtrace_catch" [
         (fun () -> p1)
         (fun _exn ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
@@ -747,12 +747,12 @@ let try_bind_tests = suite "try_bind" [
   test "fulfilled, f' raises" begin fun () ->
     try
       ignore @@ Lwt.try_bind
-        (fun () -> Lwt.return ())
+        (fun () -> Lwt.return_unit)
         (fun () -> raise Exception)
-        (fun _ -> Lwt.return ());
-      Lwt.return false
+        (fun _ -> Lwt.return_unit);
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "rejected" begin fun () ->
@@ -780,11 +780,11 @@ let try_bind_tests = suite "try_bind" [
     try
       ignore @@ Lwt.try_bind
         (fun () -> Lwt.fail Exit)
-        (fun _ -> Lwt.return ())
+        (fun _ -> Lwt.return_unit)
         (fun _ -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "pending" begin fun () ->
@@ -793,8 +793,8 @@ let try_bind_tests = suite "try_bind" [
     let p =
       Lwt.try_bind
         (fun () -> p)
-        (fun _ -> f_ran := true; Lwt.return ())
-        (fun _ -> f_ran := true; Lwt.return ())
+        (fun _ -> f_ran := true; Lwt.return_unit)
+        (fun _ -> f_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is Lwt.Sleep p) (fun correct ->
     Lwt.return (correct && not !f_ran))
@@ -818,7 +818,7 @@ let try_bind_tests = suite "try_bind" [
       Lwt.try_bind
         (fun () -> p)
         (fun _ -> raise Exception)
-        (fun _ -> Lwt.return ())
+        (fun _ -> Lwt.return_unit)
     in
     Lwt.wakeup r ();
     state_is (Lwt.Fail Exception) p
@@ -856,7 +856,7 @@ let try_bind_tests = suite "try_bind" [
     let p =
       Lwt.try_bind
         (fun () -> p)
-        (fun _ -> Lwt.return ())
+        (fun _ -> Lwt.return_unit)
         (fun _ -> raise Exception)
     in
     Lwt.wakeup_exn r Exit;
@@ -887,9 +887,9 @@ let try_bind_tests = suite "try_bind" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
         (fun _exn ->
-          Lwt.return false)
+          Lwt.return_false)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
@@ -904,10 +904,10 @@ let try_bind_tests = suite "try_bind" [
       Lwt.try_bind
         (fun () -> p1)
         (fun () ->
-          Lwt.return false)
+          Lwt.return_false)
         (fun _exn ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
@@ -953,8 +953,8 @@ let backtrace_try_bind_tests = suite "backtrace_try_bind" [
     let p =
       Lwt.backtrace_try_bind add_loc
         (fun () -> p)
-        (fun _ -> f_ran := true; Lwt.return ())
-        (fun _ -> f_ran := true; Lwt.return ())
+        (fun _ -> f_ran := true; Lwt.return_unit)
+        (fun _ -> f_ran := true; Lwt.return_unit)
     in
     state_is Lwt.Sleep p
   end;
@@ -977,7 +977,7 @@ let backtrace_try_bind_tests = suite "backtrace_try_bind" [
       Lwt.backtrace_try_bind add_loc
         (fun () -> p)
         (fun _ -> raise Exception)
-        (fun _ -> Lwt.return ())
+        (fun _ -> Lwt.return_unit)
     in
     Lwt.wakeup r ();
     state_is (Lwt.Fail Exception) p
@@ -1000,7 +1000,7 @@ let backtrace_try_bind_tests = suite "backtrace_try_bind" [
     let p =
       Lwt.backtrace_try_bind add_loc
         (fun () -> p)
-        (fun _ -> Lwt.return ())
+        (fun _ -> Lwt.return_unit)
         (fun _ -> raise Exception)
     in
     Lwt.wakeup_exn r Exit;
@@ -1016,9 +1016,9 @@ let backtrace_try_bind_tests = suite "backtrace_try_bind" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
         (fun _exn ->
-          Lwt.return false)
+          Lwt.return_false)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
@@ -1033,10 +1033,10 @@ let backtrace_try_bind_tests = suite "backtrace_try_bind" [
       Lwt.backtrace_try_bind add_loc
         (fun () -> p1)
         (fun () ->
-          Lwt.return false)
+          Lwt.return_false)
         (fun _exn ->
           Lwt.wakeup r2 ();
-          Lwt.return true)
+          Lwt.return_true)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
@@ -1051,7 +1051,7 @@ let finalize_tests = suite "finalize" [
     let p =
       Lwt.finalize
         (fun () -> Lwt.return "foo")
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is (Lwt.Return "foo") p) (fun correct ->
     Lwt.return (correct && !f'_ran = true))
@@ -1060,7 +1060,7 @@ let finalize_tests = suite "finalize" [
   test "fulfilled, f' rejected" begin fun () ->
     let p =
       Lwt.finalize
-        (fun () -> Lwt.return ())
+        (fun () -> Lwt.return_unit)
         (fun () -> Lwt.fail Exception)
     in
     state_is (Lwt.Fail Exception) p
@@ -1070,11 +1070,11 @@ let finalize_tests = suite "finalize" [
   test "fulfilled, f' raises" begin fun () ->
     try
       ignore @@ Lwt.finalize
-        (fun () -> Lwt.return ())
+        (fun () -> Lwt.return_unit)
         (fun () -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "rejected" begin fun () ->
@@ -1082,7 +1082,7 @@ let finalize_tests = suite "finalize" [
     let p =
       Lwt.finalize
         (fun () -> Lwt.fail Exception)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is (Lwt.Fail Exception) p) (fun correct ->
     Lwt.return (correct && !f'_ran = true))
@@ -1103,9 +1103,9 @@ let finalize_tests = suite "finalize" [
       ignore @@ Lwt.finalize
         (fun () -> Lwt.fail Exit)
         (fun () -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "pending" begin fun () ->
@@ -1114,7 +1114,7 @@ let finalize_tests = suite "finalize" [
     let p =
       Lwt.finalize
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is Lwt.Sleep p) (fun correct ->
     Lwt.return (correct && !f'_ran = false))
@@ -1126,7 +1126,7 @@ let finalize_tests = suite "finalize" [
     let p =
       Lwt.finalize
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.wakeup r "foo";
     Lwt.bind (state_is (Lwt.Return "foo") p) (fun correct ->
@@ -1189,7 +1189,7 @@ let finalize_tests = suite "finalize" [
     let p =
       Lwt.finalize
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.wakeup_exn r Exception;
     Lwt.bind (state_is (Lwt.Fail Exception) p) (fun correct ->
@@ -1255,11 +1255,11 @@ let finalize_tests = suite "finalize" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
-    Lwt.bind p4 (fun () -> Lwt.return true)
+    Lwt.bind p4 (fun () -> Lwt.return_true)
   end;
 
   (* See "proxy during callback" in [bind] tests. *)
@@ -1271,11 +1271,11 @@ let finalize_tests = suite "finalize" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
-    Lwt.catch (fun () -> p4) (fun _exn -> Lwt.return true)
+    Lwt.catch (fun () -> p4) (fun _exn -> Lwt.return_true)
   end;
 ]
 let suites = suites @ [finalize_tests]
@@ -1286,7 +1286,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
     let p =
       Lwt.backtrace_finalize add_loc
         (fun () -> Lwt.return "foo")
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is (Lwt.Return "foo") p) (fun correct ->
     Lwt.return (correct && !f'_ran = true))
@@ -1295,7 +1295,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
   test "fulfilled, f' rejected" begin fun () ->
     let p =
       Lwt.backtrace_finalize add_loc
-        (fun () -> Lwt.return ())
+        (fun () -> Lwt.return_unit)
         (fun () -> Lwt.fail Exception)
     in
     state_is (Lwt.Fail Exception) p
@@ -1305,11 +1305,11 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
   test "fulfilled, f' raises" begin fun () ->
     try
       ignore @@ Lwt.backtrace_finalize add_loc
-        (fun () -> Lwt.return ())
+        (fun () -> Lwt.return_unit)
         (fun () -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "rejected" begin fun () ->
@@ -1317,7 +1317,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
     let p =
       Lwt.backtrace_finalize add_loc
         (fun () -> Lwt.fail Exception)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is (Lwt.Fail Exception) p) (fun correct ->
     Lwt.return (correct && !f'_ran = true))
@@ -1338,9 +1338,9 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
       ignore @@ Lwt.backtrace_finalize add_loc
         (fun () -> Lwt.fail Exit)
         (fun () -> raise Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "pending" begin fun () ->
@@ -1349,7 +1349,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
     let p =
       Lwt.backtrace_finalize add_loc
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.bind (state_is Lwt.Sleep p) (fun correct ->
     Lwt.return (correct && !f'_ran = false))
@@ -1361,7 +1361,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
     let p =
       Lwt.backtrace_finalize add_loc
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.wakeup r "foo";
     Lwt.bind (state_is (Lwt.Return "foo") p) (fun correct ->
@@ -1396,7 +1396,7 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
     let p =
       Lwt.backtrace_finalize add_loc
         (fun () -> p)
-        (fun () -> f'_ran := true; Lwt.return ())
+        (fun () -> f'_ran := true; Lwt.return_unit)
     in
     Lwt.wakeup_exn r Exception;
     Lwt.bind (state_is (Lwt.Fail Exception) p) (fun correct ->
@@ -1434,11 +1434,11 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup r1 ();
-    Lwt.bind p4 (fun () -> Lwt.return true)
+    Lwt.bind p4 (fun () -> Lwt.return_true)
   end;
 
   (* See "proxy during callback" in [bind] tests. *)
@@ -1450,11 +1450,11 @@ let backtrace_finalize_tests = suite "backtrace_finalize" [
         (fun () -> p1)
         (fun () ->
           Lwt.wakeup r2 ();
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let p4 = Lwt.bind p2 (fun () -> p3) in
     Lwt.wakeup_exn r1 Exit;
-    Lwt.catch (fun () -> p4) (fun _exn -> Lwt.return true)
+    Lwt.catch (fun () -> p4) (fun _exn -> Lwt.return_true)
   end;
 ]
 let suites = suites @ [backtrace_finalize_tests]
@@ -1462,7 +1462,7 @@ let suites = suites @ [backtrace_finalize_tests]
 let on_success_tests = suite "on_success" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.on_success (Lwt.return ()) (fun () -> f_ran := true);
+    Lwt.on_success (Lwt.return_unit) (fun () -> f_ran := true);
     later (fun () -> !f_ran = true)
   end;
 
@@ -1470,7 +1470,7 @@ let on_success_tests = suite "on_success" [
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
-    Lwt.on_success (Lwt.return ()) (fun () -> raise Exception);
+    Lwt.on_success (Lwt.return_unit) (fun () -> raise Exception);
     later (fun () ->
       restore ();
       !saw = Some Exception)
@@ -1522,7 +1522,7 @@ let suites = suites @ [on_success_tests]
 let on_failure_tests = suite "on_failure" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.on_failure (Lwt.return ()) (fun _ -> f_ran := true);
+    Lwt.on_failure (Lwt.return_unit) (fun _ -> f_ran := true);
     later (fun () -> !f_ran = false)
   end;
 
@@ -1581,7 +1581,7 @@ let suites = suites @ [on_failure_tests]
 let on_termination_tests = suite "on_termination" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.on_termination (Lwt.return ()) (fun () -> f_ran := true);
+    Lwt.on_termination (Lwt.return_unit) (fun () -> f_ran := true);
     later (fun () -> !f_ran = true)
   end;
 
@@ -1589,7 +1589,7 @@ let on_termination_tests = suite "on_termination" [
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
-    Lwt.on_termination (Lwt.return ()) (fun () -> raise Exception);
+    Lwt.on_termination (Lwt.return_unit) (fun () -> raise Exception);
     later (fun () ->
       restore ();
       !saw = Some Exception)
@@ -1664,7 +1664,7 @@ let on_any_tests = suite "on_any" [
     let f_ran = ref false in
     let g_ran = ref false in
     Lwt.on_any
-      (Lwt.return ())
+      (Lwt.return_unit)
       (fun () -> f_ran := true)
       (fun _ -> g_ran := true);
     later (fun () -> !f_ran = true && !g_ran = false)
@@ -1674,7 +1674,7 @@ let on_any_tests = suite "on_any" [
     let saw = ref None in
     let restore =
       set_async_exception_hook (fun exn -> saw := Some exn) in
-    Lwt.on_any (Lwt.return ()) (fun () -> raise Exception) ignore;
+    Lwt.on_any (Lwt.return_unit) (fun () -> raise Exception) ignore;
     later (fun () ->
       restore ();
       !saw = Some Exception)
@@ -1754,7 +1754,7 @@ let suites = suites @ [on_any_tests]
 let async_tests = suite "async" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.async (fun () -> f_ran := true; Lwt.return ());
+    Lwt.async (fun () -> f_ran := true; Lwt.return_unit);
     later (fun () -> !f_ran = true)
   end;
 
@@ -1784,7 +1784,7 @@ let async_tests = suite "async" [
     Lwt.async (fun () ->
       Lwt.bind p (fun () ->
         resolved := true;
-        Lwt.return ()));
+        Lwt.return_unit));
     Lwt.wakeup r ();
     later (fun () -> !resolved = true)
   end;
@@ -1806,7 +1806,7 @@ let suites = suites @ [async_tests]
 let dont_wait_tests = suite "dont_wait" [
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.dont_wait (fun () -> f_ran := true; Lwt.return ()) (fun _ -> ());
+    Lwt.dont_wait (fun () -> f_ran := true; Lwt.return_unit) (fun _ -> ());
     later (fun () -> !f_ran = true)
   end;
 
@@ -1833,7 +1833,7 @@ let dont_wait_tests = suite "dont_wait" [
       (fun () ->
         Lwt.bind p (fun () ->
           resolved := true;
-          Lwt.return ()))
+          Lwt.return_unit))
       (fun _ -> ());
     Lwt.wakeup r ();
     later (fun () -> !resolved = true)
@@ -1853,17 +1853,17 @@ let suites = suites @ [dont_wait_tests]
 
 let ignore_result_tests = suite "ignore_result" [
   test "fulfilled" begin fun () ->
-    Lwt.ignore_result (Lwt.return ());
+    Lwt.ignore_result (Lwt.return_unit);
     (* Reaching this without an exception is success. *)
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "rejected" begin fun () ->
     try
       Lwt.ignore_result (Lwt.fail Exception);
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "pending, fulfilled" begin fun () ->
@@ -1871,7 +1871,7 @@ let ignore_result_tests = suite "ignore_result" [
     Lwt.ignore_result p;
     Lwt.wakeup r ();
     (* Reaching this without process termination is success. *)
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test ~sequential:true "pending, rejected" begin fun () ->
@@ -1894,7 +1894,7 @@ let join_tests = suite "join" [
   end;
 
   test "all fulfilled" begin fun () ->
-    let p = Lwt.join [Lwt.return (); Lwt.return ()] in
+    let p = Lwt.join [Lwt.return_unit; Lwt.return_unit] in
     state_is (Lwt.Return ()) p
   end;
 
@@ -1905,7 +1905,7 @@ let join_tests = suite "join" [
 
   test "fulfilled and pending, fulfilled" begin fun () ->
     let p, r = Lwt.wait () in
-    let p = Lwt.join [Lwt.return (); p] in
+    let p = Lwt.join [Lwt.return_unit; p] in
     Lwt.wakeup r ();
     state_is (Lwt.Return ()) p
   end;
@@ -1919,7 +1919,7 @@ let join_tests = suite "join" [
 
   test "fulfilled and pending, rejected" begin fun () ->
     let p, r = Lwt.wait () in
-    let p = Lwt.join [Lwt.return (); p] in
+    let p = Lwt.join [Lwt.return_unit; p] in
     Lwt.wakeup_exn r Exception;
     state_is (Lwt.Fail Exception) p
   end;
@@ -2257,10 +2257,10 @@ let choose_tests = suite "choose" [
   test "empty" begin fun () ->
     try
       ignore (Lwt.choose []);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.choose [] would return a \
                            promise that is pending forever" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "fulfilled" begin fun () ->
@@ -2323,10 +2323,10 @@ let nchoose_tests = suite "nchoose" [
   test "empty" begin fun () ->
     try
       ignore (Lwt.nchoose []);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.nchoose [] would return a \
                            promise that is pending forever" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "all fulfilled" begin fun () ->
@@ -2385,10 +2385,10 @@ let nchoose_split_tests = suite "nchoose_split" [
   test "empty" begin fun () ->
     try
       ignore (Lwt.nchoose_split []);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.nchoose_split [] would return a \
                            promise that is pending forever" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "some fulfilled" begin fun () ->
@@ -2397,18 +2397,18 @@ let nchoose_split_tests = suite "nchoose_split" [
         [Lwt.return "foo"; fst (Lwt.wait ()); Lwt.return "bar"]
     in
     begin match Lwt.state p with
-    | Lwt.Return (["foo"; "bar"], [_]) -> Lwt.return true
-    | _ -> Lwt.return false
+    | Lwt.Return (["foo"; "bar"], [_]) -> Lwt.return_true
+    | _ -> Lwt.return_false
     end [@ocaml.warning "-4"]
   end;
 
   test "fulfilled, rejected" begin fun () ->
-    let p = Lwt.nchoose_split [Lwt.return (); Lwt.fail Exception] in
+    let p = Lwt.nchoose_split [Lwt.return_unit; Lwt.fail Exception] in
     Lwt.return (Lwt.state p = Lwt.Fail Exception)
   end;
 
   test "rejected, fulfilled" begin fun () ->
-    let p = Lwt.nchoose_split [Lwt.fail Exception; Lwt.return ()] in
+    let p = Lwt.nchoose_split [Lwt.fail Exception; Lwt.return_unit] in
     Lwt.return (Lwt.state p = Lwt.Fail Exception)
   end;
 
@@ -2423,8 +2423,8 @@ let nchoose_split_tests = suite "nchoose_split" [
     assert (Lwt.state p = Lwt.Sleep);
     Lwt.wakeup r "foo";
     begin match Lwt.state p with
-    | Lwt.Return (["foo"], [_]) -> Lwt.return true
-    | _ -> Lwt.return false
+    | Lwt.Return (["foo"], [_]) -> Lwt.return_true
+    | _ -> Lwt.return_false
     end [@ocaml.warning "-4"]
   end;
 
@@ -2440,8 +2440,8 @@ let nchoose_split_tests = suite "nchoose_split" [
     let p = Lwt.nchoose_split [p; p; fst (Lwt.wait ())] in
     Lwt.wakeup r ();
     begin match Lwt.state p with
-    | Lwt.Return ([(); ()], [_]) -> Lwt.return true
-    | _ -> Lwt.return false
+    | Lwt.Return ([(); ()], [_]) -> Lwt.return_true
+    | _ -> Lwt.return_false
     end [@ocaml.warning "-4"]
   end;
 
@@ -2461,7 +2461,7 @@ let suites = suites @ [nchoose_split_tests]
 
 let state_query_tests = suite "state query" [
   test "is_sleeping: fulfilled" begin fun () ->
-    Lwt.return (not @@ Lwt.is_sleeping (Lwt.return ()))
+    Lwt.return (not @@ Lwt.is_sleeping (Lwt.return_unit))
   end;
 
   test "is_sleeping: rejected" begin fun () ->
@@ -2489,9 +2489,9 @@ let state_query_tests = suite "state query" [
   test "poll: rejected" begin fun () ->
     try
       Lwt.poll (Lwt.fail Exception) |> ignore;
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "poll: pending" begin fun () ->
@@ -2541,9 +2541,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later r ();
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later: double use on task" begin fun () ->
@@ -2551,9 +2551,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later r ();
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later_result: double use on wait" begin fun () ->
@@ -2561,9 +2561,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later_result r (Result.Ok ());
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later_result" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later_result: double use on task" begin fun () ->
@@ -2571,9 +2571,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later_result r (Result.Ok ());
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later_result" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later_exn: double use on wait" begin fun () ->
@@ -2581,9 +2581,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later_exn r Exception;
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later_exn" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later_exn: double use on task" begin fun () ->
@@ -2591,9 +2591,9 @@ let wakeup_later_tests = suite "wakeup_later" [
     Lwt.wakeup r ();
     try
       Lwt.wakeup_later_exn r Exception;
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.wakeup_later_exn" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "wakeup_later_result: nested" begin fun () ->
@@ -2632,7 +2632,7 @@ let suites = suites @ [wakeup_later_tests]
 
 let cancel_tests = suite "cancel" [
   test "fulfilled" begin fun () ->
-    let p = Lwt.return () in
+    let p = Lwt.return_unit in
     Lwt.cancel p;
     Lwt.return (Lwt.state p = Lwt.Return ())
   end;
@@ -2721,7 +2721,7 @@ let on_cancel_tests = suite "on_cancel" [
 
   test "fulfilled" begin fun () ->
     let f_ran = ref false in
-    Lwt.on_cancel (Lwt.return ()) (fun () -> f_ran := true);
+    Lwt.on_cancel (Lwt.return_unit) (fun () -> f_ran := true);
     Lwt.return (!f_ran = false)
   end;
 
@@ -2752,7 +2752,7 @@ let suites = suites @ [on_cancel_tests]
 
 let protected_tests = suite "protected" [
   test "fulfilled" begin fun () ->
-    let p = Lwt.protected (Lwt.return ()) in
+    let p = Lwt.protected (Lwt.return_unit) in
     (* If [p] starts fulfilled, it can't be canceled. *)
     Lwt.return (Lwt.state p = Lwt.Return ())
   end;
@@ -2812,7 +2812,7 @@ let suites = suites @ [protected_tests]
 
 let cancelable_tests = suite "wrap_in_cancelable" [
   test "fulfilled" begin fun () ->
-    let p = Lwt.wrap_in_cancelable (Lwt.return ()) in
+    let p = Lwt.wrap_in_cancelable (Lwt.return_unit) in
     Lwt.return (Lwt.state p = Lwt.Return ())
   end;
 
@@ -2900,7 +2900,7 @@ let suites = suites @ [cancelable_tests]
 
 let no_cancel_tests = suite "no_cancel" [
   test "fulfilled" begin fun () ->
-    let p = Lwt.no_cancel (Lwt.return ()) in
+    let p = Lwt.no_cancel (Lwt.return_unit) in
     (* [p] starts fulfilled, so it can't be canceled. *)
     Lwt.return (Lwt.state p = Lwt.Return ())
   end;
@@ -2955,10 +2955,10 @@ let pick_tests = suite "pick" [
   test "empty" begin fun () ->
     try
       ignore (Lwt.pick []);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.pick [] would return a \
                            promise that is pending forever" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "fulfilled" begin fun () ->
@@ -3045,13 +3045,13 @@ let pick_tests = suite "pick" [
         (fun _ ->
           a.(!i) <- 1;
           i := 1;
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let _ =
       Lwt.bind p3 (fun _ ->
         a.(!i) <- 2;
         i := 1;
-        Lwt.return ())
+        Lwt.return_unit)
     in
     Lwt.wakeup_later r1 ();
     Lwt.return (a.(0) = 1 && a.(1) = 2)
@@ -3063,10 +3063,10 @@ let npick_tests = suite "npick" [
   test "empty" begin fun () ->
     try
       ignore (Lwt.npick []);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument "Lwt.npick [] would return a \
                            promise that is pending forever" ->
-      Lwt.return true
+      Lwt.return_true
   end [@ocaml.warning "-52"];
 
   test "all fulfilled" begin fun () ->
@@ -3153,13 +3153,13 @@ let npick_tests = suite "npick" [
         (fun _ ->
           a.(!i) <- 1;
           i := 1;
-          Lwt.return ())
+          Lwt.return_unit)
     in
     let _ =
       Lwt.bind p3 (fun _ ->
         a.(!i) <- 2;
         i := 1;
-        Lwt.return ())
+        Lwt.return_unit)
     in
     Lwt.wakeup_later r1 ();
     Lwt.return (a.(0) = 1 && a.(1) = 2)
@@ -3171,7 +3171,7 @@ let cancel_bind_tests = suite "cancel bind" [
   test "wait, pending, canceled" begin fun () ->
     let f_ran = ref false in
     let p, _ = Lwt.wait () in
-    let p' = Lwt.bind p (fun () -> f_ran := true; Lwt.return ()) in
+    let p' = Lwt.bind p (fun () -> f_ran := true; Lwt.return_unit) in
     Lwt.cancel p';
     Lwt.return
       (!f_ran = false && Lwt.state p = Lwt.Sleep && Lwt.state p' = Lwt.Sleep)
@@ -3180,7 +3180,7 @@ let cancel_bind_tests = suite "cancel bind" [
   test "task, pending, canceled" begin fun () ->
     let f_ran = ref false in
     let p, _ = Lwt.task () in
-    let p' = Lwt.bind p (fun () -> f_ran := true; Lwt.return ()) in
+    let p' = Lwt.bind p (fun () -> f_ran := true; Lwt.return_unit) in
     Lwt.cancel p';
     Lwt.return
       (!f_ran = false &&
@@ -3287,7 +3287,7 @@ let cancel_catch_tests = suite "cancel catch" [
     let p' =
       Lwt.catch
         (fun () -> p)
-        (fun _ -> f_ran := true; Lwt.return ())
+        (fun _ -> f_ran := true; Lwt.return_unit)
     in
     Lwt.cancel p';
     Lwt.return
@@ -3389,8 +3389,8 @@ let cancel_try_bind_tests = suite "cancel try_bind" [
     let p' =
       Lwt.try_bind
         (fun () -> p)
-        (fun () -> f_or_g_ran := true; Lwt.return ())
-        (fun _ -> f_or_g_ran := true; Lwt.return ())
+        (fun () -> f_or_g_ran := true; Lwt.return_unit)
+        (fun _ -> f_or_g_ran := true; Lwt.return_unit)
     in
     Lwt.cancel p';
     Lwt.return
@@ -3486,7 +3486,7 @@ let cancel_finalize_tests = suite "cancel finalize" [
     let p' =
       Lwt.finalize
         (fun () -> p)
-        (fun () -> f_ran := true; Lwt.return ())
+        (fun () -> f_ran := true; Lwt.return_unit)
     in
     Lwt.cancel p';
     Lwt.return
@@ -3499,7 +3499,7 @@ let cancel_finalize_tests = suite "cancel finalize" [
     let p' =
       Lwt.finalize
         (fun () -> p)
-        (fun () -> f_ran := true; Lwt.return ())
+        (fun () -> f_ran := true; Lwt.return_unit)
     in
     Lwt.cancel p';
     Lwt.return
@@ -3786,7 +3786,7 @@ let storage_tests = suite "storage" [
     let key = Lwt.new_key () in
     try
       Lwt.with_value key (Some 42) (fun () -> raise Exception) |> ignore;
-      Lwt.return false
+      Lwt.return_false
     with Exception ->
       Lwt.return (Lwt.get key = None)
   end;
@@ -3889,7 +3889,7 @@ let storage_tests = suite "storage" [
 
   test "finalize" begin fun () ->
     let key = Lwt.new_key () in
-    let f = fun () -> assert (Lwt.get key = Some 1337); Lwt.return () in
+    let f = fun () -> assert (Lwt.get key = Some 1337); Lwt.return_unit in
     let p, r = Lwt.wait () in
     Lwt.with_value key (Some 42) (fun () ->
       Lwt.with_value key (Some 1337) (fun () ->
@@ -4017,7 +4017,7 @@ let infix_operator_tests = suite "infix operators" [
   test "<&>" begin fun () ->
     let open Lwt.Infix in
     let p, r = Lwt.wait () in
-    let p' = p <&> Lwt.return () in
+    let p' = p <&> Lwt.return_unit in
     Lwt.wakeup r ();
     state_is (Lwt.Return ()) p'
   end;
@@ -4072,7 +4072,7 @@ let ppx_let_tests = suite "ppx_let" [
     in
     let x : (module Local.Empty) = (module Lwt.Let_syntax.Let_syntax.Open_on_rhs) in
     ignore x;
-    Lwt.return true
+    Lwt.return_true
   end;
 ]
 let suites = suites @ [ppx_let_tests]
@@ -4202,7 +4202,7 @@ let pause_tests = suite "pause" [
     assert (Lwt.paused_count () = 0);
     Lwt.wakeup_paused ();
     assert (Lwt.paused_count () = 0);
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "pause notifier" begin fun () ->
@@ -4213,7 +4213,7 @@ let pause_tests = suite "pause" [
     assert (!seen = Some 1);
     Lwt.wakeup_paused ();
     Lwt.register_pause_notifier ignore;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "pause in unpause" begin fun () ->
@@ -4238,7 +4238,7 @@ let pause_tests = suite "pause" [
     Lwt.pause () |> ignore;
     assert (Lwt.paused_count () = 2);
     Lwt.wakeup_paused ();
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "unpause in pause" begin fun () ->
@@ -4248,7 +4248,7 @@ let pause_tests = suite "pause" [
     Lwt.pause () |> ignore;
     assert (Lwt.paused_count () = 0);
     Lwt.register_pause_notifier ignore;
-    Lwt.return true
+    Lwt.return_true
   end;
 ]
 let suites = suites @ [pause_tests]
@@ -4462,8 +4462,8 @@ let tailrec_tests = suite "tailrec" [
     let f n = Lwt.return n in
     try
       ignore (aux f 0 10000000);
-      Lwt.return true
-    with _ -> Lwt.return false
+      Lwt.return_true
+    with _ -> Lwt.return_false
   end;
 ]
 let suites = suites @ [tailrec_tests]

--- a/test/core/test_lwt_list.ml
+++ b/test/core/test_lwt_list.ml
@@ -44,7 +44,7 @@ let test_exception list_combinator =
     incr number_of_callback_calls;
     match !number_of_callback_calls with
     | 2 -> raise Exception
-    | _ -> Lwt.return ()
+    | _ -> Lwt.return_unit
   in
 
   (* Even though the callback will raise immediately for one of the list
@@ -74,7 +74,7 @@ let test_map f test_list =
         match !c with
         | 5 -> t
         | 8 -> t'
-        | _ -> Lwt.return ()
+        | _ -> Lwt.return_unit
       in
       th >>= (fun () ->
         incr r;
@@ -99,9 +99,9 @@ let test_parallelism map =
   let t, w = Lwt.wait () in
   let g _ =
     Lwt.wakeup_later w ();
-    Lwt.return () in
+    Lwt.return_unit in
   let f x =
-    if x = 0 then t >>= (fun _ -> Lwt.return ())
+    if x = 0 then t >>= (fun _ -> Lwt.return_unit)
     else g x
   in
   let p = map f [0; 1] in
@@ -114,10 +114,10 @@ let test_serialization ?(rev=false) map =
     if x = k then
       Lwt.pause () >>= fun () ->
       assert(not !other_ran);
-      Lwt.return ()
+      Lwt.return_unit
     else begin
       other_ran := true;
-      Lwt.return ()
+      Lwt.return_unit
     end
   in
   let p = map f [0; 1] in
@@ -179,25 +179,25 @@ let suite_primary = suite "lwt_list" [
   test "iter_p" begin fun () ->
     test_iter Lwt_list.iter_p [1; 0; 1];
     test_exception Lwt_list.iter_p;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "iter_s" begin fun () ->
     test_iter Lwt_list.iter_s [1; 0; 0];
     test_exception Lwt_list.iter_s;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "map_p" begin fun () ->
     test_map Lwt_list.map_p [4; 8; 5];
     test_exception Lwt_list.map_p;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "map_s" begin fun () ->
     test_map Lwt_list.map_s [4; 7; 8];
     test_exception Lwt_list.map_s;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "fold_left_s" begin fun () ->
@@ -205,7 +205,7 @@ let suite_primary = suite "lwt_list" [
     let f acc v = Lwt.return (v::acc) in
     let t = Lwt_list.fold_left_s f [] l in
     t <=> Lwt.Return (List.rev l);
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "for_all_s"
@@ -268,10 +268,10 @@ let suite_primary = suite "lwt_list" [
       (fun () ->
         Lwt_list.find_s (fun n ->
           Lwt.return ((n mod 2) = 0)) l >>= fun _result ->
-        Lwt.return false)
+        Lwt.return_false)
       (function
-        | Not_found -> Lwt.return true
-        | _ -> Lwt.return false)
+        | Not_found -> Lwt.return_true
+        | _ -> Lwt.return_false)
   end;
 
   test "rev_map_p"
@@ -289,105 +289,105 @@ let suite_primary = suite "lwt_list" [
   test "iteri_p exception" begin fun () ->
     let i f = Lwt_list.iteri_p (fun _ x -> f x) in
     test_exception i;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "iteri_s exception" begin fun () ->
     let i f = Lwt_list.iteri_s (fun _ x -> f x) in
     test_exception i;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "map_s exception" begin fun () ->
     test_exception Lwt_list.map_s;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "map_p exception" begin fun () ->
     test_exception Lwt_list.map_p;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "mapi_s exception" begin fun () ->
     let m f = Lwt_list.mapi_s (fun _ x -> f x) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "mapi_p exception" begin fun () ->
     let m f = Lwt_list.mapi_p (fun _ x -> f x) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "rev_map_s exception" begin fun () ->
     test_exception Lwt_list.rev_map_s;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "rev_map_p exception" begin fun () ->
     test_exception Lwt_list.rev_map_p;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "fold_left_s exception" begin fun () ->
     let m f = Lwt_list.fold_left_s (fun _ x -> f x) () in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "fold_right_s exception" begin fun() ->
     let m f l = Lwt_list.fold_right_s (fun x _ -> f x) l () in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "for_all_p exception" begin fun () ->
     let m f =
       Lwt_list.for_all_p (fun x -> f x >>= (fun _ -> Lwt.return_true)) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "for_all_s exception" begin fun () ->
     let m f =
       Lwt_list.for_all_s (fun x -> f x >>= (fun _ -> Lwt.return_true)) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "exists_p exception" begin fun () ->
     let m f =
       Lwt_list.exists_p (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "exists_s exception" begin fun () ->
     let m f =
       Lwt_list.exists_s (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "find_s exception" begin fun () ->
     let m f = Lwt_list.find_s (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "filter_p exception" begin fun () ->
     let m f =
       Lwt_list.filter_p (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "filter_s exception" begin fun () ->
     let m f =
       Lwt_list.filter_s (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "filter_map_p exception" begin fun () ->
@@ -395,7 +395,7 @@ let suite_primary = suite "lwt_list" [
       Lwt_list.filter_map_p (fun x -> f x >>= (fun _ -> Lwt.return (Some ())))
     in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "filter_map_s exception" begin fun () ->
@@ -403,21 +403,21 @@ let suite_primary = suite "lwt_list" [
       Lwt_list.filter_map_s (fun x -> f x >>= (fun _ -> Lwt.return (Some ())))
     in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "partition_p exception" begin fun () ->
     let m f =
       Lwt_list.partition_p (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "partition_s exception" begin fun () ->
     let m f =
       Lwt_list.partition_s (fun x -> f x >>= (fun _ -> Lwt.return_false)) in
     test_exception m;
-    Lwt.return true;
+    Lwt.return_true;
   end;
 
   test "iter_p parallelism" begin fun () ->
@@ -466,13 +466,13 @@ let suite_primary = suite "lwt_list" [
 
   test "fold_left_s serialization" begin fun () ->
     let m f =
-      Lwt_list.fold_left_s (fun _ x -> f x >>= fun _ -> Lwt.return ()) () in
+      Lwt_list.fold_left_s (fun _ x -> f x >>= fun _ -> Lwt.return_unit) () in
     test_serialization m
   end;
 
   test "fold_right_s serialization" begin fun () ->
     let m f l =
-      Lwt_list.fold_right_s (fun x _ -> f x >>= fun _ -> Lwt.return ()) l () in
+      Lwt_list.fold_right_s (fun x _ -> f x >>= fun _ -> Lwt.return_unit) l () in
     test_serialization ~rev:true m
   end;
 
@@ -536,20 +536,20 @@ let suite_primary = suite "lwt_list" [
 
   test "partition_p parallelism" begin fun () ->
     let m f l =
-      Lwt_list.partition_p (fun x -> f x >>= fun _ -> Lwt.return true) l in
+      Lwt_list.partition_p (fun x -> f x >>= fun _ -> Lwt.return_true) l in
     test_parallelism m
   end;
 
   test "partition_s serialization" begin fun () ->
     let m f l =
-      Lwt_list.partition_s (fun x -> f x >>= fun _ -> Lwt.return true) l in
+      Lwt_list.partition_s (fun x -> f x >>= fun _ -> Lwt.return_true) l in
     test_serialization m
   end;
 ]
 
 let test_big_list m =
   let make_list n = Array.to_list @@ Array.init n (fun x -> x) in
-  let f _ = Lwt.return () in
+  let f _ = Lwt.return_unit in
   m f (make_list 10_000_000) >>= (fun _ -> Lwt.return_true)
 
 let suite_intensive = suite "lwt_list big lists"
@@ -602,13 +602,13 @@ let suite_intensive = suite "lwt_list big lists"
 
   test "fold_left_s big list" begin fun () ->
     let m f =
-      Lwt_list.fold_left_s (fun _ x -> f x >>= fun _ -> Lwt.return ()) () in
+      Lwt_list.fold_left_s (fun _ x -> f x >>= fun _ -> Lwt.return_unit) () in
     test_big_list m
   end;
 
   test "fold_right_s big list" begin fun () ->
     let m f l =
-      Lwt_list.fold_right_s (fun x _ -> f x >>= fun _ -> Lwt.return ()) l () in
+      Lwt_list.fold_right_s (fun x _ -> f x >>= fun _ -> Lwt.return_unit) l () in
     test_big_list m
   end;
 
@@ -665,13 +665,13 @@ let suite_intensive = suite "lwt_list big lists"
 
   test "partition_p big list" begin fun () ->
     let m f l =
-      Lwt_list.partition_p (fun x -> f x >>= fun _ -> Lwt.return true) l in
+      Lwt_list.partition_p (fun x -> f x >>= fun _ -> Lwt.return_true) l in
     test_big_list m
   end;
 
   test "partition_s big list" begin fun () ->
     let m f l =
-      Lwt_list.partition_s (fun x -> f x >>= fun _ -> Lwt.return true) l in
+      Lwt_list.partition_s (fun x -> f x >>= fun _ -> Lwt.return_true) l in
     test_big_list m
   end;
 ]

--- a/test/core/test_lwt_pool.ml
+++ b/test/core/test_lwt_pool.ml
@@ -10,7 +10,7 @@ exception Dummy_error
 let suite = suite "lwt_pool" [
 
   test "basic create-use" begin fun () ->
-    let gen = fun () -> Lwt.return () in
+    let gen = fun () -> Lwt.return_unit in
     let p = Lwt_pool.create 1 gen in
     Lwt.return (Lwt.state (Lwt_pool.use p Lwt.return) = Lwt.Return ())
   end;
@@ -42,7 +42,7 @@ let suite = suite "lwt_pool" [
   test "validation exceptions are propagated to users" begin fun () ->
     let c = Lwt_condition.create () in
     let gen = (fun () -> let l = ref 0 in Lwt.return l) in
-    let v l = if !l = 0 then Lwt.return true else Lwt.fail Dummy_error in
+    let v l = if !l = 0 then Lwt.return_true else Lwt.fail Dummy_error in
     let p = Lwt_pool.create 1 ~validate:v gen in
     let u1 = Lwt_pool.use p (fun l -> l := 1; Lwt_condition.wait c) in
     let u2 = Lwt_pool.use p (fun l -> Lwt.return !l) in
@@ -106,7 +106,7 @@ let suite = suite "lwt_pool" [
   test "waiter are notified on replacement" begin fun () ->
     let c = Lwt_condition.create () in
     let gen = (fun () -> let l = ref 0 in Lwt.return l) in
-    let v l = if !l = 0 then Lwt.return true else Lwt.fail Dummy_error in
+    let v l = if !l = 0 then Lwt.return_true else Lwt.fail Dummy_error in
     let p = Lwt_pool.create 1 ~validate:v gen in
     let u1 = Lwt_pool.use p (fun l -> l := 1; Lwt_condition.wait c) in
     let u2 = Lwt_pool.use p (fun l -> Lwt.return !l) in
@@ -130,7 +130,7 @@ let suite = suite "lwt_pool" [
       else
         Lwt.fail Dummy_error
     in
-    let v l = if !l = 0 then Lwt.return true else Lwt.fail Dummy_error in
+    let v l = if !l = 0 then Lwt.return_true else Lwt.fail Dummy_error in
     let p = Lwt_pool.create 1 ~validate:v gen in
     let u1 = Lwt_pool.use p (fun l -> l := 1; k:= false; Lwt_condition.wait c) in
     let u2 = Lwt_pool.use p (fun l -> Lwt.return !l) in

--- a/test/packaging/dune/core/user.ml
+++ b/test/packaging/dune/core/user.ml
@@ -1,2 +1,2 @@
 let () =
-  Lwt.return () |> ignore
+  Lwt.return_unit |> ignore

--- a/test/packaging/dune/ppx/user.ml
+++ b/test/packaging/dune/ppx/user.ml
@@ -1,6 +1,6 @@
 let () =
   let p =
-    let%lwt () = Lwt.return () in
-    Lwt.return ()
+    let%lwt () = Lwt.return_unit in
+    Lwt.return_unit
   in
   ignore p

--- a/test/packaging/ocamlfind/core/user.ml
+++ b/test/packaging/ocamlfind/core/user.ml
@@ -1,2 +1,2 @@
 let () =
-  Lwt.return () |> ignore
+  Lwt.return_unit |> ignore

--- a/test/packaging/ocamlfind/ppx/user.ml
+++ b/test/packaging/ocamlfind/ppx/user.ml
@@ -1,6 +1,6 @@
 let () =
   let p =
-    let%lwt () = Lwt.return () in
-    Lwt.return ()
+    let%lwt () = Lwt.return_unit in
+    Lwt.return_unit
   in
   ignore p

--- a/test/ppx/main.ml
+++ b/test/ppx/main.ml
@@ -6,7 +6,7 @@ open Lwt
    local module inside the tester function, because that function is run inside
    an outer call to Lwt_main.run, and nested calls to Lwt_main.run are not
    allowed. *)
-let%lwt structure_let_result = Lwt.return true
+let%lwt structure_let_result = Lwt.return_true
 
 let suite = suite "ppx" [
   test "let"
@@ -56,7 +56,7 @@ let suite = suite "ppx" [
 
   test "if"
     (fun () ->
-       let x = Lwt.return true in
+       let x = Lwt.return_true in
        let%lwt a =
          if%lwt x then Lwt.return_true else Lwt.return_false
        in

--- a/test/ppx_expect/cases/let_1.ml
+++ b/test/ppx_expect/cases/let_1.ml
@@ -1,3 +1,3 @@
 let _ =
   let%lwt () = Lwt.return 5 in
-  Lwt.return ();;
+  Lwt.return_unit;;

--- a/test/ppx_expect/cases/let_2.ml
+++ b/test/ppx_expect/cases/let_2.ml
@@ -1,3 +1,3 @@
 let _ =
-  let%lwt () = Lwt.return () in
+  let%lwt () = Lwt.return_unit in
   ();;

--- a/test/ppx_expect/cases/let_3.ml
+++ b/test/ppx_expect/cases/let_3.ml
@@ -1,3 +1,3 @@
 let _ =
-  let%lwt () = Lwt.return () and () = Lwt.return 5 in
-  Lwt.return ();;
+  let%lwt () = Lwt.return_unit and () = Lwt.return 5 in
+  Lwt.return_unit;;

--- a/test/ppx_expect/cases/let_4.ml
+++ b/test/ppx_expect/cases/let_4.ml
@@ -1,3 +1,3 @@
 let _ =
-  let%lwt foo = Lwt.return () and bar = Lwt.return 5 in
+  let%lwt foo = Lwt.return_unit and bar = Lwt.return 5 in
   Lwt.return (foo + bar);;

--- a/test/ppx_expect/cases/match_1.ml
+++ b/test/ppx_expect/cases/match_1.ml
@@ -3,4 +3,4 @@ let _ =
     Lwt.return 5
   with
   | () ->
-    Lwt.return ();;
+    Lwt.return_unit;;

--- a/test/ppx_expect/cases/match_2.ml
+++ b/test/ppx_expect/cases/match_2.ml
@@ -3,4 +3,4 @@ let _ =
     ()
   with
   | () ->
-    Lwt.return ();;
+    Lwt.return_unit;;

--- a/test/ppx_expect/cases/match_3.ml
+++ b/test/ppx_expect/cases/match_3.ml
@@ -1,6 +1,6 @@
 let _ =
   match%lwt
-    Lwt.return ()
+    Lwt.return_unit
   with
   | () ->
     5;;

--- a/test/ppx_expect/cases/match_4.ml
+++ b/test/ppx_expect/cases/match_4.ml
@@ -1,8 +1,8 @@
 let _ =
   match%lwt
-    Lwt.return ()
+    Lwt.return_unit
   with
   | () ->
-    Lwt.return ()
+    Lwt.return_unit
   | exception End_of_file ->
     Lwt.return 5

--- a/test/ppx_expect/cases/match_5.ml
+++ b/test/ppx_expect/cases/match_5.ml
@@ -1,3 +1,3 @@
 let _ =
   (* The ugly one-line match is for error message compatibility with 4.09. *)
-  match%lwt Lwt.return () with exception Exit -> Lwt.return 0
+  match%lwt Lwt.return_unit with exception Exit -> Lwt.return 0

--- a/test/ppx_expect/cases/run_1.ml
+++ b/test/ppx_expect/cases/run_1.ml
@@ -1,2 +1,2 @@
 (* On one line for error message compatibility with 4.09. *)
-let%lwt () = Lwt.return ()
+let%lwt () = Lwt.return_unit

--- a/test/ppx_expect/cases/run_2.ml
+++ b/test/ppx_expect/cases/run_2.ml
@@ -1,2 +1,2 @@
-let%lwt rec () = Lwt.return ()
-and () = Lwt.return ()
+let%lwt rec () = Lwt.return_unit
+and () = Lwt.return_unit

--- a/test/ppx_expect/cases/try_1.ml
+++ b/test/ppx_expect/cases/try_1.ml
@@ -1,4 +1,4 @@
 let _ =
   try%lwt
     5
-  with _ -> Lwt.return ();;
+  with _ -> Lwt.return_unit;;

--- a/test/ppx_expect/cases/try_2.ml
+++ b/test/ppx_expect/cases/try_2.ml
@@ -1,4 +1,4 @@
 let _ =
   try%lwt
-    Lwt.return ()
+    Lwt.return_unit
   with _ -> 5;;

--- a/test/ppx_expect/cases/try_3.ml
+++ b/test/ppx_expect/cases/try_3.ml
@@ -1,4 +1,4 @@
 let _ =
   try%lwt
-    Lwt.return ()
+    Lwt.return_unit
   with _ -> Lwt.return 5;;

--- a/test/test.ml
+++ b/test/test.ml
@@ -345,7 +345,7 @@ let with_async_exception_hook hook f =
   Lwt.async_exception_hook := hook;
   Lwt.finalize f (fun () ->
     Lwt.async_exception_hook := old_hook;
-    Lwt.return ())
+    Lwt.return_unit)
 
 let instrument = function
   | true -> Printf.ksprintf (fun _s -> true)

--- a/test/unix/test_lwt_bytes.ml
+++ b/test/unix/test_lwt_bytes.ml
@@ -87,7 +87,7 @@ let test_mincore buff_len offset n_states =
   let buffer = Lwt_bytes.map_file ~fd ~shared ~size () in
   let states = Array.make n_states false in
   let () = Lwt_bytes.mincore buffer offset states in
-  Lwt.return ()
+  Lwt.return_unit
 
 let test_wait_mincore buff_len offset =
   let test_file = Printf.sprintf "bytes_mincore_write_%i" (file_suffix ()) in
@@ -126,29 +126,29 @@ let suite = suite "lwt_bytes" [
     test "get out of bounds : lower limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
       match Lwt_bytes.get buff (-1) with
-      | exception Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
     end;
 
     test "get out of bounds : upper limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
       match Lwt_bytes.get buff 3 with
-      | exception Invalid_argument _ -> Lwt.return true
-      | _ -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | _ -> Lwt.return_false
     end;
 
     test "set out of bounds : lower limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
       match Lwt_bytes.set buff (-1) 'a' with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "set out of bounds : upper limit" begin fun () ->
       let buff = Lwt_bytes.create 3 in
       match Lwt_bytes.set buff 3 'a' with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "unsafe_get/unsafe_set" begin fun () ->
@@ -211,8 +211,8 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       match Lwt_bytes.blit buf1 (-1) buf2 3 3 with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit source out of bounds: upper limit" begin fun () ->
@@ -221,8 +221,8 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       match Lwt_bytes.blit buf1 1 buf2 3 3 with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit destination out of bounds: lower limit" begin fun () ->
@@ -231,8 +231,8 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       match Lwt_bytes.blit buf1 0 buf2 (-1) 3 with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit destination out of bounds: upper limit" begin fun () ->
@@ -241,8 +241,8 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       match Lwt_bytes.blit buf1 0 buf2 4 3 with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit length out of bounds: lower limit" begin fun () ->
@@ -251,8 +251,8 @@ let suite = suite "lwt_bytes" [
       let str2 = "abcdef" in
       let buf2 = Lwt_bytes.of_string str2 in
       match Lwt_bytes.blit buf1 0 buf2 3 (-1) with
-      | exception Invalid_argument _ -> Lwt.return true
-      | () -> Lwt.return false
+      | exception Invalid_argument _ -> Lwt.return_true
+      | () -> Lwt.return_false
     end;
 
     test "blit from bytes" begin fun () ->
@@ -781,7 +781,7 @@ let suite = suite "lwt_bytes" [
     test "mincore buffer length = page_size * 2, n_states = 1"
       ~only_if:(fun () -> not Sys.win32) begin fun () ->
       test_mincore (Lwt_bytes.page_size * 2) Lwt_bytes.page_size 1
-      >>= fun () -> Lwt.return true
+      >>= fun () -> Lwt.return_true
     end;
 
     test "mincore buffer length = page_size * 2, n_states = 2"
@@ -789,10 +789,10 @@ let suite = suite "lwt_bytes" [
       Lwt.catch
         (fun () ->
            test_mincore (Lwt_bytes.page_size * 2) Lwt_bytes.page_size 2
-           >>= fun () -> Lwt.return false
+           >>= fun () -> Lwt.return_false
         )
         (function
-          | Invalid_argument _message -> Lwt.return true
+          | Invalid_argument _message -> Lwt.return_true
           | exn -> Lwt.fail exn
         )
     end;
@@ -801,19 +801,19 @@ let suite = suite "lwt_bytes" [
       ~only_if:(fun () -> not Sys.win32) begin fun () ->
       test_mincore (Lwt_bytes.page_size * 2 + 1) Lwt_bytes.page_size 2
       >>= fun () ->
-      Lwt.return true
+      Lwt.return_true
     end;
 
     test "mincore buffer length = page_size , n_states = 0"
       ~only_if:(fun () -> not Sys.win32) begin fun () ->
       test_mincore (Lwt_bytes.page_size * 2 + 1) Lwt_bytes.page_size 0
-      >>= fun () -> Lwt.return true
+      >>= fun () -> Lwt.return_true
     end;
 
     test "wait_mincore correct bounds"
       ~only_if:(fun () -> not Sys.win32) begin fun () ->
       test_wait_mincore (Lwt_bytes.page_size * 2 + 1) Lwt_bytes.page_size
-      >>= fun () -> Lwt.return true
+      >>= fun () -> Lwt.return_true
     end;
 
     test "wait_mincore offset < 0"
@@ -821,10 +821,10 @@ let suite = suite "lwt_bytes" [
       Lwt.catch
         (fun () ->
            test_wait_mincore (Lwt_bytes.page_size * 2 + 1) (-1)
-           >>= fun () -> Lwt.return false
+           >>= fun () -> Lwt.return_false
         )
         (function
-          | Invalid_argument _message -> Lwt.return true
+          | Invalid_argument _message -> Lwt.return_true
           | exn -> Lwt.fail exn
         )
     end;
@@ -835,10 +835,10 @@ let suite = suite "lwt_bytes" [
         (fun () ->
            let buff_len = Lwt_bytes.page_size * 2 + 1 in
            test_wait_mincore buff_len (buff_len + 1)
-           >>= fun () -> Lwt.return false
+           >>= fun () -> Lwt.return_false
         )
         (function
-          | Invalid_argument _message -> Lwt.return true
+          | Invalid_argument _message -> Lwt.return_true
           | exn -> Lwt.fail exn
         )
     end;

--- a/test/unix/test_lwt_engine.ml
+++ b/test/unix/test_lwt_engine.ml
@@ -69,10 +69,10 @@ let run_tests = [
     Lwt.pause () >>= fun () ->
 
     try
-      Lwt_main.run (Lwt.return ());
-      Lwt.return false
+      Lwt_main.run (Lwt.return_unit);
+      Lwt.return_false
     with Failure _ ->
-      Lwt.return true
+      Lwt.return_true
   end;
 ]
 

--- a/test/unix/test_lwt_io.ml
+++ b/test/unix/test_lwt_io.ml
@@ -87,7 +87,7 @@ let suite = suite "lwt_io" [
       Lwt_io.write oc "bar" >>= fun () ->
       if !sent <> [] then begin
         prerr_endline "auto-flush: !sent not empty";
-        Lwt.return false
+        Lwt.return_false
       end
       else
         Lwt_unix.sleep 0.1 >>= fun () ->
@@ -118,7 +118,7 @@ let suite = suite "lwt_io" [
           Lwt_io.write oc "bar" >>= fun () ->
           if !sent <> [] then begin
             prerr_endline "auto-flush atomic: !sent not empty";
-            Lwt.return false
+            Lwt.return_false
           end
           else
             Lwt_unix.sleep 0.1 >>= fun () ->
@@ -418,10 +418,10 @@ let suite = suite "lwt_io" [
     Lwt.catch
       (fun () ->
         Lwt_io.file_length "." >>= fun _ ->
-        Lwt.return false)
+        Lwt.return_false)
       (function
       | Unix.Unix_error (Unix.EISDIR, "file_length", ".") ->
-        Lwt.return true
+        Lwt.return_true
       | exn -> Lwt.fail exn)
   end;
 

--- a/test/unix/test_lwt_timeout.ml
+++ b/test/unix/test_lwt_timeout.ml
@@ -98,15 +98,15 @@ let suite = suite "Lwt_timeout" [
     Lwt_timeout.create 1 ignore
     |> Lwt_timeout.stop;
 
-    Lwt.return true
+    Lwt.return_true
   end;
 
   test "invalid delay" begin fun () ->
     try
       ignore (Lwt_timeout.create 0 ignore);
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument _ ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test "change" begin fun () ->
@@ -165,9 +165,9 @@ let suite = suite "Lwt_timeout" [
     let timeout = (Lwt_timeout.create 1 ignore) in
     try
       Lwt_timeout.change timeout 0;
-      Lwt.return false
+      Lwt.return_false
     with Invalid_argument _ ->
-      Lwt.return true
+      Lwt.return_true
   end;
 
   test ~sequential:true "exception in action" begin fun () ->

--- a/test/unix/test_lwt_unix.ml
+++ b/test/unix/test_lwt_unix.ml
@@ -388,7 +388,7 @@ let readv_tests =
     (if close then
       Lwt_unix.close read_fd
     else
-      Lwt.return ()) >>= fun () ->
+      Lwt.return_unit) >>= fun () ->
 
     let actual =
       List.fold_left (fun acc -> function
@@ -515,7 +515,7 @@ let readv_tests =
       Lwt_list.for_all_s (fun t -> t ()) [
         writer write_fd "foobar";
         reader ~close:false read_fd io_vectors underlying 3 "_foo_______";
-        (fun () -> Lwt_unix.IO_vectors.drop io_vectors 3; Lwt.return true);
+        (fun () -> Lwt_unix.IO_vectors.drop io_vectors 3; Lwt.return_true);
         reader read_fd io_vectors underlying 3 "_foo__bar__";
       ]
     end;
@@ -544,7 +544,7 @@ let writev_tests =
     (if close then
       Lwt_unix.close write_fd
     else
-      Lwt.return ()) >>= fun () ->
+      Lwt.return_unit) >>= fun () ->
     let blocking_matches =
       match blocking, is_blocking with
       | Some v, v' when v <> v' ->
@@ -782,7 +782,7 @@ let writev_tests =
 
       Lwt_list.for_all_s (fun t -> t ()) [
         writer ~close:false write_fd io_vectors 3;
-        (fun () -> Lwt_unix.IO_vectors.drop io_vectors 3; Lwt.return true);
+        (fun () -> Lwt_unix.IO_vectors.drop io_vectors 3; Lwt.return_true);
         writer write_fd io_vectors 3;
         reader read_fd "foobar";
       ]
@@ -804,7 +804,7 @@ let send_recv_msg_tests = [
       ~io_vectors:source_iovecs
       ~fds:[Lwt_unix.unix_file_descr pipe_write] >>= fun n ->
     if n <> 6 then
-      Lwt.return false
+      Lwt.return_false
 
     else
       let destination_buffer = Bytes.of_string "_________" in
@@ -823,12 +823,12 @@ let send_recv_msg_tests = [
       in
       match succeeded with
       | None ->
-        Lwt.return false
+        Lwt.return_false
       | Some fd ->
 
         let n = Unix.write fd (Bytes.of_string "baz") 0 3 in
         if n <> 3 then
-          Lwt.return false
+          Lwt.return_false
 
         else
           let buffer = Bytes.create 3 in
@@ -840,10 +840,10 @@ let send_recv_msg_tests = [
             Lwt_unix.close pipe_read >>= fun () ->
             Lwt_unix.close pipe_write >>= fun () ->
             Unix.close fd;
-            Lwt.return true
+            Lwt.return_true
 
           | _ ->
-            Lwt.return false
+            Lwt.return_false
   end;
 
   test "send_msg, recv_msg (Lwt_bytes, old)" ~only_if:(fun () -> not Sys.win32)
@@ -872,7 +872,7 @@ let send_recv_msg_tests = [
       ~io_vectors:source_iovecs
       ~fds:[Lwt_unix.unix_file_descr pipe_write] >>= fun n ->
     if n <> 6 then
-      Lwt.return false
+      Lwt.return_false
 
     else
       let destination_buffer = Lwt_bytes.of_string "_________" in
@@ -899,12 +899,12 @@ let send_recv_msg_tests = [
       in
       match succeeded with
       | None ->
-        Lwt.return false
+        Lwt.return_false
       | Some fd ->
 
         let n = Unix.write fd (Bytes.of_string "baz") 0 3 in
         if n <> 3 then
-          Lwt.return false
+          Lwt.return_false
 
         else
           let buffer = Bytes.create 3 in
@@ -916,10 +916,10 @@ let send_recv_msg_tests = [
             Lwt_unix.close pipe_read >>= fun () ->
             Lwt_unix.close pipe_write >>= fun () ->
             Unix.close fd;
-            Lwt.return true
+            Lwt.return_true
 
           | _ ->
-            Lwt.return false
+            Lwt.return_false
   end;
 ]
 

--- a/test/unix/test_mcast.ml
+++ b/test/unix/test_mcast.ml
@@ -53,7 +53,7 @@ let test_mcast name join set_loop =
              fd1 (ADDR_INET (Unix.inet_addr_any, mcast_port))) >>= fun () ->
            let t1 = child mcast_addr join fd1 in
            let t2 = parent mcast_addr mcast_port set_loop fd2 in
-           Lwt.join [t1; t2] >>= fun () -> Lwt.return true
+           Lwt.join [t1; t2] >>= fun () -> Lwt.return_true
         )
         (function
           | Lwt_unix.Timeout ->

--- a/test/unix/test_sleep_and_timeout.ml
+++ b/test/unix/test_sleep_and_timeout.ml
@@ -54,7 +54,7 @@ let suite = suite "Lwt_unix sleep and timeout" [
            Lwt_unix.with_timeout duration f
            >>= fun () ->
            Printf.eprintf "\nno timeout\n";
-           Lwt.return false
+           Lwt.return_false
         )
         (function
           | Lwt_unix.Timeout ->
@@ -67,7 +67,7 @@ let suite = suite "Lwt_unix sleep and timeout" [
 
     test "pause" begin fun () ->
       let bind_callback_ran = ref false in
-      Lwt.async (fun () -> Lwt.return () >|= fun () -> bind_callback_ran := true);
+      Lwt.async (fun () -> Lwt.return_unit >|= fun () -> bind_callback_ran := true);
       let bind_is_immediate = !bind_callback_ran in
       let pause_callback_ran = ref false in
       Lwt.async (fun () -> Lwt.pause () >|= fun () -> pause_callback_ran := true);


### PR DESCRIPTION
Not the greatest contribution ever, but I think it's better for consistency.
```sh
sed -i -e 's/Lwt\.return None/Lwt.return_none/g'   \
       -e 's/Lwt\.return ()/Lwt.return_unit/g'     \
       -e 's/Lwt\.return true/Lwt.return_true/g'   \
       -e 's/Lwt\.return false/Lwt.return_false/g' \
       -e 's/Lwt\.return \[\]/Lwt.return_nil/g'    \
       **/*.ml
```