### PR TITLE
lwt_pool: fix starvation bug

### DIFF
--- a/src/core/lwt_pool.ml
+++ b/src/core/lwt_pool.ml
@@ -130,7 +130,9 @@ let check_and_release p c cleared =
   p.check c (fun result -> ok := result);
   if cleared || not !ok then (
     (* Element is not ok or the pool was cleared - dispose of it *)
-    dispose p c
+    dispose p c >>= fun () ->
+    replace_disposed p;
+    Lwt.return_unit
   )
   else (
     (* Element is ok - release it back to the pool *)

--- a/test/core/test_lwt_pool.ml
+++ b/test/core/test_lwt_pool.ml
@@ -183,18 +183,15 @@ let suite = suite "lwt_pool" [
     in
     let gen = (fun () -> Lwt.return_unit) in
     let p = Lwt_pool.create 1 ~check:(fun _ is_ok -> is_ok false) gen in
-    let holder = use p (fun _ ->
-      Lwt.bind
-        (Lwt_unix.sleep 1.)
-        (fun () -> failwith "op timeout"))
-    in
+    let yielder, stop_yielding = Lwt.wait () in
+    let holder = use p (fun _ -> Lwt.bind yielder (fun () -> failwith "op timeout")) in
     let waiter = use p (fun _ -> Lwt.return_unit) in
-    let no_starvation = Lwt.bind
-      (Lwt.join [holder; waiter])
-      (fun () -> Lwt.return_true)
-    in
-    let hanging = Lwt.bind (Lwt_unix.sleep 3.0) (fun () -> Lwt.return_false) in
-    Lwt.pick [no_starvation; hanging]
+    let no_starvation = Lwt.join [holder; waiter] in
+    Lwt.wakeup stop_yielding ();
+    Lwt.bind (Lwt.pause ())
+      (fun () -> match Lwt.state no_starvation with
+      | Lwt.Return _ -> Lwt.return_true
+      | Lwt.Fail _ | Lwt.Sleep -> Lwt.return_false)
   end;
 
-  ]
+]

--- a/test/core/test_lwt_pool.ml
+++ b/test/core/test_lwt_pool.ml
@@ -176,4 +176,25 @@ let suite = suite "lwt_pool" [
     Lwt.return (v = 1))
   end;
 
+  test "no starvation for waiters if pool member fails" begin fun () ->
+    let use p f = Lwt.catch
+      (fun () -> Lwt_pool.use p (fun _ -> f ()))
+      (fun _ -> Lwt.return_unit)
+    in
+    let gen = (fun () -> Lwt.return_unit) in
+    let p = Lwt_pool.create 1 ~check:(fun _ is_ok -> is_ok false) gen in
+    let holder = use p (fun _ ->
+      Lwt.bind
+        (Lwt_unix.sleep 1.)
+        (fun () -> failwith "op timeout"))
+    in
+    let waiter = use p (fun _ -> Lwt.return_unit) in
+    let no_starvation = Lwt.bind
+      (Lwt.join [holder; waiter])
+      (fun () -> Lwt.return_true)
+    in
+    let hanging = Lwt.bind (Lwt_unix.sleep 3.0) (fun () -> Lwt.return_false) in
+    Lwt.pick [no_starvation; hanging]
+  end;
+
   ]


### PR DESCRIPTION
[BUG] Pool waiters starve when in-use members fail and there are no new pool use attempts.

Lwt_pool.use has two failure paths, but only one wakes waiters:
1. Free member fails validate → dispose + replace_disposed (wakes a waiter with a fresh member, or hands it the creation error).
2. In-use member's operation raises → dispose only. No waiter is woken, no replacement created.

Waiters can only be woken by a `release` or `replace_disposed`. If all members are disposed via the failed-use path (2) and there are waiters because of pool oversubscription, they sleep indefinitely.