### PR TITLE
doc: list Lwt_seq in the lwt API index

### DIFF
--- a/src/core/index.mld
+++ b/src/core/index.mld
@@ -127,6 +127,7 @@ This is the system-independent, pure-OCaml core of Lwt. To link with it, use
 {!modules:
   Lwt
   Lwt_list
+  Lwt_seq
   Lwt_stream
   Lwt_result
   Lwt_mutex


### PR DESCRIPTION
`Lwt_seq` (lazy sequences, `@since 5.5.0`) is public and fully documented, but was missing from the `{!modules:}` list in `src/core/index.mld`, so it never appeared in the API navigation. Add it next to `Lwt_list`/`Lwt_stream`. Doc-only change; the page is already generated.