### PR TITLE
[ci] Use the latest version of `actions/checkout`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Hack Git CRLF for ocaml/setup-ocaml issue #529
         if: ${{ startsWith(matrix.os, 'windows-') }}


### PR DESCRIPTION
To avoid the warning about deprecated Node.js 16 actions.  See https://github.com/ocsigen/lwt/actions/runs/8134580776.
