### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -5,7 +5,8 @@
 ;; (wodoc build runs `dune build @doc` itself when --src is not given.)
 (project lwt)
 (title Lwt)
-(pub /lwt)
+(url-prefix /lwt)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing lwt/index.html)
 ;; no (highlight …): wodoc's default starter already colours lwt/jsoo/eliom syntax.
 ;; lwt's sibling packages are not dependency edges, so odoc leaves their refs


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps Lwt's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.