### PR TITLE
Minor C fixes

### DIFF
--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -65,7 +65,7 @@ CAMLprim value lwt_process_create_process(value prog, value cmdline, value env,
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
   DWORD flags = 0, err;
-  HANDLE hp, fd0, fd1, fd2;
+  HANDLE fd0, fd1, fd2;
   HANDLE to_close0 = INVALID_HANDLE_VALUE, to_close1 = INVALID_HANDLE_VALUE,
     to_close2 = INVALID_HANDLE_VALUE;
 

--- a/src/unix/lwt_process_stubs.c
+++ b/src/unix/lwt_process_stubs.c
@@ -170,6 +170,6 @@ CAMLprim value lwt_process_terminate_process(value handle, value code) {
 
 /* This is used to suppress a warning from ranlib about the object file having
    no symbols. */
-void lwt_process_dummy_symbol() {}
+void lwt_process_dummy_symbol(void) {}
 
 #endif /* defined(LWT_ON_WINDOWS) */

--- a/src/unix/lwt_unix.h
+++ b/src/unix/lwt_unix.h
@@ -124,7 +124,7 @@ typedef struct lwt_unix_condition lwt_unix_condition;
 int lwt_unix_launch_thread(void *(*start)(void *), void *data);
 
 /* Return a handle to the currently running thread. */
-lwt_unix_thread lwt_unix_thread_self();
+lwt_unix_thread lwt_unix_thread_self(void);
 
 /* Returns whether two thread handles refer to the same thread. */
 int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2);

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -239,9 +239,12 @@ void lwt_unix_condition_wait(lwt_unix_condition *condition,
 int lwt_unix_launch_thread(void *(*start)(void *), void *data) {
   HANDLE handle =
       CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)start, data, 0, NULL);
-  if (handle)
+  if (handle) {
     CloseHandle(handle);
-  return 0;
+    return 0;
+  }
+  win32_maperr(GetLastError());
+  return errno;
 }
 
 lwt_unix_thread lwt_unix_thread_self() { return GetCurrentThreadId(); }

--- a/src/unix/lwt_unix_stubs.c
+++ b/src/unix/lwt_unix_stubs.c
@@ -152,7 +152,7 @@ CAMLprim value lwt_unix_mapped(value v_bstr) {
    | Byte order                                                      |
    +-----------------------------------------------------------------+ */
 
-value lwt_unix_system_byte_order() {
+value lwt_unix_system_byte_order(void) {
 #ifdef ARCH_BIG_ENDIAN
   return Val_int(1);
 #else
@@ -193,7 +193,7 @@ int lwt_unix_launch_thread(void *(*start)(void *), void *data) {
   return zero_if_created_otherwise_errno;
 }
 
-lwt_unix_thread lwt_unix_thread_self() { return pthread_self(); }
+lwt_unix_thread lwt_unix_thread_self(void) { return pthread_self(); }
 
 int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2) {
   return pthread_equal(thread1, thread2);
@@ -247,7 +247,7 @@ int lwt_unix_launch_thread(void *(*start)(void *), void *data) {
   return errno;
 }
 
-lwt_unix_thread lwt_unix_thread_self() { return GetCurrentThreadId(); }
+lwt_unix_thread lwt_unix_thread_self(void) { return GetCurrentThreadId(); }
 
 int lwt_unix_thread_equal(lwt_unix_thread thread1, lwt_unix_thread thread2) {
   return thread1 == thread2;
@@ -530,19 +530,19 @@ static enum notification_mode notification_mode =
     NOTIFICATION_MODE_NOT_INITIALIZED;
 
 /* Send one notification. */
-static int (*notification_send)();
+static int (*notification_send)(void);
 
 /* Read one notification. */
-static int (*notification_recv)();
+static int (*notification_recv)(void);
 
-static void init_notifications() {
+static void init_notifications(void) {
   lwt_unix_mutex_init(&notification_mutex);
   notification_count = 4096;
   notifications =
       (intnat *)lwt_unix_malloc(notification_count * sizeof(intnat));
 }
 
-static void resize_notifications() {
+static void resize_notifications(void) {
   long new_notification_count = notification_count * 2;
   intnat *new_notifications =
       (intnat *)lwt_unix_malloc(new_notification_count * sizeof(intnat));
@@ -603,7 +603,7 @@ value lwt_unix_send_notification_stub(value id) {
   return Val_unit;
 }
 
-value lwt_unix_recv_notifications() {
+value lwt_unix_recv_notifications(void) {
   int ret, i, current_index;
   value result;
 #if !defined(LWT_ON_WINDOWS)
@@ -664,17 +664,17 @@ value lwt_unix_recv_notifications() {
 
 static SOCKET socket_r, socket_w;
 
-static int windows_notification_send() {
+static int windows_notification_send(void) {
   char buf = '!';
   return send(socket_w, &buf, 1, 0);
 }
 
-static int windows_notification_recv() {
+static int windows_notification_recv(void) {
   char buf;
   return recv(socket_r, &buf, 1, 0);
 }
 
-value lwt_unix_init_notification() {
+value lwt_unix_init_notification(void) {
   SOCKET sockets[2];
 
   switch (notification_mode) {
@@ -717,12 +717,12 @@ static void set_close_on_exec(int fd) {
 
 static int notification_fd;
 
-static int eventfd_notification_send() {
+static int eventfd_notification_send(void) {
   uint64_t buf = 1;
   return write(notification_fd, (char *)&buf, 8);
 }
 
-static int eventfd_notification_recv() {
+static int eventfd_notification_recv(void) {
   uint64_t buf;
   return read(notification_fd, (char *)&buf, 8);
 }
@@ -731,17 +731,17 @@ static int eventfd_notification_recv() {
 
 static int notification_fds[2];
 
-static int pipe_notification_send() {
+static int pipe_notification_send(void) {
   char buf = 0;
   return write(notification_fds[1], &buf, 1);
 }
 
-static int pipe_notification_recv() {
+static int pipe_notification_recv(void) {
   char buf;
   return read(notification_fds[0], &buf, 1);
 }
 
-value lwt_unix_init_notification() {
+value lwt_unix_init_notification(void) {
   switch (notification_mode) {
 #if defined(HAVE_EVENTFD)
     case NOTIFICATION_MODE_EVENTFD:
@@ -978,7 +978,7 @@ static lwt_unix_mutex pool_mutex;
 static int threading_initialized = 0;
 
 /* Initialize the pool of thread. */
-void initialize_threading() {
+void initialize_threading(void) {
   if (threading_initialized == 0) {
     lwt_unix_mutex_init(&pool_mutex);
     lwt_unix_condition_init(&pool_condition);

--- a/src/unix/unix_c/unix_gethostbyaddr_job.c
+++ b/src/unix/unix_c/unix_gethostbyaddr_job.c
@@ -33,13 +33,13 @@ struct job_gethostbyaddr {
 static void worker_gethostbyaddr(struct job_gethostbyaddr *job)
 {
 #if HAS_GETHOSTBYADDR_R == 7
-    int h_errno;
+    int local_h_errno;
     job->ptr = gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer,
-                               NETDB_BUFFER_SIZE, &h_errno);
+                               NETDB_BUFFER_SIZE, &local_h_errno);
 #elif HAS_GETHOSTBYADDR_R == 8
-    int h_errno;
+    int local_h_errno;
     if (gethostbyaddr_r(&job->addr, 4, AF_INET, &job->entry, job->buffer,
-                        NETDB_BUFFER_SIZE, &job->ptr, &h_errno) != 0)
+                        NETDB_BUFFER_SIZE, &job->ptr, &local_h_errno) != 0)
         job->ptr = NULL;
 #else
     job->ptr = gethostbyaddr(&job->addr, 4, AF_INET);

--- a/src/unix/unix_c/unix_gethostbyname_job.c
+++ b/src/unix/unix_c/unix_gethostbyname_job.c
@@ -34,13 +34,13 @@ struct job_gethostbyname {
 static void worker_gethostbyname(struct job_gethostbyname *job)
 {
 #if HAS_GETHOSTBYNAME_R == 5
-    int h_errno;
+    int local_h_errno;
     job->ptr = gethostbyname_r(job->name, &job->entry, job->buffer,
-                               NETDB_BUFFER_SIZE, &h_errno);
+                               NETDB_BUFFER_SIZE, &local_h_errno);
 #elif HAS_GETHOSTBYNAME_R == 6
-    int h_errno;
+    int local_h_errno;
     if (gethostbyname_r(job->name, &job->entry, job->buffer, NETDB_BUFFER_SIZE,
-                        &(job->ptr), &h_errno) != 0)
+                        &(job->ptr), &local_h_errno) != 0)
         job->ptr = NULL;
 #else
     job->ptr = gethostbyname(job->name);

--- a/src/unix/windows_c/windows_bytes_read.c
+++ b/src/unix/windows_c/windows_bytes_read.c
@@ -44,7 +44,7 @@ CAMLprim value lwt_unix_bytes_read(value fd, value buf, value vofs, value vlen)
             numwritten = 0;
         } else if (err) {
             win32_maperr(err);
-            uerror("write", Nothing);
+            uerror("read", Nothing);
         }
         written = numwritten;
     }


### PR DESCRIPTION
Minor C fixes:
- Windows: fix error path of `lwt_unix_launch_thread`
- Windows: fix `s/write/read/` error message
- Fix strict-prototypes warnings
- Fix conflicts with [`netdb.h` `h_errno`](https://pubs.opengroup.org/onlinepubs/9799919799/) (removed in POSIX Issue 7)
- Remove unused variable
