### PR TITLE
Don't run removed tests of libuv backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ coverage :
 	rm -rf _build/default/test/ppx_expect
 	find _build -name '*.coverage' | xargs rm -f
 	BISECT_ENABLE=yes dune runtest --force
-	BISECT_ENABLE=yes dune build @runtest_libuv --force
 	bisect-ppx-report html $(EXPECTED_FILES)
 	bisect-ppx-report summary
 	@echo See _coverage/index.html


### PR DESCRIPTION
Follow-up to #966, I think this was forgotten.