### PR TITLE
Fix opam constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
   (ppxlib (>= 0.16.0))
   (ppx_let :with-test)
   (bisect_ppx :with-test)
-  lwt))
+  (lwt (>= 5.7.0))))
 
 (package
  (name lwt_react)

--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -16,7 +16,7 @@ depends: [
   "ppxlib" {>= "0.16.0"}
   "ppx_let" {with-test}
   "bisect_ppx" {with-test}
-  "lwt"
+  "lwt" {>= "5.7.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
following https://github.com/ocaml/opam-repository/pull/27693

lwt_ppx uses `Lwt.reraise` which was introduced in Lwt 5.7