### PR TITLE
Adopt OCaml's code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact Jérôme
+Vouillon, Raphael Proust, Vincent Balat, Hugo Heuzard and Gabriel
+Radanne at <moderation [at] ocsigen [dot] org>
+(or some of them individually).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,6 +7,6 @@ This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/co
 This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
 
 To report any violations, please contact Jérôme
-Vouillon, Raphael Proust, Vincent Balat, Hugo Heuzard and Gabriel
+Vouillon, Raphaël Proust, Vincent Balat, Hugo Heuzard and Gabriel
 Radanne at <moderation [at] ocsigen [dot] org>
 (or some of them individually).


### PR DESCRIPTION
This PR proposes to add the OCaml Code of Conduct. Full text is available at https://github.com/ocaml/code-of-conduct, and a discussion around it is at https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494.

