### PR TITLE
Modern C and compatibility fixes

### DIFF
--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -165,7 +165,7 @@ sig
   val add_link_flags : string list -> unit
 end =
 struct
-  let c_flags = ref []
+  let c_flags = ref ["-Wall"; "-fdiagnostics-color=always"]
   let link_flags = ref []
 
   let extend c_flags' link_flags' =
@@ -424,7 +424,7 @@ struct
         let code = {|
           #include <ev.h>
 
-          int main()
+          int main(void)
           {
               ev_default_loop(0);
               return 0;
@@ -452,7 +452,7 @@ struct
         let code = {|
           #include <pthread.h>
 
-          int main()
+          int main(void)
           {
               pthread_create(0, 0, 0, 0);
               return 0;
@@ -494,7 +494,7 @@ struct
       compiles context {|
         #include <sys/eventfd.h>
 
-        int main()
+        int main(void)
         {
             eventfd(0, 0);
             return 0;
@@ -511,7 +511,7 @@ struct
         #include <sys/types.h>
         #include <sys/socket.h>
 
-        int main()
+        int main(void)
         {
             struct msghdr msg;
             msg.msg_controllen = 0;
@@ -531,7 +531,7 @@ struct
         #define _GNU_SOURCE
         #include <sched.h>
 
-        int main()
+        int main(void)
         {
             sched_getcpu();
             return 0;
@@ -549,7 +549,7 @@ struct
         #define _GNU_SOURCE
         #include <sched.h>
 
-        int main()
+        int main(void)
         {
             sched_getaffinity(0, 0, 0);
             return 0;
@@ -562,7 +562,7 @@ struct
     #include <sys/types.h>
     #include <sys/socket.h>
 
-    int main()
+    int main(void)
     {
         struct |} ^ struct_name ^ {| cred;
         socklen_t cred_len = sizeof(cred);
@@ -612,7 +612,7 @@ struct
         #include <sys/types.h>
         #include <unistd.h>
 
-        int main()
+        int main(void)
         {
             uid_t euid;
             gid_t egid;
@@ -630,7 +630,7 @@ struct
       compiles context {|
         #include <unistd.h>
 
-        int main()
+        int main(void)
         {
             int (*fdatasyncp)(int) = fdatasync;
             fdatasyncp(0);
@@ -650,7 +650,7 @@ struct
         #include <netdb.h>
         #include <stddef.h>
 
-        int main()
+        int main(void)
         {
             int x;
             x =
@@ -733,7 +733,7 @@ struct
         #define NON_R_GETHOSTBYNAME 1
         #endif
 
-        int main()
+        int main(void)
         {
         #if defined(NON_R_GETHOSTBYNAME) || defined(NON_R_GETHOSTBYNAME)
         #error "not available"
@@ -750,7 +750,7 @@ struct
     #include <sys/stat.h>
     #include <unistd.h>
 
-    int main() {
+    int main(void) {
         struct stat *buf;
         double a, m, c;
         a = (double)buf->st_a|} ^ projection ^ {|;
@@ -790,7 +790,7 @@ struct
         #include <unistd.h>
         #include <sys/mman.h>
 
-        int main()
+        int main(void)
         {
             int (*mincore_ptr)(void*, size_t, unsigned char*) = mincore;
             return (int)(mincore_ptr == NULL);
@@ -808,7 +808,7 @@ struct
         #include <sys/socket.h>
         #include <stddef.h>
 
-        int main()
+        int main(void)
         {
             accept4(0, NULL, 0, 0);
             return 0;

--- a/src/unix/config/discover.ml
+++ b/src/unix/config/discover.ml
@@ -792,7 +792,7 @@ struct
 
         int main(void)
         {
-            int (*mincore_ptr)(void*, size_t, unsigned char*) = mincore;
+            int (*mincore_ptr)(const void*, size_t, char*) = mincore;
             return (int)(mincore_ptr == NULL);
         }
       |}

--- a/src/unix/lwt_libev_stubs.c
+++ b/src/unix/lwt_libev_stubs.c
@@ -6,7 +6,6 @@
 /* Stubs for libev */
 
 #include "lwt_config.h"
-#include "lwt_unix.h"
 
 #if defined(HAVE_LIBEV)
 
@@ -20,6 +19,8 @@
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include <ev.h>
+
+#include "lwt_unix.h"
 
 /* +-----------------------------------------------------------------+
    | Backend types                                                   |
@@ -220,6 +221,8 @@ CAMLprim value lwt_libev_timer_stop(value loop, value val_watcher) {
 }
 
 #else
+
+#include "lwt_unix.h"
 
 LWT_NOT_AVAILABLE1(libev_init)
 LWT_NOT_AVAILABLE1(libev_stop)

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -7,7 +7,7 @@
 
 #if defined(LWT_ON_WINDOWS)
 
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 
 #if OCAML_VERSION < 41300
 #define CAML_INTERNALS

--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -14,6 +14,11 @@
 #include <caml/socketaddr.h>
 #include <string.h>
 
+#if OCAML_VERSION < 50000
+#define caml_convert_flag_list(flags, table) \
+    caml_convert_flag_list((flags), (int *)(table))
+#endif
+
 /* The macro to get the file-descriptor from a value. */
 #if defined(LWT_ON_WINDOWS)
 #define FD_val(value) win_CRT_fd_of_filedescr(value)

--- a/src/unix/unix_c/unix_access_job.c
+++ b/src/unix/unix_c/unix_access_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_access_job.c
+++ b/src/unix/unix_c/unix_access_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_bytes_recv.c
+++ b/src/unix/unix_c/unix_bytes_recv.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_bytes_recv(value fd, value buf, value ofs, value len,

--- a/src/unix/unix_c/unix_bytes_recvfrom.c
+++ b/src/unix/unix_c/unix_bytes_recvfrom.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_bytes_recvfrom(value fd, value buf, value ofs, value len,

--- a/src/unix/unix_c/unix_bytes_send.c
+++ b/src/unix/unix_c/unix_bytes_send.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_bytes_send(value fd, value buf, value ofs, value len,

--- a/src/unix/unix_c/unix_bytes_sendto.c
+++ b/src/unix/unix_c/unix_bytes_sendto.c
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_bytes_sendto(value fd, value buf, value ofs, value len,

--- a/src/unix/unix_c/unix_chdir_job.c
+++ b/src/unix/unix_c/unix_chdir_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_chdir_job.c
+++ b/src/unix/unix_c/unix_chdir_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_chmod_job.c
+++ b/src/unix/unix_c/unix_chmod_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_chmod_job.c
+++ b/src/unix/unix_c/unix_chmod_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_chown_job.c
+++ b/src/unix/unix_c/unix_chown_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_chown_job.c
+++ b/src/unix/unix_c/unix_chown_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_chroot_job.c
+++ b/src/unix/unix_c/unix_chroot_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_chroot_job.c
+++ b/src/unix/unix_c/unix_chroot_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_close_job.c
+++ b/src/unix/unix_c/unix_close_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_close_job.c
+++ b/src/unix/unix_c/unix_close_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_fchmod_job.c
+++ b/src/unix/unix_c/unix_fchmod_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_fchmod_job.c
+++ b/src/unix/unix_c/unix_fchmod_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_fchown_job.c
+++ b/src/unix/unix_c/unix_fchown_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_fchown_job.c
+++ b/src/unix/unix_c/unix_fchown_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_fdatasync_job.c
+++ b/src/unix/unix_c/unix_fdatasync_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS) && defined(HAVE_FDATASYNC)
 

--- a/src/unix/unix_c/unix_fdatasync_job.c
+++ b/src/unix/unix_c/unix_fdatasync_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_fsync_job.c
+++ b/src/unix/unix_c/unix_fsync_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_fsync_job.c
+++ b/src/unix/unix_c/unix_fsync_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_ftruncate_job.c
+++ b/src/unix/unix_c/unix_ftruncate_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_ftruncate_job.c
+++ b/src/unix/unix_c/unix_ftruncate_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_link_job.c
+++ b/src/unix/unix_c/unix_link_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_link_job.c
+++ b/src/unix/unix_c/unix_link_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_lseek_job.c
+++ b/src/unix/unix_c/unix_lseek_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_lseek_job.c
+++ b/src/unix/unix_c/unix_lseek_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_mkdir_job.c
+++ b/src/unix/unix_c/unix_mkdir_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_mkdir_job.c
+++ b/src/unix/unix_c/unix_mkdir_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_mkfifo_job.c
+++ b/src/unix/unix_c/unix_mkfifo_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_mkfifo_job.c
+++ b/src/unix/unix_c/unix_mkfifo_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_recv.c
+++ b/src/unix/unix_c/unix_recv.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_recv(value fd, value buf, value ofs, value len, value flags)

--- a/src/unix/unix_c/unix_recvfrom.c
+++ b/src/unix/unix_c/unix_recvfrom.c
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_recvfrom(value fd, value buf, value ofs, value len, value flags)

--- a/src/unix/unix_c/unix_rename_job.c
+++ b/src/unix/unix_c/unix_rename_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_rename_job.c
+++ b/src/unix/unix_c/unix_rename_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_rmdir_job.c
+++ b/src/unix/unix_c/unix_rmdir_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_rmdir_job.c
+++ b/src/unix/unix_c/unix_rmdir_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_send.c
+++ b/src/unix/unix_c/unix_send.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_send(value fd, value buf, value ofs, value len, value flags)

--- a/src/unix/unix_c/unix_sendto.c
+++ b/src/unix/unix_c/unix_sendto.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include "lwt_unix.h"
 #include "unix_recv_send_utils.h"
 
 value lwt_unix_sendto(value fd, value buf, value ofs, value len, value flags,

--- a/src/unix/unix_c/unix_symlink_job.c
+++ b/src/unix/unix_c/unix_symlink_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_symlink_job.c
+++ b/src/unix/unix_c/unix_symlink_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_tcdrain_job.c
+++ b/src/unix/unix_c/unix_tcdrain_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS) && !defined(__ANDROID__)
 

--- a/src/unix/unix_c/unix_tcdrain_job.c
+++ b/src/unix/unix_c/unix_tcdrain_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_tcflow_job.c
+++ b/src/unix/unix_c/unix_tcflow_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_tcflow_job.c
+++ b/src/unix/unix_c/unix_tcflow_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_tcflush_job.c
+++ b/src/unix/unix_c/unix_tcflush_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_tcflush_job.c
+++ b/src/unix/unix_c/unix_tcflush_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_tcsendbreak_job.c
+++ b/src/unix/unix_c/unix_tcsendbreak_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_tcsendbreak_job.c
+++ b/src/unix/unix_c/unix_tcsendbreak_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_termios_conversion.c
+++ b/src/unix/unix_c/unix_termios_conversion.c
@@ -132,7 +132,7 @@ static const struct {
 #endif
 };
 
-#define NSPEEDS (sizeof(speedtable) / sizeof(speedtable[0]))
+#define NSPEEDS (int)(sizeof(speedtable) / sizeof(speedtable[0]))
 
 static tcflag_t *choose_field(struct termios *terminal_status, long field)
 {

--- a/src/unix/unix_c/unix_truncate_job.c
+++ b/src/unix/unix_c/unix_truncate_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_truncate_job.c
+++ b/src/unix/unix_c/unix_truncate_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_unlink_job.c
+++ b/src/unix/unix_c/unix_unlink_job.c
@@ -16,11 +16,12 @@
 */
 
 /* Caml headers. */
-#include "lwt_unix.h"
+#include "lwt_config.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include "lwt_unix.h"
 
 #if !defined(LWT_ON_WINDOWS)
 

--- a/src/unix/unix_c/unix_unlink_job.c
+++ b/src/unix/unix_c/unix_unlink_job.c
@@ -16,7 +16,7 @@
 */
 
 /* Caml headers. */
-#include <lwt_unix.h>
+#include "lwt_unix.h"
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/unix/unix_c/unix_wait4.c
+++ b/src/unix/unix_c/unix_wait4.c
@@ -12,6 +12,7 @@
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
+#include "lwt_unix.h"
 
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
This PR:
- Fixes modern C89/C99/C11/C17 compilers requiring `(void)` (no parameter) instead of `()` (pre C89 any parameter);
- Fixes `mincore` detection on BSD and macOS;
- Fixes a compatibility issue with `caml_convert_flag_list` taking an `int *` in OCaml 4 and a `const int *` in OCaml 5, with a minor header reordering;
- Fixes a sign comparison warning.