### PR TITLE
Constify C constructors and flags tables

### DIFF
--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -465,10 +465,11 @@ failure:
   uerror("socketpair", Nothing);
 }
 
-static int socket_domain_table[] = {PF_UNIX, PF_INET, PF_INET6};
+static const int socket_domain_table[] =
+  {PF_UNIX, PF_INET, PF_INET6};
 
-static int socket_type_table[] = {SOCK_STREAM, SOCK_DGRAM, SOCK_RAW,
-                                  SOCK_SEQPACKET};
+static const int socket_type_table[] =
+  {SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_SEQPACKET};
 
 CAMLprim value lwt_unix_socketpair_stub(value cloexec, value domain, value type,
                                         value protocol) {

--- a/src/unix/unix_c/unix_access_job.c
+++ b/src/unix/unix_c/unix_access_job.c
@@ -34,7 +34,7 @@
    +-----------------------------------------------------------------+ */
 
 /* Table mapping constructors of ocaml type Unix.access_permission to C values. */
-static int access_permission_table[] = {
+static const int access_permission_table[] = {
   /* Constructor R_OK. */
   R_OK,
   /* Constructor W_OK. */

--- a/src/unix/unix_c/unix_getaddrinfo_job.c
+++ b/src/unix/unix_c/unix_getaddrinfo_job.c
@@ -29,7 +29,7 @@ struct job_getaddrinfo {
     char data[];
 };
 
-static value cst_to_constr(int n, int *tbl, int size, int deflt)
+static value cst_to_constr(int n, const int *tbl, int size, int deflt)
 {
     int i;
     for (i = 0; i < size; i++)
@@ -37,7 +37,7 @@ static value cst_to_constr(int n, int *tbl, int size, int deflt)
     return Val_int(deflt);
 }
 
-static value convert_addrinfo(struct addrinfo *a)
+static value convert_addrinfo(const struct addrinfo *a)
 {
     CAMLparam0();
     CAMLlocal3(vres, vaddr, vcanonname);

--- a/src/unix/unix_c/unix_getnameinfo_job.c
+++ b/src/unix/unix_c/unix_getnameinfo_job.c
@@ -28,8 +28,8 @@ struct job_getnameinfo {
     int result;
 };
 
-static int getnameinfo_flag_table[] = {NI_NOFQDN, NI_NUMERICHOST, NI_NAMEREQD,
-                                       NI_NUMERICSERV, NI_DGRAM};
+static const int getnameinfo_flag_table[] =
+  {NI_NOFQDN, NI_NUMERICHOST, NI_NAMEREQD, NI_NUMERICSERV, NI_DGRAM};
 
 static void worker_getnameinfo(struct job_getnameinfo *job)
 {

--- a/src/unix/unix_c/unix_lockf_job.c
+++ b/src/unix/unix_c/unix_lockf_job.c
@@ -84,8 +84,8 @@ static void worker_lockf(struct job_lockf *job)
 
 #else
 
-static int lock_command_table[] = {F_ULOCK, F_LOCK, F_TLOCK,
-                                   F_TEST,  F_LOCK, F_TLOCK};
+static const int lock_command_table[] =
+  {F_ULOCK, F_LOCK, F_TLOCK, F_TEST,  F_LOCK, F_TLOCK};
 
 static void worker_lockf(struct job_lockf *job)
 {

--- a/src/unix/unix_c/unix_lseek_job.c
+++ b/src/unix/unix_c/unix_lseek_job.c
@@ -35,7 +35,7 @@
    +-----------------------------------------------------------------+ */
 
 /* Table mapping constructors of ocaml type Unix.seek_command to C values. */
-static int seek_command_table[] = {
+static const int seek_command_table[] = {
   /* Constructor SEEK_SET. */
   SEEK_SET,
   /* Constructor SEEK_CUR. */

--- a/src/unix/unix_c/unix_madvise.c
+++ b/src/unix/unix_c/unix_madvise.c
@@ -12,7 +12,7 @@
 #include <caml/bigarray.h>
 #include <sys/mman.h>
 
-static int advise_table[] = {
+static const int advise_table[] = {
     MADV_NORMAL, MADV_RANDOM, MADV_SEQUENTIAL, MADV_WILLNEED, MADV_DONTNEED,
 #if defined(MADV_MERGEABLE)
 	MADV_MERGEABLE,

--- a/src/unix/unix_c/unix_open_job.c
+++ b/src/unix/unix_c/unix_open_job.c
@@ -35,7 +35,7 @@
 #define caml_unix_cloexec_default unix_cloexec_default
 #endif
 
-static int open_flag_table[] = {
+static const int open_flag_table[] = {
     O_RDONLY, O_WRONLY, O_RDWR,  O_NONBLOCK, O_APPEND, O_CREAT, O_TRUNC,
     O_EXCL,   O_NOCTTY, O_DSYNC, O_SYNC,     O_RSYNC,  0, /* O_SHARE_DELETE,
                                                              Windows-only */

--- a/src/unix/unix_c/unix_recv_send_utils.c
+++ b/src/unix/unix_c/unix_recv_send_utils.c
@@ -19,7 +19,7 @@
 
 #include "unix_recv_send_utils.h"
 
-int msg_flag_table[3] = {MSG_OOB, MSG_DONTROUTE, MSG_PEEK};
+const int msg_flag_table[3] = {MSG_OOB, MSG_DONTROUTE, MSG_PEEK};
 
 value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs)
 {

--- a/src/unix/unix_c/unix_recv_send_utils.h
+++ b/src/unix/unix_c/unix_recv_send_utils.h
@@ -36,7 +36,7 @@
 #define caml_unix_socket_type_table socket_type_table
 #endif
 
-extern int msg_flag_table[];
+extern const int msg_flag_table[];
 extern int caml_unix_socket_domain_table[];
 extern int caml_unix_socket_type_table[];
 extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,

--- a/src/unix/unix_c/unix_recv_send_utils.h
+++ b/src/unix/unix_c/unix_recv_send_utils.h
@@ -36,9 +36,15 @@
 #define caml_unix_socket_type_table socket_type_table
 #endif
 
-extern const int msg_flag_table[];
+#if OCAML_VERSION < 50300
 extern int caml_unix_socket_domain_table[];
 extern int caml_unix_socket_type_table[];
+#else
+extern const int caml_unix_socket_domain_table[];
+extern const int caml_unix_socket_type_table[];
+#endif
+
+extern const int msg_flag_table[];
 extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
                          socklen_t *addr_len /*out*/);
 value wrapper_recv_msg(int fd, int n_iovs, struct iovec *iovs);

--- a/src/unix/unix_c/unix_tcflow_job.c
+++ b/src/unix/unix_c/unix_tcflow_job.c
@@ -35,7 +35,7 @@
    +-----------------------------------------------------------------+ */
 
 /* Table mapping constructors of ocaml type Unix.flow_action to C values. */
-static int flow_action_table[] = {
+static const int flow_action_table[] = {
   /* Constructor TCOOFF. */
   TCOOFF,
   /* Constructor TCOON. */

--- a/src/unix/unix_c/unix_tcflush_job.c
+++ b/src/unix/unix_c/unix_tcflush_job.c
@@ -35,7 +35,7 @@
    +-----------------------------------------------------------------+ */
 
 /* Table mapping constructors of ocaml type Unix.flush_queue to C values. */
-static int flush_queue_table[] = {
+static const int flush_queue_table[] = {
   /* Constructor TCIFLUSH. */
   TCIFLUSH,
   /* Constructor TCOFLUSH. */

--- a/src/unix/unix_c/unix_tcsetattr_job.c
+++ b/src/unix/unix_c/unix_tcsetattr_job.c
@@ -24,7 +24,7 @@ struct job_tcsetattr {
     int error_code;
 };
 
-static int when_flag_table[] = {TCSANOW, TCSADRAIN, TCSAFLUSH};
+static const int when_flag_table[] = {TCSANOW, TCSADRAIN, TCSAFLUSH};
 
 static void worker_tcsetattr(struct job_tcsetattr *job)
 {

--- a/src/unix/unix_c/unix_termios_conversion.c
+++ b/src/unix/unix_c/unix_termios_conversion.c
@@ -20,7 +20,7 @@ enum { Iflags, Oflags, Cflags, Lflags };
 
 /* Structure of the terminal_io record. Cf. unix.mli */
 
-static long terminal_io_descr[] = {
+static const long terminal_io_descr[] = {
     /* Input modes */
     Bool, Iflags, IGNBRK, Bool, Iflags, BRKINT, Bool, Iflags, IGNPAR, Bool,
     Iflags, PARMRK, Bool, Iflags, INPCK, Bool, Iflags, ISTRIP, Bool, Iflags,
@@ -40,7 +40,7 @@ static long terminal_io_descr[] = {
     Char, VINTR, Char, VQUIT, Char, VERASE, Char, VKILL, Char, VEOF, Char, VEOL,
     Char, VMIN, Char, VTIME, Char, VSTART, Char, VSTOP, End};
 
-static struct {
+static const struct {
     speed_t speed;
     int baud;
 } speedtable[] = {{B50, 50},
@@ -152,10 +152,9 @@ static tcflag_t *choose_field(struct termios *terminal_status, long field)
 
 void encode_terminal_status(struct termios *terminal_status, volatile value *dst)
 {
-    long *pc;
     int i;
 
-    for (pc = terminal_io_descr; *pc != End; dst++) {
+    for (const long *pc = terminal_io_descr; *pc != End; dst++) {
         switch (*pc++) {
             case Bool: {
                 tcflag_t *src = choose_field(terminal_status, *pc++);
@@ -209,10 +208,9 @@ void encode_terminal_status(struct termios *terminal_status, volatile value *dst
 
 int decode_terminal_status(struct termios *terminal_status, volatile value *src)
 {
-    long *pc;
     int i;
 
-    for (pc = terminal_io_descr; *pc != End; src++) {
+    for (const long *pc = terminal_io_descr; *pc != End; src++) {
         switch (*pc++) {
             case Bool: {
                 tcflag_t *dst = choose_field(terminal_status, *pc++);

--- a/src/unix/unix_c/unix_termios_conversion.c
+++ b/src/unix/unix_c/unix_termios_conversion.c
@@ -152,8 +152,6 @@ static tcflag_t *choose_field(struct termios *terminal_status, long field)
 
 void encode_terminal_status(struct termios *terminal_status, volatile value *dst)
 {
-    int i;
-
     for (const long *pc = terminal_io_descr; *pc != End; dst++) {
         switch (*pc++) {
             case Bool: {
@@ -167,7 +165,7 @@ void encode_terminal_status(struct termios *terminal_status, volatile value *dst
                 int ofs = *pc++;
                 int num = *pc++;
                 tcflag_t msk = *pc++;
-                for (i = 0; i < num; i++) {
+                for (int i = 0; i < num; i++) {
                     if ((*src & msk) == pc[i]) {
                         *dst = Val_int(i + ofs);
                         break;
@@ -189,7 +187,7 @@ void encode_terminal_status(struct termios *terminal_status, volatile value *dst
                         speed = cfgetispeed(terminal_status);
                         break;
                 }
-                for (i = 0; i < NSPEEDS; i++) {
+                for (int i = 0; i < NSPEEDS; i++) {
                     if (speed == speedtable[i].speed) {
                         *dst = Val_int(speedtable[i].baud);
                         break;
@@ -208,8 +206,6 @@ void encode_terminal_status(struct termios *terminal_status, volatile value *dst
 
 int decode_terminal_status(struct termios *terminal_status, volatile value *src)
 {
-    int i;
-
     for (const long *pc = terminal_io_descr; *pc != End; src++) {
         switch (*pc++) {
             case Bool: {
@@ -226,7 +222,7 @@ int decode_terminal_status(struct termios *terminal_status, volatile value *src)
                 int ofs = *pc++;
                 int num = *pc++;
                 tcflag_t msk = *pc++;
-                i = Int_val(*src) - ofs;
+                int i = Int_val(*src) - ofs;
                 if (i >= 0 && i < num) {
                     *dst = (*dst & ~msk) | pc[i];
                 } else {
@@ -240,7 +236,7 @@ int decode_terminal_status(struct termios *terminal_status, volatile value *src)
                 int which = *pc++;
                 int baud = Int_val(*src);
                 int res = 0;
-                for (i = 0; i < NSPEEDS; i++) {
+                for (int i = 0; i < NSPEEDS; i++) {
                     if (baud == speedtable[i].baud) {
                         switch (which) {
                             case Output:

--- a/src/unix/unix_c/unix_wait4.c
+++ b/src/unix/unix_c/unix_wait4.c
@@ -58,7 +58,7 @@ static value alloc_process_status(int status)
     return st;
 }
 
-static int wait_flag_table[] = {WNOHANG, WUNTRACED};
+static const int wait_flag_table[] = {WNOHANG, WUNTRACED};
 
 value lwt_unix_wait4(value flags, value pid_req)
 {


### PR DESCRIPTION
There's little value to this considering the constructors tables are static, used very locally, but this serves nonetheless as an indication to the programmer that the tables are not to be modified. Now these tables will go in the readonly segment, where they belong.

Cf https://github.com/ocaml/ocaml/pull/12223, https://github.com/ocaml/ocaml/pull/12951.