### PR TITLE
Expose `Lwt_io.delete_recursively`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 ====== Additions ======
 
   * Lwt.reraise an exception raising function which preserves backtraces, recommended for use in Lwt.catch (#963)
+  * Expose Lwt_io.delete_recursively for deleting a directory and its content recursively. (#984, Antonin Décimo)
 
 ====== Build ======
 

--- a/src/unix/lwt_io.mli
+++ b/src/unix/lwt_io.mli
@@ -543,9 +543,19 @@ val with_temp_dir :
     arguments to it. Once the temporary directory is created at [path],
     [with_temp_dir f] calls [f path]. When the promise returned by [f path] is
     resolved, [with_temp_dir f] recursively deletes the temporary directory and
-    all its contents.
+    all its contents by calling {!Lwt_io.delete_recursively}.
 
     @since 4.4.0 *)
+
+val delete_recursively : string -> unit Lwt.t
+(** [delete_recursively path] attempts to delete the directory [path]
+    and all its content recursively.
+
+    This is likely VERY slow for directories with many files. That is probably
+    best addressed by switching to blocking calls run inside a worker thread,
+    i.e. with {!Lwt_preemptive}.
+
+    @since 5.7.0 *)
 
 val open_connection :
   ?fd : Lwt_unix.file_descr ->


### PR DESCRIPTION
Slight variations of this code are getting duplicated across our codebase, maybe it's best to expose it at the root in Lwt? Would another name better fit the function?