### PR TITLE
Update dune-project with maintenance-intent latest

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.15)
+(lang dune 3.18)
 
 (name lwt)
 
@@ -20,6 +20,7 @@
  (maintainers
    "Raphaël Proust <code@bnwr.net>"
    "Shon Feder <shon.feder@gmail.com>")
+ (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 4.08))
   (lwt (>= 5.3))))
@@ -28,6 +29,7 @@
  (name lwt_ppx)
  (version 5.9.2+dev)
  (synopsis "PPX syntax for Lwt, providing something similar to async/await from JavaScript")
+ (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 4.08))
   (ppxlib (>= 0.36))
@@ -38,6 +40,7 @@
  (synopsis "DO NOT RELEASE! only for testing let_ppx")
  (license NOTFORRELEASE) ;; trap for opam-repo ci
  (allow_empty)
+ (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 5.1))
   (ppx_let (and :with-test (>= v0.17.1)))))
@@ -46,6 +49,7 @@
  (name lwt_react)
  (version 1.2.0+dev)
  (synopsis "Helpers for using React with Lwt")
+ (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 4.08))
   (cppo (and :build (>= 1.1)))
@@ -65,6 +69,7 @@ Meanwhile, OCaml code, including code creating and waiting on promises, runs in
 a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis.
 ")
+ (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 4.08))
   (cppo (and :build (>= 1.1)))

--- a/lwt.opam
+++ b/lwt.opam
@@ -21,7 +21,7 @@ homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
-  "dune" {>= "3.15"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {dev & >= "1.7.3-1"}

--- a/lwt_ppx.opam
+++ b/lwt_ppx.opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
-  "dune" {>= "3.15"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.36"}
   "lwt" {>= "5.7"}
@@ -33,3 +33,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
+x-maintenance-intent: ["(latest)"]

--- a/lwt_ppx__ppx_let_tests.opam
+++ b/lwt_ppx__ppx_let_tests.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
-  "dune" {>= "3.15"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "5.1"}
   "ppx_let" {with-test & >= "v0.17.1"}
   "odoc" {with-doc}
@@ -30,3 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
+x-maintenance-intent: ["(latest)"]

--- a/lwt_react.opam
+++ b/lwt_react.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
-  "dune" {>= "3.15"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "cppo" {build & >= "1.1"}
   "lwt" {>= "3.0"}
@@ -33,3 +33,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
+x-maintenance-intent: ["(latest)"]

--- a/lwt_retry.opam
+++ b/lwt_retry.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
-  "dune" {>= "3.15"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
   "lwt" {>= "5.3"}
   "odoc" {with-doc}
@@ -31,3 +31,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This is a request from the opam-repository maintainers.

The ultimate goal is to push package versions that are not maintained
(and thus irrelevant) to a opam-repository-archive - which will make
every client have to perform fewer work, every CI system to compute
less. Apart from CPU and memory savings, there's bandwidth being saved.

policy document
https://github.com/ocaml/opam-repository/blob/master/governance/policies/archiving.md