### PR TITLE
Fix `Lwt_io.read_value` on OCaml 5.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,8 @@
 
   * Fix race in worker loop. (Thomas Leonard, #993, #994)
 
+  * Fix marshall header size in Lwt_io.read_value. (Simmo Saan, #995)
+
 
 ===== 5.6.1 =====
 

--- a/src/unix/lwt_io.ml
+++ b/src/unix/lwt_io.ml
@@ -842,12 +842,12 @@ struct
         Lwt.return (Bytes.unsafe_to_string buf)
 
   let read_value ic =
-    let header = Bytes.create 20 in
-    unsafe_read_into_exactly ic header 0 20 >>= fun () ->
+    let header = Bytes.create Marshal.header_size in
+    unsafe_read_into_exactly ic header 0 Marshal.header_size >>= fun () ->
     let bsize = Marshal.data_size header 0 in
-    let buffer = Bytes.create (20 + bsize) in
-    Bytes.unsafe_blit header 0 buffer 0 20;
-    unsafe_read_into_exactly ic buffer 20 bsize >>= fun () ->
+    let buffer = Bytes.create (Marshal.header_size + bsize) in
+    Bytes.unsafe_blit header 0 buffer 0 Marshal.header_size;
+    unsafe_read_into_exactly ic buffer Marshal.header_size bsize >>= fun () ->
     Lwt.return (Marshal.from_bytes buffer 0)
 
   (* +---------------------------------------------------------------+


### PR DESCRIPTION
The Marshal header size was changed in https://github.com/ocaml/ocaml/pull/12006.