### PR TITLE
Make signal handling work on OCaml 5 and with Eio

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,11 +23,20 @@
 
   * Lwt_preemptive.run_in_main_dont_wait to run a function in the main preemptive thread but without waiting for the result. (Kate Deplaix, #960)
 
+  * Lwt_unix.handle_signal and Lwt_engine.forwards_signal to allow other IO libraries (such as Eio) to share signal handlers. (Thomas Leonard, #993, #991)
+
 ====== Build ======
 
   * Remove unused dependency in dune file. (#969, Kate Deplaix)
 
   * Fix some compilation warnings for C stubs with OCaml 5. (#976, Antonin Décimo)
+
+====== Fixes ======
+
+  * Use SA_ONSTACK on OCaml5 to avoid SIGSEGV. (Thomas Leonard, #993, #981)
+
+  * Fix race in worker loop. (Thomas Leonard, #993, #994)
+
 
 ===== 5.6.1 =====
 

--- a/src/unix/lwt_engine.ml
+++ b/src/unix/lwt_engine.ml
@@ -108,6 +108,8 @@ class virtual abstract = object(self)
   method timer_count = Lwt_sequence.length timers
 
   method fork = ()
+
+  method forwards_signal (_signum:int) = false
 end
 
 class type t = object
@@ -433,6 +435,7 @@ let readable_count () = !current#readable_count
 let writable_count () = !current#writable_count
 let timer_count () = !current#timer_count
 let fork () = !current#fork
+let forwards_signal n = !current#forwards_signal n
 
 module Versioned =
 struct

--- a/src/unix/lwt_engine.mli
+++ b/src/unix/lwt_engine.mli
@@ -53,6 +53,13 @@ val fake_io : Unix.file_descr -> unit
 val fork : unit -> unit
   (** Called internally by Lwt_unix.fork to make sure we don't get strange behaviour *)
 
+val forwards_signal : int -> bool
+(** [forwards_signal signum] is [true] if the engine will call {!Lwt_unix.handle_signal}
+    when signal [signum] occurs. In this case, Lwt will not install its own signal handler.
+
+    Normally, this just returns [false], but when Lwt is used in combination
+    with other IO libraries, this allows sharing e.g. the SIGCHLD handler. *)
+
 (** {2 Engines} *)
 
 (** An engine represents a set of functions used to register different
@@ -82,6 +89,7 @@ class virtual abstract : object
   method readable_count : int
   method writable_count : int
   method timer_count : int
+  method forwards_signal : int -> bool
 
   (** {2 Backend methods} *)
 

--- a/src/unix/lwt_unix.cppo.ml
+++ b/src/unix/lwt_unix.cppo.ml
@@ -2227,11 +2227,18 @@ let event_notifications = ref (Lwt_engine.on_readable (init_notification ()) han
    | Signals                                                         |
    +-----------------------------------------------------------------+ *)
 
-external set_signal : int -> int -> unit = "lwt_unix_set_signal"
-external remove_signal : int -> unit = "lwt_unix_remove_signal"
+external set_signal : int -> int -> bool -> unit = "lwt_unix_set_signal"
+external remove_signal : int -> bool -> unit = "lwt_unix_remove_signal"
 external init_signals : unit -> unit = "lwt_unix_init_signals"
+external handle_signal : int -> unit = "lwt_unix_handle_signal"
 
 let () = init_signals ()
+
+let set_signal signum notification =
+  set_signal signum notification (Lwt_engine.forwards_signal signum)
+
+let remove_signal signum =
+  remove_signal signum (Lwt_engine.forwards_signal signum)
 
 module Signal_map = Map.Make(struct type t = int let compare a b = a - b end)
 

--- a/src/unix/lwt_unix.cppo.mli
+++ b/src/unix/lwt_unix.cppo.mli
@@ -854,6 +854,14 @@ val reinstall_signal_handler : int -> unit
       signal handler (with [Sys.set_signal]). This is useful in case
       another part of the program install another signal handler. *)
 
+val handle_signal : int -> unit
+  (** [handle_signal signum] acts as if Lwt had received the [signum] signal.
+      This allows another IO library to install the handler, perform its own
+      handling, but still notify Lwt. It is particularly useful for SIGCHLD,
+      where several IO libraries may be spawning sub-processes.
+
+      This function is thread-safe. *)
+
 (** {2 Sockets} *)
 
 type inet_addr = Unix.inet_addr

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -169,6 +169,7 @@ value lwt_unix_system_byte_order() {
 int lwt_unix_launch_thread(void *(*start)(void *), void *data) {
   pthread_t thread;
   pthread_attr_t attr;
+  sigset_t mask, old_mask;
 
   pthread_attr_init(&attr);
 
@@ -176,8 +177,16 @@ int lwt_unix_launch_thread(void *(*start)(void *), void *data) {
      it when it terminates: */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
+  /* Block all signals, otherwise ocaml handlers defined with the
+     module Sys may be executed in the new thread, oops... */
+  sigfillset(&mask);
+  pthread_sigmask(SIG_SETMASK, &mask, &old_mask);
+
   int zero_if_created_otherwise_errno =
       pthread_create(&thread, &attr, start, data);
+
+  /* Restore the signal mask for the calling thread. */
+  pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 
   pthread_attr_destroy(&attr);
 
@@ -978,17 +987,10 @@ void initialize_threading() {
    | Worker loop                                                     |
    +-----------------------------------------------------------------+ */
 
-/* Function executed by threads of the pool. */
+/* Function executed by threads of the pool.
+ * Note: all signals are masked for this thread. */
 static void *worker_loop(void *data) {
   lwt_unix_job job = (lwt_unix_job)data;
-
-#if defined(HAVE_PTHREAD)
-  /* Block all signals, otherwise ocaml handlers defined with the
-     module Sys may be executed in this thread, oops... */
-  sigset_t mask;
-  sigfillset(&mask);
-  pthread_sigmask(SIG_SETMASK, &mask, NULL);
-#endif
 
   /* Execute the initial job if any. */
   if (job != NULL) execute_job(job);

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -840,7 +840,11 @@ CAMLprim value lwt_unix_set_signal(value val_signum, value val_notification) {
   }
 #else
   sa.sa_handler = handle_signal;
+#if OCAML_VERSION >= 50000
+  sa.sa_flags = SA_ONSTACK;
+#else
   sa.sa_flags = 0;
+#endif
   sigemptyset(&sa.sa_mask);
   if (sigaction(signum, &sa, NULL) == -1) {
     signal_notifications[signum] = -1;


### PR DESCRIPTION
The first commit fixes #981 by using `SA_ONSTACK` with OCaml 5 so that signals do not cause memory corruption.

The second commit is a solution to #991. Before installing a signal handler, Lwt now checks first with the engine, which may now prevent Lwt from installing its handler and instead forward signals from some external handler.

This allows e.g. sharing the SIGCHLD handler with Eio.

It would also be possible to do it the other way around (so that Eio uses Lwt's signal handler). However, Lwt only notifies a single domain and if that domain is busy then the signal will be delayed, whereas Eio's signal handler notifies all interested domains immediately.

The third commit fixes #994, which causes the process to segfault if an OCaml signal handler runs in a Lwt worker thread before that thread has set the signal mask. This bug is more likely to be seen when using Lwt with Eio.

These changes should be low-risk:
- The `SA_ONSTACK` change only affects OCaml 5, where Lwt already segfaults.
- The new engine method has a default that just returns `false`, causing the existing code to behave exactly as before.
- The signal masking is essentially the same trick that OCaml itself uses when creating new threads: https://github.com/ocaml/ocaml/blob/686f49870d69f3d2246b2111e54dbe0d042aa681/runtime/domain.c#L1148-L1161

/cc @raphael-proust