### PR TITLE
Prepare for stricter checking in GCC 14

### DIFF
--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -652,9 +652,8 @@ struct
 
         int main()
         {
-            struct hostent *he;
-            struct servent *se;
-            he =
+            int x;
+            x =
               gethostbyname_r(
                 (const char*)NULL,
                 (struct hostent*)NULL,
@@ -662,9 +661,9 @@ struct
                 (int)0,
                 (struct hostent**)NULL,
                 (int*)NULL);
-            he =
+            x =
               gethostbyaddr_r(
-                (const char*)NULL,
+                (const void*)NULL,
                 (int)0,
                 (int)0,
                 (struct hostent*)NULL,
@@ -672,7 +671,7 @@ struct
                 (int)0,
                 (struct hostent**)NULL,
                 (int*)NULL);
-            se =
+            x =
               getservbyname_r(
                 (const char*)NULL,
                 (const char*)NULL,
@@ -680,7 +679,7 @@ struct
                 (char*)NULL,
                 (int)0,
                 (struct servent**)NULL);
-            se =
+            x =
               getservbyport_r(
                 (int)0,
                 (const char*)NULL,
@@ -688,20 +687,20 @@ struct
                 (char*)NULL,
                 (int)0,
                 (struct servent**)NULL);
-            pr =
+            x =
               getprotoent_r(
                 (struct protoent*)NULL,
                 (char*)NULL,
                 (int)0,
                 (struct protoent**)NULL);
-            pr =
+            x =
               getprotobyname_r(
                 (const char*)NULL,
                 (struct protoent*)NULL,
                 (char*)NULL,
                 (int)0,
                 (struct protoent**)NULL);
-            pr =
+            x =
               getprotobynumber_r(
                 (int)0,
                 (struct protoent*)NULL,
@@ -793,7 +792,7 @@ struct
 
         int main()
         {
-            int (*mincore_ptr)(const void*, size_t, char*) = mincore;
+            int (*mincore_ptr)(void*, size_t, unsigned char*) = mincore;
             return (int)(mincore_ptr == NULL);
         }
       |}

--- a/src/unix/unix_c/unix_getprotoby_getservby_job.c
+++ b/src/unix/unix_c/unix_getprotoby_getservby_job.c
@@ -9,6 +9,7 @@
 
 #define ARGS(args...) args
 
+#include <errno.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/memory.h>


### PR DESCRIPTION
GCC 14 will be stricter about such things as implicit function return types, implicit conversions between pointers and integers, and mismatched pointer types.  Some warnings will become errors.  The Fedora project is preparing for these changes:
- https://fedoraproject.org/wiki/Changes/PortingToModernC
- https://fedoraproject.org/wiki/Toolchain/PortingToModernC

The lwt package fails to build with the test compiler mentioned in those links.  The main symptom is missing features due to a gcc run that ends with an error, even though the feature is present.  The cause is mostly implicit conversions between pointers and integers.  In addition, due to header streamlining, `errno.h` is no longer implicitly included in `unix_getprotoby_getservby_job.c`, so include it explicitly.

I await the results of the CI run with fear and trepidation.
