### PR TITLE
Enable to read which backend was picked by libev.

### DIFF
--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -147,6 +147,8 @@ struct
   let devpoll = EV_DEVPOLL
   let port = EV_PORT
 
+  let equal = ( = )
+
   let name = function
     | EV_DEFAULT -> "EV_DEFAULT"
     | EV_SELECT -> "EV_SELECT"
@@ -160,6 +162,7 @@ struct
 end
 
 external ev_init : Ev_backend.t -> ev_loop = "lwt_libev_init"
+external ev_backend : ev_loop -> Ev_backend.t = "lwt_libev_backend"
 external ev_stop : ev_loop -> unit = "lwt_libev_stop"
 external ev_loop : ev_loop -> bool -> unit = "lwt_libev_loop"
 external ev_unloop : ev_loop -> unit = "lwt_libev_unloop"
@@ -174,6 +177,8 @@ class libev ?(backend=Ev_backend.default) () = object
 
   val loop = ev_init backend
   method loop = loop
+
+  method backend = ev_backend loop
 
   method private cleanup = ev_stop loop
 

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -127,6 +127,8 @@ sig
   val devpoll : t
   val port : t
 
+  val equal : t -> t -> bool
+
   val pp : Format.formatter -> t -> unit
 end
 
@@ -136,6 +138,9 @@ end
     creation of the class will raise {!Lwt_sys.Not_available}. *)
 class libev : ?backend:Ev_backend.t -> unit -> object
   inherit t
+
+  method backend : Ev_backend.t
+    (** The backend picked by libev. *)
 
   val loop : ev_loop
     (** The libev loop used for this engine. *)
@@ -200,6 +205,7 @@ sig
   class libev_1 : object
     inherit t
     val loop : ev_loop
+    method backend : Ev_backend.t
     method loop : ev_loop
   end
   [@@ocaml.deprecated
@@ -214,6 +220,7 @@ sig
   class libev_2 : ?backend:Ev_backend.t -> unit -> object
     inherit t
     val loop : ev_loop
+    method backend : Ev_backend.t
     method loop : ev_loop
   end
   [@@ocaml.deprecated

--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -91,6 +91,25 @@ CAMLprim value lwt_libev_init(value backend) {
   return result;
 }
 
+CAMLprim value lwt_libev_backend(value loop) {
+  switch (ev_backend(Ev_loop_val(loop))) {
+  case EVBACKEND_SELECT:
+    return Val_int(val_EVBACKEND_SELECT);
+  case EVBACKEND_POLL:
+    return Val_int(val_EVBACKEND_POLL);
+  case EVBACKEND_EPOLL:
+    return Val_int(val_EVBACKEND_EPOLL);
+  case EVBACKEND_KQUEUE:
+    return Val_int(val_EVBACKEND_KQUEUE);
+  case EVBACKEND_DEVPOLL:
+    return Val_int(val_EVBACKEND_DEVPOLL);
+  case EVBACKEND_PORT:
+    return Val_int(val_EVBACKEND_PORT);
+  default:
+    assert(0);
+  }
+}
+
 CAMLprim value lwt_libev_stop(value loop) {
   ev_loop_destroy(Ev_loop_val(loop));
   return Val_unit;


### PR DESCRIPTION
My use case for this is letting libev choose its backend freely, but checking it did not fallback to `select` in production as the 1024 file descriptor limit is not fit for purpose.